### PR TITLE
importing and using faster tw functions

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -55,6 +55,10 @@
   and on a jupyter notebook produces a table with valuable information of the Transformation objects.
   [(#141)](https://github.com/XanaduAI/MrMustard/pull/141)
 
+* We now use `_hermite_multidimensional_renorm` and `_grad_hermite_multidimensional_renorm` from 
+  thewalrus, bypassing the logic in `hermite_multidimensional` to eventually call those functions.
+  [(#145)](https://github.com/XanaduAI/MrMustard/pull/145)
+
 ### Bug fixes
 * Fixed a bug in the `State.ket()` method. An attribute was called with a typo in its name.
   [(#135)](https://github.com/XanaduAI/MrMustard/pull/135)

--- a/mrmustard/math/tensorflow.py
+++ b/mrmustard/math/tensorflow.py
@@ -16,7 +16,10 @@
 
 import numpy as np
 import tensorflow as tf
-from thewalrus._hermite_multidimensional import _hermite_multidimensional_renorm, _grad_hermite_multidimensional_renorm
+from thewalrus._hermite_multidimensional import (
+    _hermite_multidimensional_renorm,
+    _grad_hermite_multidimensional_renorm,
+)
 
 from mrmustard.math.autocast import Autocast
 from mrmustard.types import (
@@ -339,10 +342,10 @@ class TFMath(MathInterface):
             The renormalized Hermite polynomial of given shape.
         """
         G = np.zeros(shape, dtype=np.complex128)
-        G[(0,)*len(shape)] = C
+        G[(0,) * len(shape)] = C
         G = tf.numpy_function(_hermite_multidimensional_renorm, [A, B, G], G.dtype)
 
-        def grad(dLdG): # NOTE: dLdG is the derivative of L with respect to poly *conjugate*
+        def grad(dLdG):  # NOTE: dLdG is the derivative of L with respect to poly *conjugate*
             dG_dC = np.array(G / C, dtype=np.complex128)
             dG_dA = np.zeros(G.shape + A.shape, dtype=np.complex128)
             dG_dB = np.zeros(G.shape + B.shape, dtype=np.complex128)
@@ -353,7 +356,11 @@ class TFMath(MathInterface):
             dLdA = self.sum(dLdG[..., None, None] * self.conj(dG_dA), axes=ax)
             dLdB = self.sum(dLdG[..., None] * self.conj(dG_dB), axes=ax)
             dLdC = self.sum(dLdG * self.conj(dG_dC), axes=ax)
-            return dLdA, dLdB, dLdC  # NOTE: dLdA, dLdB, dLdC are the derivatives of L with respect to A, B, C *conjugate*
+            return (
+                dLdA,
+                dLdB,
+                dLdC,
+            )  # NOTE: dLdA, dLdB, dLdC are the derivatives of L with respect to A, B, C *conjugate*
 
         return G, grad
 

--- a/tests/test_physics/test_fock/test_fock.py
+++ b/tests/test_physics/test_fock/test_fock.py
@@ -148,8 +148,8 @@ def test_density_matrix(num_modes):
     [
         Vacuum(num_modes=2),
         Fock(4),
-        Coherent(x=0.1, y=-0.4, cutoffs=[15]),
-        Gaussian(num_modes=2, cutoffs=[15]),
+        Coherent(x=0.1, y=-0.4, cutoffs=[25]),
+        Gaussian(num_modes=2, cutoffs=[35]),
     ],
 )
 def test_dm_to_ket(state):


### PR DESCRIPTION
instead of using the public functions in the walrus, which include input checks and logic for piping to the right particular case, we use the particular case directly (_renormalized_ hermite polynomials).
