### PR TITLE
Remove `torch` from docs

### DIFF
--- a/doc/code/math.rst
+++ b/doc/code/math.rst
@@ -10,7 +10,6 @@ Backends
     :maxdepth: 1
 
     math/tensorflow
-    math/torch
 
 .. automodapi:: mrmustard.math
     :no-heading:

--- a/doc/code/math/torch.rst
+++ b/doc/code/math/torch.rst
@@ -1,8 +1,0 @@
-Torch
-==========
-
-.. currentmodule:: mrmustard.math.torch
-
-.. automodapi:: mrmustard.math.torch
-    :no-heading:
-    :include-all-objects:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -149,6 +149,9 @@ edit_on_github_branch = "master/doc"
 # the order in which autodoc lists the documented members
 autodoc_member_order = "bysource"
 
+# mock non-installed imports
+autodoc_mock_imports = ["torch"]
+
 # inheritance_diagram graphviz attributes
 inheritance_node_attrs = dict(color="lightskyblue1", style="filled")
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -6,6 +6,3 @@ sphinx-copybutton
 sphinx-automodapi
 sphinxcontrib-bibtex
 mistune==0.8.4
-
-# not a strict requirement for mrmustard; needed for docs support
-torch==1.9.0+cpu

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,3 @@
-mistune==0.8.4
 sphinx
 docutils
 m2r2
@@ -6,3 +5,7 @@ sphinx-autodoc-typehints
 sphinx-copybutton
 sphinx-automodapi
 sphinxcontrib-bibtex
+mistune==0.8.4
+
+# not a strict requirement for mrmustard; needed for docs support
+torch==1.9.0+cpu


### PR DESCRIPTION
**Context:**
Readthedocs requires `torch` to build, which is not a strict requirement for Mr Mustard.

**Description of the Change:**
Removes `math/torch.py` from doc, since the module is still "under construction".

**Benefits:**
Readthedocs should build.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None
