### PR TITLE
Bump tensorflow version (protobuf hotfix)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy==1.21.6
 scipy==1.8.0
 numba==0.55.1
 thewalrus==0.19.0
-tensorflow==2.8.0
+tensorflow==2.9.1
 rich==10.15.1
 tqdm==4.62.3
 matplotlib==3.5.0


### PR DESCRIPTION
**Context:**
Breaking change in protobuf v4.21.0-rc1 [breaks ](https://github.com/protocolbuffers/protobuf/issues/10051) `import tensorflow`.

**Description of the Change:**
This PR bumps Tensorflow version to use a [release](https://github.com/tensorflow/tensorflow/releases/tag/v2.9.1) that has an upper bound for `protobuf` in Tensorflow's `setup.py`. This is a hotfix from tensorflow and the version should be updated as soon as there is a new release.

**Benefits:**
Avoid errors coming from protobuf latest version.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None