### PR TITLE
fix logger test side effects

### DIFF
--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -63,25 +63,29 @@ def reset_logging(pytestconfig):
     logging.root.handlers = []
     root_level = logging.root.level
 
+    # Reset the logging specific configurations before test
+    for module in modules_contain_logging:
+        logger = logging.getLogger(module.__name__)
+        logger.handlers = []
+        logger.setLevel(logging.NOTSET)
+        logger.propagate = True
+
     logging_plugin = pytestconfig.pluginmanager.unregister(name="logging-plugin")
 
     yield
+
+    # Reset the logging specific configurations after test
+    for module in modules_contain_logging:
+        logger = logging.getLogger(module.__name__)
+        logger.handlers = []
+        logger.setLevel(logging.NOTSET)
+        logger.propagate = True
 
     logging.root.handlers[:] = root_handlers
     logging.root.setLevel(root_level)
 
     if logging_plugin:
         pytestconfig.pluginmanager.register(logging_plugin, "logging-plugin")
-
-
-@pytest.fixture(autouse=True)
-def reset_logging_module():
-    """Reset the logging specific configurations such as handlers or levels for
-    the module specific loggers."""
-    for module in modules_contain_logging:
-        logger = logging.getLogger(module.__name__)
-        logger.handlers = []
-        logger.setLevel(logging.NOTSET)
 
 
 @pytest.mark.parametrize("module", modules_contain_logging)


### PR DESCRIPTION
**Context:**
A logger was implemented on Mr Mustard on PR #107 following strawberry fields logger implementation. As discovered on strawberry fields, logger tests had side-effects on the logger configuration hence making tests that use the logger fail if they are executed after `test_logger`.

In specific, `test_logging_handler_defined` was setting `logger.propagate = False` meaning that messages are not passed to the handlers of ancestor loggers (see logger [docs](https://docs.python.org/3/library/logging.html#logging.Logger)). This in turn implied that, if no handlers were set for the specific logger, no message would be emitted hence making tests that check for output messages fail.

**Description of the Change:**
This PR incorporates the same changes applied on PR _fix failing logger tests [#675](https://github.com/XanaduAI/strawberryfields/pull/675)_.

**Benefits:**
Hopefully no failing logger tests for obscure reasons.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None
