### PR TITLE
Check for `Sequence` instead of `Iterable` on parameter extraction

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -44,12 +44,13 @@
 
 * The Parametrized and Training classes have been refactored. The new training module has been added
   and with it the new Parameter class: now trainable tensors are wrapped in an instance of Parameter.
-  [(#133)](https://github.com/XanaduAI/MrMustard/pull/133)
-  
+  [(#133)](https://github.com/XanaduAI/MrMustard/pull/133),
+  patch [(#144)](https://github.com/XanaduAI/MrMustard/pull/144)
+
 * The string representations of the `Circuit` and `Transformation` objects have been improved:
   the `Circuit.__repr__` method now produces a string that can be used to generate a circuit in
   a identical state (same gates and parameters), the `Transformation.__str__` and objects
-  inheriting from it now prints the name, memory location of the object as well as the modes 
+  inheriting from it now prints the name, memory location of the object as well as the modes
   of the circuit in which the transformation is acting on. The `_markdown_repr_` has been implemented
   and on a jupyter notebook produces a table with valuable information of the Transformation objects.
   [(#141)](https://github.com/XanaduAI/MrMustard/pull/141)

--- a/mrmustard/training/parametrized.py
+++ b/mrmustard/training/parametrized.py
@@ -79,7 +79,7 @@ def _traverse_parametrized(object_: Any, extract_type: Parameter) -> Generator:
     """
 
     for obj in object_:
-        if isinstance(obj, Iterable):
+        if isinstance(obj, Sequence):
             yield from _traverse_parametrized(obj, extract_type)
         elif isinstance(obj, Parametrized):
             yield from _traverse_parametrized(obj.__dict__.values(), extract_type)

--- a/mrmustard/training/parametrized.py
+++ b/mrmustard/training/parametrized.py
@@ -18,7 +18,7 @@ class constructor generate a backend Tensor and are assigned to fields
 of the class.
 """
 
-from typing import Sequence, List, Generator, Iterable, Any
+from typing import Sequence, List, Generator, Any
 from mrmustard.math import Math
 from .parameter import create_parameter, Trainable, Constant, Parameter
 
@@ -79,7 +79,7 @@ def _traverse_parametrized(object_: Any, extract_type: Parameter) -> Generator:
     """
 
     for obj in object_:
-        if isinstance(obj, Sequence):
+        if isinstance(obj, Sequence):  # pylint: disable=isinstance-second-argument-not-valid-type
             yield from _traverse_parametrized(obj, extract_type)
         elif isinstance(obj, Parametrized):
             yield from _traverse_parametrized(obj.__dict__.values(), extract_type)


### PR DESCRIPTION
**Context:**
`State` instances contain tensors as variables (for example, the symplectic or covariance matrix of the state). States being also instances of `Parametrized` are recursed to obtain the trainable and constant parameters.

**Description of the Change:**
This PR substitutes the recurrence check from `Iterable` to `Sequence`. This specific logic branch is targeted for objects that contain lists (hence a `Sequence`) of Parametrized instances, like a circuit. Since tensors are also instances of `Iterable`, every object containing a tensor as a variable will be recursed but will result in an error.

**Benefits:**
Resolves the bug
```pycon
>>> SqueezedVacuum(r=1.0).constant_parameters 
TypeError: Cannot iterate over a scalar tensor.

>>> SqueezedVacuum(r=1.0).trainable_parameters 
TypeError: Cannot iterate over a scalar tensor.
```
for all instances of `State`.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None