### PR TITLE
update requirements.txt

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,12 +8,16 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python
+      - name: Setup python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/mrmustard/utils/training.py
+++ b/mrmustard/utils/training.py
@@ -74,8 +74,12 @@ class Optimizer:
                 with bar:
                     while not self.should_stop(max_steps):
                         cost, grads = math.value_and_gradients(cost_fn, params)
-                        update_symplectic(params["symplectic"], grads["symplectic"], self.symplectic_lr)
-                        update_orthogonal(params["orthogonal"], grads["orthogonal"], self.orthogonal_lr)
+                        update_symplectic(
+                            params["symplectic"], grads["symplectic"], self.symplectic_lr
+                        )
+                        update_orthogonal(
+                            params["orthogonal"], grads["orthogonal"], self.orthogonal_lr
+                        )
                         update_euclidean(params["euclidean"], grads["euclidean"], self.euclidean_lr)
                         self.opt_history.append(cost)
                         bar.step(math.asnumpy(cost))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-numpy==1.19.5
-scipy==1.7.3
-numba==0.53.1
-thewalrus==0.17.0
-tensorflow==2.6.3
+numpy==1.21.6
+scipy==1.8.0
+numba==0.55.1
+thewalrus==0.19.0
+tensorflow==2.8.0
 rich==10.15.1
 tqdm==4.62.3
 matplotlib==3.5.0


### PR DESCRIPTION
**Context:**
A Buffer Overflow vulnerability exists in NumPy 1.9.x in the PyArray_NewFromDescr_int function of ctors.c when specifying arrays of large dimensions (over 32) from Python code, which could let a malicious user cause a Denial of Service.

**Description of the Change:**
This PR updates Mr Mustard's dependencies to the latest possible versions that support `python >= 3.8`.

**Benefits:**
Latest version of dependencies. No vulnerabilities from Numpy.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None
