### PR TITLE
Stop optimizer execution on `KeyboardInterrupt`

### DIFF
--- a/mrmustard/utils/training.py
+++ b/mrmustard/utils/training.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from logging import Logger
 import numpy as np
 from scipy.linalg import expm
 from mrmustard.types import *
 from mrmustard.utils import graphics
+from mrmustard.logger import create_logger
 from mrmustard.math import Math
 
 math = Math()
@@ -38,6 +40,7 @@ class Optimizer:
         self.orthogonal_lr: float = orthogonal_lr
         self.euclidean_lr: float = euclidean_lr
         self.opt_history: List[float] = [0]
+        self.log = create_logger(__name__)
 
     def minimize(
         self, cost_fn: Callable, by_optimizing: Sequence[Trainable], max_steps: int = 1000
@@ -73,9 +76,10 @@ class Optimizer:
                     update_euclidean(params["euclidean"], grads["euclidean"], self.euclidean_lr)
                     self.opt_history.append(cost)
                     bar.step(math.asnumpy(cost))
-        except KeyboardInterrupt as e:  # graceful exit
-            print("KeyboardInterrupt: Stopping execution...")
-            raise StopExecution from e
+        except KeyboardInterrupt:  # graceful exit
+            raise self.OptimizerInterruptedError(
+                "Stopping optimizer execution...", self.log
+            ) from None
 
     def should_stop(self, max_steps: int) -> bool:
         r"""Returns ``True`` if the optimization should stop (either because the loss is stable or because the maximum number of steps is reached)."""
@@ -86,16 +90,19 @@ class Optimizer:
                 sum(abs(self.opt_history[-i - 1] - self.opt_history[-i]) for i in range(1, 20))
                 < 1e-6
             ):
-                print("Loss looks stable, stopping here.")
+                self.log.info("Loss looks stable, stopping here.")
                 return True
         return False
 
+    class OptimizerInterruptedError(Exception):
+        """A helper class to quietly stop execution without printing a traceback."""
 
-class StopExecution(Exception):
-    """A helper class to quietly stop execution without printing a traceback."""
+        def __init__(self, message: str, logger: Logger) -> None:
+            super().__init__()
+            logger.info(message)
 
-    def _render_traceback_(self):
-        pass
+        def _render_traceback_(self):
+            pass
 
 
 # ~~~~~~~~~~~~~~~~~

--- a/mrmustard/utils/training.py
+++ b/mrmustard/utils/training.py
@@ -77,9 +77,8 @@ class Optimizer:
                     self.opt_history.append(cost)
                     bar.step(math.asnumpy(cost))
         except KeyboardInterrupt:  # graceful exit
-            raise self.OptimizerInterruptedError(
-                "Stopping optimizer execution...", self.log
-            ) from None
+            logger.info("Optimizer execution halted due to keyboard interruption.")
+            raise self.OptimizerInterruptedError() from None
 
     def should_stop(self, max_steps: int) -> bool:
         r"""Returns ``True`` if the optimization should stop (either because the loss is stable or because the maximum number of steps is reached)."""
@@ -97,9 +96,8 @@ class Optimizer:
     class OptimizerInterruptedError(Exception):
         """A helper class to quietly stop execution without printing a traceback."""
 
-        def __init__(self, message: str, logger: Logger) -> None:
+        def __init__(self) -> None:
             super().__init__()
-            logger.info(message)
 
         def _render_traceback_(self):
             pass

--- a/mrmustard/utils/training.py
+++ b/mrmustard/utils/training.py
@@ -73,8 +73,9 @@ class Optimizer:
                     update_euclidean(params["euclidean"], grads["euclidean"], self.euclidean_lr)
                     self.opt_history.append(cost)
                     bar.step(math.asnumpy(cost))
-        except KeyboardInterrupt:  # graceful exit
-            return
+        except KeyboardInterrupt as e:  # graceful exit
+            print("KeyboardInterrupt: Stopping execution...")
+            raise StopExecution from e
 
     def should_stop(self, max_steps: int) -> bool:
         r"""Returns ``True`` if the optimization should stop (either because the loss is stable or because the maximum number of steps is reached)."""
@@ -88,6 +89,11 @@ class Optimizer:
                 print("Loss looks stable, stopping here.")
                 return True
         return False
+
+class StopExecution(Exception):
+    """A helper class to quietly stop execution without printing a traceback."""
+    def _render_traceback_(self):
+        pass
 
 
 # ~~~~~~~~~~~~~~~~~

--- a/mrmustard/utils/training.py
+++ b/mrmustard/utils/training.py
@@ -90,8 +90,10 @@ class Optimizer:
                 return True
         return False
 
+
 class StopExecution(Exception):
     """A helper class to quietly stop execution without printing a traceback."""
+
     def _render_traceback_(self):
         pass
 


### PR DESCRIPTION
**Context:**
When running a `for` loop that is iterating over the `Optimizer` sending a `KeyboardInterrupt` signal (e. g., `ctrl/cmd + c`) does not stop the program execution but only the current iteration of the loop.

**Description of the Change:**
The execution will gracefully stop, meaning no traceback will be printed to the user. To do this a helper class `StopExecution` inheriting from `Exception` is implemented overriding the `_render_traceback_` method in order not to print a traceback.

**Benefits:**
`ctrl/cmd + c` while on a optimization loop stops the execution of the program.

**Possible Drawbacks:**
This will not restore the parameters to the previous values, i. e. the values before any optimization step was performed. 

**Related GitHub Issues:** 
Resolves #104 
