### PR TITLE
Make `TFMath` adhere to signatures on `MathInterface`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -60,7 +60,7 @@ body:
     id: source-code-and-tracebacks
     attributes:
       value: |
-        ## source code and tracebacks
+        # Source code and tracebacks
 
         Any additional code snippets and error tracebacks related to the issue?
   - type: textarea

--- a/mrmustard/math/math_interface.py
+++ b/mrmustard/math/math_interface.py
@@ -83,13 +83,14 @@ class MathInterface(ABC):
         ...
 
     @abstractmethod
-    def arange(self, start: int, limit: int = None, delta: int = 1) -> Tensor:
+    def arange(self, start: int, limit: int = None, delta: int = 1, dtype: Any = None) -> Tensor:
         r"""Returns an array of evenly spaced values within a given interval.
 
         Args:
             start (int): start of the interval
             limit (int): end of the interval
             delta (int): step size
+            dtype (type): dtype of the returned array
 
         Returns:
             array: array of evenly spaced values
@@ -225,8 +226,10 @@ class MathInterface(ABC):
         self,
         array: Tensor,
         filters: Tensor,
-        padding="VALID",
-        data_format="NWC",
+        strides: Optional[List[int]] = None,
+        padding = "VALID",
+        data_format =" NWC",
+        dilations: Optional[List[int]] = None,
     ) -> Tensor:  # TODO: remove strides and data_format?
         r"""Performs a convolution on array with filters.
 
@@ -532,7 +535,7 @@ class MathInterface(ABC):
 
     @abstractmethod
     def new_variable(
-        self, value: Tensor, bounds: Tuple[Optional[float], Optional[float]], name: str
+        self, value: Tensor, bounds: Tuple[Optional[float], Optional[float]], name: str, dtype: Any
     ) -> Tensor:
         r"""Returns a new variable with the given value and bounds.
 
@@ -540,19 +543,20 @@ class MathInterface(ABC):
             value (array): value of the new variable
             bounds (tuple): bounds of the new variable
             name (str): name of the new variable
-
+            dtype (type): dtype of the array
         Returns:
             array: new variable
         """
         ...
 
     @abstractmethod
-    def new_constant(self, value: Tensor, name: str) -> Tensor:
+    def new_constant(self, value: Tensor, name: str, dtype: Any) -> Tensor:
         r"""Returns a new constant with the given value.
 
         Args:
             value (array): value of the new constant
             name (str): name of the new constant
+            dtype (type): dtype of the array
 
         Returns:
             array: new constant
@@ -753,11 +757,12 @@ class MathInterface(ABC):
         ...
 
     @abstractmethod
-    def trace(self, array: Tensor) -> Tensor:
+    def trace(self, array: Tensor, dtype: Any = None) -> Tensor:
         r"""Returns the trace of array.
 
         Args:
             array (array): array to take the trace of
+            dtype (type): ``dtype`` of the output array
 
         Returns:
             array: trace of array

--- a/mrmustard/math/math_interface.py
+++ b/mrmustard/math/math_interface.py
@@ -226,8 +226,8 @@ class MathInterface(ABC):
         self,
         array: Tensor,
         filters: Tensor,
-        strides: Optional[List[int]] = None,
-        dilations: Optional[List[int]] = None,
+        padding="VALID",
+        data_format="NWC",
     ) -> Tensor:  # TODO: remove strides and data_format?
         r"""Performs a convolution on array with filters.
 

--- a/mrmustard/math/math_interface.py
+++ b/mrmustard/math/math_interface.py
@@ -227,8 +227,8 @@ class MathInterface(ABC):
         array: Tensor,
         filters: Tensor,
         strides: Optional[List[int]] = None,
-        padding = "VALID",
-        data_format =" NWC",
+        padding="VALID",
+        data_format=" NWC",
         dilations: Optional[List[int]] = None,
     ) -> Tensor:  # TODO: remove strides and data_format?
         r"""Performs a convolution on array with filters.

--- a/mrmustard/math/math_interface.py
+++ b/mrmustard/math/math_interface.py
@@ -227,8 +227,6 @@ class MathInterface(ABC):
         array: Tensor,
         filters: Tensor,
         strides: Optional[List[int]] = None,
-        padding="VALID",
-        data_format=" NWC",
         dilations: Optional[List[int]] = None,
     ) -> Tensor:  # TODO: remove strides and data_format?
         r"""Performs a convolution on array with filters.

--- a/mrmustard/math/tensorflow.py
+++ b/mrmustard/math/tensorflow.py
@@ -32,7 +32,7 @@ from mrmustard.types import (
 )
 from .math_interface import MathInterface
 
-# pylint: disable=too-many-public-methods,no-self-argument
+# pylint: disable=too-many-public-methods,no-self-argument,arguments-differ
 class TFMath(MathInterface):
     r"""Tensorflow implemantion of the :class:`Math` interface."""
 
@@ -375,7 +375,6 @@ class TFMath(MathInterface):
         """Returns the eigenvalues and eigenvectors of a matrix."""
         return tf.linalg.eigh(tensor)
 
-    # pylint: disable=arguments-differ
     def sqrtm(self, tensor: tf.Tensor, rtol=1e-05, atol=1e-08) -> Tensor:
         """Returns the matrix square root of a square matrix, such that ``sqrt(A) @ sqrt(A) = A``."""
 

--- a/mrmustard/math/tensorflow.py
+++ b/mrmustard/math/tensorflow.py
@@ -97,6 +97,7 @@ class TFMath(MathInterface):
             constraint = None
         return constraint
 
+    # pylint: disable=arguments-differ
     @Autocast()
     def convolution(
         self,

--- a/mrmustard/math/tensorflow.py
+++ b/mrmustard/math/tensorflow.py
@@ -60,9 +60,9 @@ class TFMath(MathInterface):
     def asnumpy(self, tensor: tf.Tensor) -> Tensor:
         return np.array(tensor)
 
-    def assign(self, array: tf.Tensor, value: tf.Tensor) -> tf.Tensor:
-        array.assign(value)
-        return array
+    def assign(self, tensor: tf.Tensor, value: tf.Tensor) -> tf.Tensor:
+        tensor.assign(value)
+        return tensor
 
     def astensor(self, array: Union[np.ndarray, tf.Tensor], dtype=None) -> tf.Tensor:
         return tf.convert_to_tensor(array, dtype=dtype)
@@ -70,10 +70,10 @@ class TFMath(MathInterface):
     def atleast_1d(self, array: tf.Tensor, dtype=None) -> tf.Tensor:
         return self.cast(tf.reshape(array, [-1]), dtype)
 
-    def cast(self, x: tf.Tensor, dtype=None) -> tf.Tensor:
+    def cast(self, array: tf.Tensor, dtype=None) -> tf.Tensor:
         if dtype is None:
-            return x
-        return tf.cast(x, dtype)
+            return array
+        return tf.cast(array, dtype)
 
     def clip(self, array, a_min, a_max) -> tf.Tensor:
         return tf.clip_by_value(array, a_min, a_max)
@@ -115,8 +115,8 @@ class TFMath(MathInterface):
     def cosh(self, array: tf.Tensor) -> tf.Tensor:
         return tf.math.cosh(array)
 
-    def det(self, a: tf.Tensor) -> tf.Tensor:
-        return tf.linalg.det(a)
+    def det(self, matrix: tf.Tensor) -> tf.Tensor:
+        return tf.linalg.det(matrix)
 
     def diag(self, array: tf.Tensor, k: int = 0) -> tf.Tensor:
         return tf.linalg.diag(array, k=k)
@@ -139,8 +139,8 @@ class TFMath(MathInterface):
     def eye(self, size: int, dtype=tf.float64) -> tf.Tensor:
         return tf.eye(size, dtype=dtype)
 
-    def from_backend(self, thing) -> bool:
-        return isinstance(thing, (tf.Tensor, tf.Variable))
+    def from_backend(self, value) -> bool:
+        return isinstance(value, (tf.Tensor, tf.Variable))
 
     def gather(self, array: tf.Tensor, indices: tf.Tensor, axis: int = None) -> tf.Tensor:
         return tf.gather(array, indices, axis=axis)
@@ -155,8 +155,8 @@ class TFMath(MathInterface):
     def imag(self, array: tf.Tensor) -> tf.Tensor:
         return tf.math.imag(array)
 
-    def inv(self, a: tf.Tensor) -> tf.Tensor:
-        return tf.linalg.inv(a)
+    def inv(self, tensor: tf.Tensor) -> tf.Tensor:
+        return tf.linalg.inv(tensor)
 
     def is_trainable(self, tensor: tf.Tensor) -> bool:
         return isinstance(tensor, tf.Variable)
@@ -224,12 +224,13 @@ class TFMath(MathInterface):
     ) -> tf.Tensor:
         return tf.pad(array, paddings, mode, constant_values)
 
-    def pinv(self, array: tf.Tensor) -> tf.Tensor:
-        return tf.linalg.pinv(array)
+    @staticmethod
+    def pinv(matrix: tf.Tensor) -> tf.Tensor:
+        return tf.linalg.pinv(matrix)
 
     @Autocast()
-    def pow(self, array: tf.Tensor, exponent: float) -> tf.Tensor:
-        return tf.math.pow(array, exponent)
+    def pow(self, x: tf.Tensor, y: float) -> tf.Tensor:
+        return tf.math.pow(x, y)
 
     def real(self, array: tf.Tensor) -> tf.Tensor:
         return tf.math.real(array)
@@ -292,9 +293,8 @@ class TFMath(MathInterface):
     # Special functions
     # ~~~~~~~~~~~~~~~~~
 
-    def DefaultEuclideanOptimizer(
-        self,
-    ) -> tf.keras.optimizers.Optimizer:  # TODO: a wrapper class is better?
+    @staticmethod
+    def DefaultEuclideanOptimizer() -> tf.keras.optimizers.Optimizer:  # TODO: a wrapper class is better?
         r"""Default optimizer for the Euclidean parameters."""
         return tf.keras.optimizers.Adam(learning_rate=0.001)
 
@@ -374,6 +374,7 @@ class TFMath(MathInterface):
         """Returns the eigenvalues and eigenvectors of a matrix."""
         return tf.linalg.eigh(tensor)
 
+    # pylint: disable=arguments-differ
     def sqrtm(self, tensor: tf.Tensor, rtol=1e-05, atol=1e-08) -> Tensor:
         """Returns the matrix square root of a square matrix, such that ``sqrt(A) @ sqrt(A) = A``."""
 


### PR DESCRIPTION
**Context:**
All backends must implement and adhere to signatures on `MathInterface`

**Description of the Change:**
Modifies the signature of methods on `TFmath` and some of `MathInterface` abstract methods so that both the tensorflow and torch backend adhere to `MathInterface`.

**Benefits:**
Consistent implementation of backends
