### PR TITLE
Run latest Black version

### DIFF
--- a/mrmustard/physics/gaussian.py
+++ b/mrmustard/physics/gaussian.py
@@ -587,7 +587,7 @@ def general_dyne(
     new_cov = A - math.matmul(math.matmul(AB, inv), math.transpose(AB))
     new_means = a + math.matvec(math.matmul(AB, inv), proj_means - b)
     prob = math.exp(-math.sum(math.matvec(inv, proj_means - b) * (proj_means - b))) / (
-        pi ** nB * (hbar ** -nB) * math.sqrt(math.det(B + proj_cov))
+        pi**nB * (hbar**-nB) * math.sqrt(math.det(B + proj_cov))
     )  # TODO: check this (hbar part especially)
     return prob, new_cov, new_means
 
@@ -630,9 +630,9 @@ def number_cov(cov: Matrix, means: Vector, hbar: float) -> Matrix:
     N = means.shape[-1] // 2
     mCm = cov * means[:, None] * means[None, :]
     dd = math.diag(math.diag_part(mCm[:N, :N] + mCm[N:, N:] + mCm[:N, N:] + mCm[N:, :N])) / (
-        2 * hbar ** 2
+        2 * hbar**2
     )
-    CC = (cov ** 2 + mCm) / (2 * hbar ** 2)
+    CC = (cov**2 + mCm) / (2 * hbar**2)
     return (
         CC[:N, :N] + CC[N:, N:] + CC[:N, N:] + CC[N:, :N] + dd - 0.25 * math.eye(N, dtype=CC.dtype)
     )

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ pytest==6.2.5
 pytest-cov==3.0.0
 hypothesis==6.31.6
 pylint==2.10.0
+black>=22.1.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,4 +22,4 @@ settings.register_profile("ci", max_examples=1000, deadline=None)
 settings.register_profile("dev", max_examples=10, deadline=None)
 settings.register_profile("debug", max_examples=10, verbosity=Verbosity.verbose, deadline=None)
 
-settings.load_profile(os.getenv(u"HYPOTHESIS_PROFILE", "dev"))
+settings.load_profile(os.getenv("HYPOTHESIS_PROFILE", "dev"))

--- a/tests/random.py
+++ b/tests/random.py
@@ -25,7 +25,7 @@ r = st.floats(
     min_value=0, max_value=0.5, allow_infinity=False, allow_nan=False
 )  # reasonable squeezing magnitude
 real_not_zero = st.one_of(st.floats(max_value=-0.00001), st.floats(min_value=0.00001))
-integer = st.integers(min_value=0, max_value=2 ** 32 - 1)
+integer = st.integers(min_value=0, max_value=2**32 - 1)
 small_float = st.floats(min_value=-0.1, max_value=0.1, allow_infinity=False, allow_nan=False)
 medium_float = st.floats(min_value=-1.0, max_value=1.0, allow_infinity=False, allow_nan=False)
 large_float = st.floats(min_value=-10.0, max_value=10.0, allow_infinity=False, allow_nan=False)

--- a/tests/test_lab/test_detectors.py
+++ b/tests/test_lab/test_detectors.py
@@ -52,7 +52,7 @@ def test_detector_squeezed_state(r, phi, eta, dc):
     mean = np.arange(len(ps)) @ ps.numpy()
     expected_mean = eta * np.sinh(r) ** 2 + dc
     assert np.allclose(mean, expected_mean)
-    variance = np.arange(len(ps)) ** 2 @ ps.numpy() - mean ** 2
+    variance = np.arange(len(ps)) ** 2 @ ps.numpy() - mean**2
     expected_variance = eta * np.sinh(r) ** 2 * (1 + eta * (1 + 2 * np.sinh(r) ** 2)) + dc
     assert np.allclose(variance, expected_variance)
 
@@ -77,8 +77,8 @@ def test_detector_two_mode_squeezed_state(r, phi, eta_s, eta_i, dc_s, dc_i):
     n_i = eta_i * np.sinh(r) ** 2
     expected_mean_i = n_i + dc_i
     expected_mean_s = n_s + dc_s
-    var_s = np.sum(ps, axis=1) @ n ** 2 - mean_s ** 2
-    var_i = np.sum(ps, axis=0) @ n ** 2 - mean_i ** 2
+    var_s = np.sum(ps, axis=1) @ n**2 - mean_s**2
+    var_i = np.sum(ps, axis=0) @ n**2 - mean_i**2
     expected_var_s = n_s * (n_s + 1) + dc_s
     expected_var_i = n_i * (n_i + 1) + dc_i
     covar = n @ ps.numpy() @ n - mean_s * mean_i
@@ -203,18 +203,13 @@ def test_homodyne_on_2mode_squeezed_vacuum_with_displacement(s, X, d):
     r = homodyne.r
     remaining_state = tmsv << homodyne[0]
     xb, xa, pb, pa = d
-    means = (
-        np.array(
-            [
-                xa
-                + (2 * np.sqrt(s * (s + 1)) * (X - xb))
-                / (1 + 2 * s + np.cosh(2 * r) - np.sinh(2 * r)),
-                pa
-                + (2 * np.sqrt(s * (s + 1)) * pb) / (1 + 2 * s + np.cosh(2 * r) + np.sinh(2 * r)),
-            ]
-        )
-        * np.sqrt(2 * settings.HBAR)
-    )
+    means = np.array(
+        [
+            xa
+            + (2 * np.sqrt(s * (s + 1)) * (X - xb)) / (1 + 2 * s + np.cosh(2 * r) - np.sinh(2 * r)),
+            pa + (2 * np.sqrt(s * (s + 1)) * pb) / (1 + 2 * s + np.cosh(2 * r) + np.sinh(2 * r)),
+        ]
+    ) * np.sqrt(2 * settings.HBAR)
     assert np.allclose(remaining_state.means, means)
 
 
@@ -248,14 +243,14 @@ def test_heterodyne_on_2mode_squeezed_vacuum_with_displacement(
 
 def test_norm_1mode():
     assert np.allclose(
-        Coherent(2.0) << Fock(3), np.abs((2.0 ** 3) / np.sqrt(6) * np.exp(-0.5 * 4.0)) ** 2
+        Coherent(2.0) << Fock(3), np.abs((2.0**3) / np.sqrt(6) * np.exp(-0.5 * 4.0)) ** 2
     )
 
 
 def test_norm_2mode():
     leftover = Coherent(x=[2.0, 2.0]) << Fock(3)[0]
     assert np.isclose(
-        (2.0 ** 3) / np.sqrt(6) * np.exp(-0.5 * 4.0), physics.norm(leftover), atol=1e-5
+        (2.0**3) / np.sqrt(6) * np.exp(-0.5 * 4.0), physics.norm(leftover), atol=1e-5
     )
 
 

--- a/tests/test_lab/test_gates_fock.py
+++ b/tests/test_lab/test_gates_fock.py
@@ -59,7 +59,7 @@ def test_gate_compositions(gates):
 @given(x=st.floats(min_value=-2, max_value=2), y=st.floats(min_value=-2, max_value=2))
 def test_fock_representation_displacement(x, y):
     D = Dgate(x=x, y=y)
-    expected = displacement(r=np.sqrt(x ** 2 + y ** 2), phi=np.arctan2(y, x), cutoff=20)
+    expected = displacement(r=np.sqrt(x**2 + y**2), phi=np.arctan2(y, x), cutoff=20)
     assert np.allclose(expected, D.U(cutoffs=[20]), atol=1e-5)
 
 

--- a/tests/test_physics/test_fock/test_fock.py
+++ b/tests/test_physics/test_fock/test_fock.py
@@ -58,7 +58,7 @@ def test_coherent_state(alpha):
     cutoff = 10
     amps = Coherent(x=alpha.real, y=alpha.imag).ket(cutoffs=[cutoff])
     expected = np.exp(-0.5 * np.abs(alpha) ** 2) * np.array(
-        [alpha ** n / np.sqrt(factorial(n)) for n in range(cutoff)]
+        [alpha**n / np.sqrt(factorial(n)) for n in range(cutoff)]
     )
     assert np.allclose(amps, expected, atol=1e-6)
 
@@ -79,7 +79,7 @@ def test_squeezed_state(r, phi):
             [
                 (-np.exp(1j * phi) * np.tanh(r)) ** n
                 * np.sqrt(factorial(2 * n))
-                / (2 ** n * factorial(n))
+                / (2**n * factorial(n))
                 for n in range(len_non_zero)
             ]
         )


### PR DESCRIPTION
**Context:**
Black has been updated to v22.1.0 which changes the way the power operators should be styled:

`a ** b` should now be formatted as `a**b`.

**Description of the Change:**
All spaces around the power operator are removed (along with at least one other minor change).

**Benefits:**
The formatting check now passes with the latest version of Black.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None
