### PR TITLE
CI on master branch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: Tests
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 jobs:


### PR DESCRIPTION
**Context:**
CI workflows should run when merging or pushing to `main` branch.

**Description of the Change:**
CI workflow files are pointing to the non-existent ref `master`. This PR changes `master` to `main` wherever referenced.

**Benefits:**
`main` branch code is tested whenever a merge or a push happens.
