### PR TITLE
set `State` modes with `kwargs` and `__getitem__`

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Bug fixes
 
+* Setting the modes on which detectors and state acts using modes kwarg or __getitem__ give consistent results. [(#114)](https://github.com/XanaduAI/MrMustard/pull/114)
 ### Documentation
 
 ### Contributors

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Bug fixes
 
-* Setting the modes on which detectors and state acts using modes kwarg or __getitem__ give consistent results. [(#114)](https://github.com/XanaduAI/MrMustard/pull/114)
+* Setting the modes on which detectors and state acts using `modes` kwarg or __getitem__ give consistent results. [(#114)](https://github.com/XanaduAI/MrMustard/pull/114)
 ### Documentation
 
 ### Contributors

--- a/mrmustard/lab/states.py
+++ b/mrmustard/lab/states.py
@@ -109,7 +109,7 @@ class Coherent(Parametrized, State):
         )
         means = gaussian.displacement(self.x, self.y, settings.HBAR)
         cov = gaussian.vacuum_cov(means.shape[-1] // 2, settings.HBAR)
-        State.__init__(self, cov=cov, means=means, cutoffs=cutoffs)
+        State.__init__(self, cov=cov, means=means, cutoffs=cutoffs, modes=modes)
 
     @property
     def means(self):
@@ -367,7 +367,7 @@ class DisplacedSqueezed(Parametrized, State):
         )
         cov = gaussian.squeezed_vacuum_cov(self.r, self.phi, settings.HBAR)
         means = gaussian.displacement(self.x, self.y, settings.HBAR)
-        State.__init__(self, cov=cov, means=means, cutoffs=cutoffs)
+        State.__init__(self, cov=cov, means=means, cutoffs=cutoffs, modes=modes)
 
     @property
     def cov(self):

--- a/tests/test_lab/test_detectors.py
+++ b/tests/test_lab/test_detectors.py
@@ -14,19 +14,32 @@
 
 from hypothesis import settings, given, strategies as st
 from hypothesis.extra.numpy import arrays
-from mrmustard.math import Math
 
-math = Math()
 import numpy as np
 import tensorflow as tf
 from scipy.stats import poisson
 
-from mrmustard.lab import *
+from mrmustard.math import Math
+from mrmustard.lab import (
+    PNRDetector,
+    Coherent,
+    Sgate,
+    Vacuum,
+    S2gate,
+    BSgate,
+    Attenuator,
+    Homodyne,
+    Heterodyne,
+    TMSV,
+    Dgate,
+    Fock,
+)
 from mrmustard.utils.training import Optimizer
 from mrmustard.physics import gaussian
 from mrmustard import physics
 from mrmustard import settings
 
+math = Math()
 np.random.seed(137)
 
 

--- a/tests/test_lab/test_detectors.py
+++ b/tests/test_lab/test_detectors.py
@@ -57,7 +57,7 @@ def test_detector_squeezed_state(r, phi, eta, dc):
     mean = np.arange(len(ps)) @ ps.numpy()
     expected_mean = eta * np.sinh(r) ** 2 + dc
     assert np.allclose(mean, expected_mean)
-    variance = np.arange(len(ps)) ** 2 @ ps.numpy() - mean ** 2
+    variance = np.arange(len(ps)) ** 2 @ ps.numpy() - mean**2
     expected_variance = eta * np.sinh(r) ** 2 * (1 + eta * (1 + 2 * np.sinh(r) ** 2)) + dc
     assert np.allclose(variance, expected_variance)
 
@@ -82,8 +82,8 @@ def test_detector_two_mode_squeezed_state(r, phi, eta_s, eta_i, dc_s, dc_i):
     n_i = eta_i * np.sinh(r) ** 2
     expected_mean_i = n_i + dc_i
     expected_mean_s = n_s + dc_s
-    var_s = np.sum(ps, axis=1) @ n ** 2 - mean_s ** 2
-    var_i = np.sum(ps, axis=0) @ n ** 2 - mean_i ** 2
+    var_s = np.sum(ps, axis=1) @ n**2 - mean_s**2
+    var_i = np.sum(ps, axis=0) @ n**2 - mean_i**2
     expected_var_s = n_s * (n_s + 1) + dc_s
     expected_var_i = n_i * (n_i + 1) + dc_i
     covar = n @ ps.numpy() @ n - mean_s * mean_i
@@ -211,18 +211,13 @@ def test_homodyne_on_2mode_squeezed_vacuum_with_displacement(s, X, d):
     r = homodyne.r
     remaining_state = tmsv << homodyne[0]
     xb, xa, pb, pa = d
-    means = (
-        np.array(
-            [
-                xa
-                + (2 * np.sqrt(s * (s + 1)) * (X - xb))
-                / (1 + 2 * s + np.cosh(2 * r) - np.sinh(2 * r)),
-                pa
-                + (2 * np.sqrt(s * (s + 1)) * pb) / (1 + 2 * s + np.cosh(2 * r) + np.sinh(2 * r)),
-            ]
-        )
-        * np.sqrt(2 * settings.HBAR)
-    )
+    means = np.array(
+        [
+            xa
+            + (2 * np.sqrt(s * (s + 1)) * (X - xb)) / (1 + 2 * s + np.cosh(2 * r) - np.sinh(2 * r)),
+            pa + (2 * np.sqrt(s * (s + 1)) * pb) / (1 + 2 * s + np.cosh(2 * r) + np.sinh(2 * r)),
+        ]
+    ) * np.sqrt(2 * settings.HBAR)
     assert np.allclose(remaining_state.means, means)
 
 
@@ -257,14 +252,14 @@ def test_heterodyne_on_2mode_squeezed_vacuum_with_displacement(
 def test_norm_1mode():
     assert np.allclose(
         Coherent(2.0) << Fock(3),
-        np.abs((2.0 ** 3) / np.sqrt(6) * np.exp(-0.5 * 4.0)) ** 2,
+        np.abs((2.0**3) / np.sqrt(6) * np.exp(-0.5 * 4.0)) ** 2,
     )
 
 
 def test_norm_2mode():
     leftover = Coherent(x=[2.0, 2.0]) << Fock(3)[0]
     assert np.isclose(
-        (2.0 ** 3) / np.sqrt(6) * np.exp(-0.5 * 4.0), physics.norm(leftover), atol=1e-5
+        (2.0**3) / np.sqrt(6) * np.exp(-0.5 * 4.0), physics.norm(leftover), atol=1e-5
     )
 
 

--- a/tests/test_lab/test_detectors.py
+++ b/tests/test_lab/test_detectors.py
@@ -274,6 +274,14 @@ def test_norm_2mode_gaussian_normalized():
 
 
 def test_homodyne_mode_kwargs():
+    """Test that S gates and Homodyne mesurements are applied to the correct modes via the `modes` kwarg.
+
+    Here the initial state is a "diagonal" (angle=pi/2) squeezed state in mode 0
+    and a "vertical" (angle=0) squeezed state in mode 1.
+
+    Because the modes are separable, measuring in one mode should leave the state in the
+    other mode unchaged.
+    """
 
     S1 = Sgate(modes=[0], r=1, phi=np.pi / 2)
     S2 = Sgate(modes=[1], r=1, phi=0)
@@ -286,6 +294,14 @@ def test_homodyne_mode_kwargs():
 
 
 def test_heterodyne_mode_kwargs():
+    """Test that S gates and Heterodyne mesurements are applied to the correct modes via the `modes` kwarg.
+
+    Here the initial state is a "diagonal" (angle=pi/2) squeezed state in mode 0
+    and a "vertical" (angle=0) squeezed state in mode 1.
+
+    Because the modes are separable, measuring in one mode should leave the state in the
+    other mode unchaged.
+    """
 
     S1 = Sgate(modes=[0], r=1, phi=np.pi / 2)
     S2 = Sgate(modes=[1], r=1, phi=0)

--- a/tests/test_lab/test_detectors.py
+++ b/tests/test_lab/test_detectors.py
@@ -262,3 +262,25 @@ def test_norm_2mode_normalized():
 def test_norm_2mode_gaussian_normalized():
     leftover = Coherent(x=[2.0, 2.0]) << Coherent(x=1.0, normalize=True)[0]
     assert np.isclose(1.0, physics.norm(leftover), atol=1e-5)
+
+def test_homodyne_mode_kwargs():
+
+    S1 = Sgate(modes=[0], r=1, phi=np.pi/2)
+    S2 = Sgate(modes=[1], r=1, phi=0)
+    initial_state = Vacuum(2) >> S1 >> S2
+    final_state = initial_state << Homodyne(modes=[1],quadrature_angle=0,result=[0.3])
+
+    expected_state = Vacuum(1) >> S1
+
+    assert np.allclose(final_state.dm(), expected_state.dm())
+
+def test_heterodyne_mode_kwargs():
+
+    S1 = Sgate(modes=[0], r=1, phi=np.pi/2)
+    S2 = Sgate(modes=[1], r=1, phi=0)
+    initial_state = Vacuum(2) >> S1 >> S2
+    final_state = initial_state << Heterodyne(modes=[1])
+
+    expected_state = Vacuum(1) >> S1
+
+    assert np.allclose(final_state.dm(), expected_state.dm())

--- a/tests/test_lab/test_detectors.py
+++ b/tests/test_lab/test_detectors.py
@@ -58,9 +58,7 @@ def test_detector_squeezed_state(r, phi, eta, dc):
     expected_mean = eta * np.sinh(r) ** 2 + dc
     assert np.allclose(mean, expected_mean)
     variance = np.arange(len(ps)) ** 2 @ ps.numpy() - mean ** 2
-    expected_variance = (
-        eta * np.sinh(r) ** 2 * (1 + eta * (1 + 2 * np.sinh(r) ** 2)) + dc
-    )
+    expected_variance = eta * np.sinh(r) ** 2 * (1 + eta * (1 + 2 * np.sinh(r) ** 2)) + dc
     assert np.allclose(variance, expected_variance)
 
 
@@ -144,9 +142,9 @@ def test_homodyne_on_2mode_squeezed_vacuum(s, X):
         / 2.0
     )
     assert np.allclose(remaining_state.cov, cov)
-    means = np.array(
-        [2 * np.sqrt(s * (1 + s)) * X / (np.exp(-2 * r) + 1 + 2 * s), 0.0]
-    ) * np.sqrt(2 * settings.HBAR)
+    means = np.array([2 * np.sqrt(s * (1 + s)) * X / (np.exp(-2 * r) + 1 + 2 * s), 0.0]) * np.sqrt(
+        2 * settings.HBAR
+    )
     assert np.allclose(remaining_state.means, means)
 
 
@@ -220,8 +218,7 @@ def test_homodyne_on_2mode_squeezed_vacuum_with_displacement(s, X, d):
                 + (2 * np.sqrt(s * (s + 1)) * (X - xb))
                 / (1 + 2 * s + np.cosh(2 * r) - np.sinh(2 * r)),
                 pa
-                + (2 * np.sqrt(s * (s + 1)) * pb)
-                / (1 + 2 * s + np.cosh(2 * r) + np.sinh(2 * r)),
+                + (2 * np.sqrt(s * (s + 1)) * pb) / (1 + 2 * s + np.cosh(2 * r) + np.sinh(2 * r)),
             ]
         )
         * np.sqrt(2 * settings.HBAR)

--- a/tests/test_lab/test_detectors.py
+++ b/tests/test_lab/test_detectors.py
@@ -43,7 +43,12 @@ def test_detector_coherent_state(alpha, eta, dc):
     assert np.allclose(ps, expected)
 
 
-@given(r=st.floats(0, 0.5), phi=st.floats(0, 2 * np.pi), eta=st.floats(0, 1), dc=st.floats(0, 0.2))
+@given(
+    r=st.floats(0, 0.5),
+    phi=st.floats(0, 2 * np.pi),
+    eta=st.floats(0, 1),
+    dc=st.floats(0, 0.2),
+)
 def test_detector_squeezed_state(r, phi, eta, dc):
     """Tests the correct mean and variance are generated when a squeezed state hits an imperfect detector"""
     S = Sgate(r=r, phi=phi)
@@ -52,8 +57,10 @@ def test_detector_squeezed_state(r, phi, eta, dc):
     mean = np.arange(len(ps)) @ ps.numpy()
     expected_mean = eta * np.sinh(r) ** 2 + dc
     assert np.allclose(mean, expected_mean)
-    variance = np.arange(len(ps)) ** 2 @ ps.numpy() - mean**2
-    expected_variance = eta * np.sinh(r) ** 2 * (1 + eta * (1 + 2 * np.sinh(r) ** 2)) + dc
+    variance = np.arange(len(ps)) ** 2 @ ps.numpy() - mean ** 2
+    expected_variance = (
+        eta * np.sinh(r) ** 2 * (1 + eta * (1 + 2 * np.sinh(r) ** 2)) + dc
+    )
     assert np.allclose(variance, expected_variance)
 
 
@@ -77,8 +84,8 @@ def test_detector_two_mode_squeezed_state(r, phi, eta_s, eta_i, dc_s, dc_i):
     n_i = eta_i * np.sinh(r) ** 2
     expected_mean_i = n_i + dc_i
     expected_mean_s = n_s + dc_s
-    var_s = np.sum(ps, axis=1) @ n**2 - mean_s**2
-    var_i = np.sum(ps, axis=0) @ n**2 - mean_i**2
+    var_s = np.sum(ps, axis=1) @ n ** 2 - mean_s ** 2
+    var_i = np.sum(ps, axis=0) @ n ** 2 - mean_i ** 2
     expected_var_s = n_s * (n_s + 1) + dc_s
     expected_var_i = n_i * (n_i + 1) + dc_i
     covar = n @ ps.numpy() @ n - mean_s * mean_i
@@ -128,15 +135,18 @@ def test_homodyne_on_2mode_squeezed_vacuum(s, X):
     remaining_state = TMSV(r=np.arcsinh(np.sqrt(abs(s)))) << homodyne[0]
     cov = (
         np.diag(
-            [1 - 2 * s / (1 / np.tanh(r) * (1 + s) + s), 1 + 2 * s / (1 / np.tanh(r) * (1 + s) - s)]
+            [
+                1 - 2 * s / (1 / np.tanh(r) * (1 + s) + s),
+                1 + 2 * s / (1 / np.tanh(r) * (1 + s) - s),
+            ]
         )
         * settings.HBAR
         / 2.0
     )
     assert np.allclose(remaining_state.cov, cov)
-    means = np.array([2 * np.sqrt(s * (1 + s)) * X / (np.exp(-2 * r) + 1 + 2 * s), 0.0]) * np.sqrt(
-        2 * settings.HBAR
-    )
+    means = np.array(
+        [2 * np.sqrt(s * (1 + s)) * X / (np.exp(-2 * r) + 1 + 2 * s), 0.0]
+    ) * np.sqrt(2 * settings.HBAR)
     assert np.allclose(remaining_state.means, means)
 
 
@@ -203,13 +213,19 @@ def test_homodyne_on_2mode_squeezed_vacuum_with_displacement(s, X, d):
     r = homodyne.r
     remaining_state = tmsv << homodyne[0]
     xb, xa, pb, pa = d
-    means = np.array(
-        [
-            xa
-            + (2 * np.sqrt(s * (s + 1)) * (X - xb)) / (1 + 2 * s + np.cosh(2 * r) - np.sinh(2 * r)),
-            pa + (2 * np.sqrt(s * (s + 1)) * pb) / (1 + 2 * s + np.cosh(2 * r) + np.sinh(2 * r)),
-        ]
-    ) * np.sqrt(2 * settings.HBAR)
+    means = (
+        np.array(
+            [
+                xa
+                + (2 * np.sqrt(s * (s + 1)) * (X - xb))
+                / (1 + 2 * s + np.cosh(2 * r) - np.sinh(2 * r)),
+                pa
+                + (2 * np.sqrt(s * (s + 1)) * pb)
+                / (1 + 2 * s + np.cosh(2 * r) + np.sinh(2 * r)),
+            ]
+        )
+        * np.sqrt(2 * settings.HBAR)
+    )
     assert np.allclose(remaining_state.means, means)
 
 
@@ -243,14 +259,15 @@ def test_heterodyne_on_2mode_squeezed_vacuum_with_displacement(
 
 def test_norm_1mode():
     assert np.allclose(
-        Coherent(2.0) << Fock(3), np.abs((2.0**3) / np.sqrt(6) * np.exp(-0.5 * 4.0)) ** 2
+        Coherent(2.0) << Fock(3),
+        np.abs((2.0 ** 3) / np.sqrt(6) * np.exp(-0.5 * 4.0)) ** 2,
     )
 
 
 def test_norm_2mode():
     leftover = Coherent(x=[2.0, 2.0]) << Fock(3)[0]
     assert np.isclose(
-        (2.0**3) / np.sqrt(6) * np.exp(-0.5 * 4.0), physics.norm(leftover), atol=1e-5
+        (2.0 ** 3) / np.sqrt(6) * np.exp(-0.5 * 4.0), physics.norm(leftover), atol=1e-5
     )
 
 
@@ -263,20 +280,22 @@ def test_norm_2mode_gaussian_normalized():
     leftover = Coherent(x=[2.0, 2.0]) << Coherent(x=1.0, normalize=True)[0]
     assert np.isclose(1.0, physics.norm(leftover), atol=1e-5)
 
+
 def test_homodyne_mode_kwargs():
 
-    S1 = Sgate(modes=[0], r=1, phi=np.pi/2)
+    S1 = Sgate(modes=[0], r=1, phi=np.pi / 2)
     S2 = Sgate(modes=[1], r=1, phi=0)
     initial_state = Vacuum(2) >> S1 >> S2
-    final_state = initial_state << Homodyne(modes=[1],quadrature_angle=0,result=[0.3])
+    final_state = initial_state << Homodyne(modes=[1], quadrature_angle=0, result=[0.3])
 
     expected_state = Vacuum(1) >> S1
 
     assert np.allclose(final_state.dm(), expected_state.dm())
 
+
 def test_heterodyne_mode_kwargs():
 
-    S1 = Sgate(modes=[0], r=1, phi=np.pi/2)
+    S1 = Sgate(modes=[0], r=1, phi=np.pi / 2)
     S2 = Sgate(modes=[1], r=1, phi=0)
     initial_state = Vacuum(2) >> S1 >> S2
     final_state = initial_state << Heterodyne(modes=[1])

--- a/tests/test_lab/test_states.py
+++ b/tests/test_lab/test_states.py
@@ -27,9 +27,7 @@ from tests import random
 @st.composite
 def xy_arrays(draw):
     length = draw(st.integers(2, 10))
-    return draw(
-        arrays(dtype=np.float, shape=(2, length), elements=st.floats(-5.0, 5.0))
-    )
+    return draw(arrays(dtype=np.float, shape=(2, length), elements=st.floats(-5.0, 5.0)))
 
 
 @st.composite
@@ -50,17 +48,13 @@ def test_vacuum_state(num_modes, hbar):
 @given(x=st.floats(-5.0, 5.0), y=st.floats(-5.0, 5.0))
 def test_coherent_state_single(x, y):
     state = Coherent(x, y)
-    assert np.allclose(
-        state.cov, np.array([[settings.HBAR / 2, 0], [0, settings.HBAR / 2]])
-    )
+    assert np.allclose(state.cov, np.array([[settings.HBAR / 2, 0], [0, settings.HBAR / 2]]))
     assert np.allclose(state.means, np.array([x, y]) * np.sqrt(2 * settings.HBAR))
 
 
 @given(hbar=st.floats(0.5, 2.0), x=st.floats(-5.0, 5.0), y=st.floats(-5.0, 5.0))
 def test_coherent_state_list(hbar, x, y):
-    assert np.allclose(
-        gp.displacement([x], [y], hbar), np.array([x, y]) * np.sqrt(2 * hbar)
-    )
+    assert np.allclose(gp.displacement([x], [y], hbar), np.array([x, y]) * np.sqrt(2 * hbar))
 
 
 @given(hbar=st.floats(0.5, 2.0), x=st.floats(-5.0, 5.0), y=st.floats(-5.0, 5.0))
@@ -77,9 +71,7 @@ def test_coherent_state_multiple(xy):
     state = Coherent(x, y)
     assert np.allclose(state.cov, np.eye(2 * len(x)) * settings.HBAR / 2)
     assert len(x) == len(y)
-    assert np.allclose(
-        state.means, np.concatenate([x, y], axis=-1) * np.sqrt(2 * settings.HBAR)
-    )
+    assert np.allclose(state.means, np.concatenate([x, y], axis=-1) * np.sqrt(2 * settings.HBAR))
 
 
 @given(xy=xy_arrays())

--- a/tests/test_lab/test_states.py
+++ b/tests/test_lab/test_states.py
@@ -19,6 +19,7 @@ from hypothesis.extra.numpy import arrays
 from mrmustard.physics import gaussian as gp
 from mrmustard.lab.states import *
 from mrmustard.lab.gates import *
+from mrmustard.lab.abstract import State
 from mrmustard import settings
 from tests import random
 
@@ -175,3 +176,17 @@ def test_random_state_is_entangled():
     assert N1 > 0
     assert N2 > 0
     assert np.allclose(N1, N2)
+
+
+@given(modes=st.lists(st.integers(), min_size=2, max_size=5, unique=True))
+def test_getitem_set_modes(modes):
+    """Test that using `State.__getitem__` and `modes` kwarg correctly set the modes of the state."""
+
+    cutoff = len(modes) + 1
+    ket = np.zeros([cutoff]*len(modes), dtype=np.complex128)
+    ket[1,1] = 1.0 + 0.0j
+
+    state1 = State(ket=ket)[modes]
+    state2 = State(ket=ket, modes=modes)
+
+    assert state1.modes == state2.modes

--- a/tests/test_lab/test_states.py
+++ b/tests/test_lab/test_states.py
@@ -27,7 +27,9 @@ from tests import random
 @st.composite
 def xy_arrays(draw):
     length = draw(st.integers(2, 10))
-    return draw(arrays(dtype=np.float, shape=(2, length), elements=st.floats(-5.0, 5.0)))
+    return draw(
+        arrays(dtype=np.float, shape=(2, length), elements=st.floats(-5.0, 5.0))
+    )
 
 
 @st.composite
@@ -48,19 +50,24 @@ def test_vacuum_state(num_modes, hbar):
 @given(x=st.floats(-5.0, 5.0), y=st.floats(-5.0, 5.0))
 def test_coherent_state_single(x, y):
     state = Coherent(x, y)
-    assert np.allclose(state.cov, np.array([[settings.HBAR / 2, 0], [0, settings.HBAR / 2]]))
+    assert np.allclose(
+        state.cov, np.array([[settings.HBAR / 2, 0], [0, settings.HBAR / 2]])
+    )
     assert np.allclose(state.means, np.array([x, y]) * np.sqrt(2 * settings.HBAR))
 
 
 @given(hbar=st.floats(0.5, 2.0), x=st.floats(-5.0, 5.0), y=st.floats(-5.0, 5.0))
 def test_coherent_state_list(hbar, x, y):
-    assert np.allclose(gp.displacement([x], [y], hbar), np.array([x, y]) * np.sqrt(2 * hbar))
+    assert np.allclose(
+        gp.displacement([x], [y], hbar), np.array([x, y]) * np.sqrt(2 * hbar)
+    )
 
 
 @given(hbar=st.floats(0.5, 2.0), x=st.floats(-5.0, 5.0), y=st.floats(-5.0, 5.0))
 def test_coherent_state_array(hbar, x, y):
     assert np.allclose(
-        gp.displacement(np.array([x]), np.array([y]), hbar), np.array([x, y]) * np.sqrt(2 * hbar)
+        gp.displacement(np.array([x]), np.array([y]), hbar),
+        np.array([x, y]) * np.sqrt(2 * hbar),
     )
 
 
@@ -70,7 +77,9 @@ def test_coherent_state_multiple(xy):
     state = Coherent(x, y)
     assert np.allclose(state.cov, np.eye(2 * len(x)) * settings.HBAR / 2)
     assert len(x) == len(y)
-    assert np.allclose(state.means, np.concatenate([x, y], axis=-1) * np.sqrt(2 * settings.HBAR))
+    assert np.allclose(
+        state.means, np.concatenate([x, y], axis=-1) * np.sqrt(2 * settings.HBAR)
+    )
 
 
 @given(xy=xy_arrays())
@@ -183,8 +192,8 @@ def test_getitem_set_modes(modes):
     """Test that using `State.__getitem__` and `modes` kwarg correctly set the modes of the state."""
 
     cutoff = len(modes) + 1
-    ket = np.zeros([cutoff]*len(modes), dtype=np.complex128)
-    ket[1,1] = 1.0 + 0.0j
+    ket = np.zeros([cutoff] * len(modes), dtype=np.complex128)
+    ket[1, 1] = 1.0 + 0.0j
 
     state1 = State(ket=ket)[modes]
     state2 = State(ket=ket, modes=modes)


### PR DESCRIPTION
**Context:**
`Homodyne(modes=[m],...)` and `Heterodyne(modes=[m],...)` should apply a detector to modes `m`.

**Description of the Change:**
- `modes` kwarg is added to `State.__init__` in `Homodyne`
- adds `modes` kwarg to `Coherent` on `Heterodyne`
- test detectors are applied to correct modes
- test using `modes` kwarg or `__getitem__` give consistent results 

**Benefits:**
Setting state/detector modes using `modes` kwarg or `__getitem__` give consistent results.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
Closes #110 