### PR TITLE
Pin `requirements-dev`

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-pytest
-hypothesis
-pytest-cov
-pylint
+pytest==6.2.5
+pytest-cov==3.0.0
+hypothesis==6.31.6
+pylint==2.10.0


### PR DESCRIPTION
**Context:**
Both Tensorflow and pylint require different versions of `typing-extensions` leading to conflict when installing from unpinned `requirements-dev.txt`.

**Description of the Change:**
This PR pins package versions on `requirements-dev.txt` and solves the dependency conflict.

**Benefits:**
Smoot installation of packages for development.

**Possible Drawbacks:**
Will use `pylint==2.10.0` which is not the latest release.
