### PR TITLE
Sampling from measurements

### DIFF
--- a/mrmustard/lab/detectors.py
+++ b/mrmustard/lab/detectors.py
@@ -16,7 +16,7 @@
 This module implements the set of detector classes that perform measurements on quantum circuits.
 """
 
-from typing import List, Tuple, Union, Optional
+from typing import List, Tuple, Union, Optional, Sequence
 from mrmustard.types import Matrix
 from mrmustard.training import Parametrized
 from mrmustard.lab.abstract import FockMeasurement
@@ -246,19 +246,26 @@ class Homodyne(DisplacedSqueezed):
     def __init__(
         self,
         quadrature_angle: Union[float, List[float]],
-        result: Union[float, List[float]] = 0.0,
-        modes: List[int] = None,
+        result: Optional[Union[float, List[float]]] = None,
+        modes: Optional[List[int]] = None,
         r: Union[float, List[float]] = settings.HOMODYNE_SQUEEZING,
     ):
-        quadrature_angle = math.astensor(quadrature_angle, dtype="float64")
-        result = math.astensor(result, dtype="float64")
-        x = result * math.cos(quadrature_angle)
-        y = result * math.sin(quadrature_angle)
-        r = math.astensor(r, dtype="float64")
-        super().__init__(
-            r=r,
-            phi=2 * quadrature_angle,
-            x=x,
-            y=y,
-            modes=modes,
-        )
+        if result is None:
+            self.sample = True
+            self.quadrature_angle = quadrature_angle
+            super().__init__(
+                r=r,
+                modes=modes,
+            )
+        else:
+            quadrature_angle = math.astensor(quadrature_angle, dtype="float64")
+            result = math.astensor(result, dtype="float64")
+            x = result * math.cos(quadrature_angle)
+            y = result * math.sin(quadrature_angle)
+            super().__init__(
+                r=r,
+                phi=2 * quadrature_angle,
+                x=x,
+                y=y,
+                modes=modes,
+            )


### PR DESCRIPTION
**Context:**
Currently applying homodyne or heterodyne detection returns the probability of the outcome. It is of interest as well to be able to output samples from measurements.

**Description of the Change:**
- Adds `tensorflow-probability==0.17.0` to Mr Mustard's dependencies. [TensorFlow Probability](https://www.tensorflow.org/probability/overview) provides integration of probabilistic methods with automatic differentiation and hardware acceleration (GPUs). Pytorch also provides similar functionality through the [`torch.distributions`](https://pytorch.org/docs/stable/distributions.html) module.
- For gaussian states, samples are drawn from the gaussian PDF. The PDF has been implemented using TensorFlow's multivariate normal distribution.
- For Fock states...

**Benefits:**
...

**Possible Drawbacks:**
Adds an extra dependency  `tensorflow-probability` to Mr Mustard increasing the bundle size of the library.