### PR TITLE
use lists instead of generators when indexing states

### DIFF
--- a/mrmustard/physics/fock.py
+++ b/mrmustard/physics/fock.py
@@ -218,16 +218,16 @@ def ABC(cov, means, full: bool, choi_r: float = None) -> Tuple[Matrix, Vector, S
 def fidelity(state_a, state_b, a_ket: bool, b_ket: bool) -> Scalar:
     r"""Computes the fidelity between two states in Fock representation."""
     if a_ket and b_ket:
-        min_cutoffs = (slice(min(a, b)) for a, b in zip(state_a.shape, state_b.shape))
+        min_cutoffs = [slice(min(a, b)) for a, b in zip(state_a.shape, state_b.shape)]
         state_a = state_a[min_cutoffs]
         state_b = state_b[min_cutoffs]
         return math.abs(math.sum(math.conj(state_a) * state_b)) ** 2
 
     if a_ket:
-        min_cutoffs = (
+        min_cutoffs = [
             slice(min(a, b))
             for a, b in zip(state_a.shape, state_b.shape[: len(state_b.shape) // 2])
-        )
+        ]
         state_a = state_a[min_cutoffs]
         state_b = state_b[min_cutoffs * 2]
         a = math.reshape(state_a, -1)
@@ -236,10 +236,10 @@ def fidelity(state_a, state_b, a_ket: bool, b_ket: bool) -> Scalar:
         )
 
     if b_ket:
-        min_cutoffs = (
+        min_cutoffs = [
             slice(min(a, b))
             for a, b in zip(state_a.shape[: len(state_a.shape) // 2], state_b.shape)
-        )
+        ]
         state_a = state_a[min_cutoffs * 2]
         state_b = state_b[min_cutoffs]
         b = math.reshape(state_b, -1)


### PR DESCRIPTION
**Context:**
Tensors do not support indexed/slicing with generators

**Description of the Change:**
Use lists instead of generators for list of indices

**Benefits:**
Tensors are indexed correctly avoiding unexpected errors.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
Fixes #116 