### PR TITLE
Calculate displacement operator unitary matrix using The Walrus

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -55,6 +55,9 @@
   and on a jupyter notebook produces a table with valuable information of the Transformation objects.
   [(#141)](https://github.com/XanaduAI/MrMustard/pull/141)
 
+* The `Dgate` now uses The Walrus to calculate the unitary and gradients of the displacement gate in fock representation,
+  providing better numerical stability for larger cutoff and displacement values. [(#147)](https://github.com/XanaduAI/MrMustard/pull/147)
+
 ### Bug fixes
 * Fixed a bug in the `State.ket()` method. An attribute was called with a typo in its name.
   [(#135)](https://github.com/XanaduAI/MrMustard/pull/135)

--- a/mrmustard/lab/gates.py
+++ b/mrmustard/lab/gates.py
@@ -93,6 +93,19 @@ class Dgate(Parametrized, Transformation):
     def d_vector(self):
         return gaussian.displacement(self.x.value, self.y.value, settings.HBAR)
 
+    def U(self, cutoffs: List[int]):
+        r"""Returns the unitary representation of the Displacement gate using the Laguerre
+        polynomials."""
+        if len(cutoffs) != self.num_modes:
+            raise ValueError(
+                f"Expected `len(cutoffs)={len(self.num_modes)}` but {len(cutoffs)} cutoffs were given."
+            )
+
+        r = math.sqrt(self.x.value**2 + self.y.value**2)
+        phi = math.atan(self.y.value / self.x.value)
+
+        return math.displacement(r, phi, cutoffs)
+
 
 class Sgate(Parametrized, Transformation):
     r"""Squeezing gate.

--- a/mrmustard/lab/gates.py
+++ b/mrmustard/lab/gates.py
@@ -108,11 +108,7 @@ class Dgate(Parametrized, Transformation):
             if N > 1
             else math.sqrt([self.x.value**2 + self.y.value**2])
         )
-        phi = (
-            math.atan(self.y.value / self.x.value)
-            if N > 1
-            else math.atan([self.y.value / self.x.value])
-        )
+        phi = math.atan2(self.y.value, self.x.value)
 
         # calculate displacement independently for each mode
         unitaries = []

--- a/mrmustard/lab/gates.py
+++ b/mrmustard/lab/gates.py
@@ -108,7 +108,11 @@ class Dgate(Parametrized, Transformation):
             if N > 1
             else math.sqrt([self.x.value**2 + self.y.value**2])
         )
-        phi = math.atan2(self.y.value, self.x.value)
+        phi = (
+            math.atan2(self.y.value, self.x.value)
+            if N > 1
+            else math.atan2([self.y.value], [self.x.value])
+        )
 
         # calculate displacement independently for each mode
         unitaries = []

--- a/mrmustard/lab/gates.py
+++ b/mrmustard/lab/gates.py
@@ -110,8 +110,9 @@ class Dgate(Parametrized, Transformation):
             # and return the outer product
             unitaries = []
             for idx, cutoff in enumerate(cutoffs):
-                if math.abs(r[idx]) < 1e-15 and math.abs(phi[idx]) < 1e-15:
-                    Ud = math.eyes(cutoff)
+                # if args are close to zero, return the identity
+                if math.abs(r[idx]).numpy() < 1e-15:
+                    Ud = math.eye(cutoff)
                 else:
                     Ud = math.displacement(r[idx], phi[idx], cutoff)
 
@@ -126,7 +127,8 @@ class Dgate(Parametrized, Transformation):
                 list(range(0, 2 * N, 2)) + list(range(1, 2 * N, 2)),
             )
 
-        if math.abs(r) < 1e-15 and math.abs(phi) < 1e-15:
+        # if args are close to zero, return the identity
+        if math.abs(r).numpy() < 1e-15:
             return math.eye(cutoffs[0])
         else:
             return math.displacement(r, phi, cutoffs[0])

--- a/mrmustard/lab/gates.py
+++ b/mrmustard/lab/gates.py
@@ -101,10 +101,15 @@ class Dgate(Parametrized, Transformation):
                 f"Expected `len(cutoffs)={len(self.num_modes)}` but {len(cutoffs)} cutoffs were given."
             )
 
+        if isinstance(cutoffs, List) and len(cutoffs) == 1:
+            cutoff = cutoffs[0]
+        else:
+            raise NotImplementedError("Displacement is only implemented for a single mode.")
+
         r = math.sqrt(self.x.value**2 + self.y.value**2)
         phi = math.atan(self.y.value / self.x.value)
 
-        return math.displacement(r, phi, cutoffs)
+        return math.displacement(r, phi, cutoff)
 
 
 class Sgate(Parametrized, Transformation):

--- a/mrmustard/math/math_interface.py
+++ b/mrmustard/math/math_interface.py
@@ -253,6 +253,17 @@ class MathInterface(ABC):
         """
 
     @abstractmethod
+    def atan(self, array: Tensor) -> Tensor:
+        r"""Computes the trignometric inverse tangent of array element-wise.
+
+        Args:
+            array (array): array to take the arctan of
+
+        Returns:
+            array: arctan of array
+        """
+
+    @abstractmethod
     def det(self, matrix: Tensor) -> Tensor:
         r"""Returns the determinant of matrix.
 
@@ -388,6 +399,19 @@ class MathInterface(ABC):
 
         Returns:
             array: renormalized hermite polynomials
+        """
+
+    @abstractmethod
+    def displacement(self, r: Scalar, phi: Scalar, cutoff: Scalar, dtype):
+        r"""Calculates the matrix elements of the displacement gate and its derivatives.
+
+        Args:
+            r (float): displacement magnitude
+            phi (float): displacement angle
+            cutoff (int): Fock ladder cutoff
+            dtype (data type): Specifies the data type used for the calculation
+        Returns:
+            Tuple(array[complex], function): matrix representing the displacement operation and its gradient
         """
 
     @abstractmethod

--- a/mrmustard/math/math_interface.py
+++ b/mrmustard/math/math_interface.py
@@ -253,14 +253,15 @@ class MathInterface(ABC):
         """
 
     @abstractmethod
-    def atan(self, array: Tensor) -> Tensor:
-        r"""Computes the trignometric inverse tangent of array element-wise.
+    def atan2(self, y: Tensor, x: Tensor) -> Tensor:
+        r"""Computes the trignometric inverse tangent of y/x element-wise.
 
         Args:
-            array (array): array to take the arctan of
+            y (array): numerator array
+            x (array): denominator array
 
         Returns:
-            array: arctan of array
+            array: arctan of y/x
         """
 
     @abstractmethod

--- a/mrmustard/math/tensorflow.py
+++ b/mrmustard/math/tensorflow.py
@@ -122,7 +122,7 @@ class TFMath(MathInterface):
 
     def atan2(self, y: tf.Tensor, x: tf.Tensor) -> tf.Tensor:
         return tf.math.atan2(y, x)
-        
+
     def make_complex(self, real: tf.Tensor, imag: tf.Tensor) -> tf.Tensor:
         return tf.complex(real, imag)
 

--- a/mrmustard/math/tensorflow.py
+++ b/mrmustard/math/tensorflow.py
@@ -362,11 +362,11 @@ class TFMath(MathInterface):
         return poly, grad
 
     @tf.custom_gradient
-    def displacement(self, r, phi, cutoff, dtype=tf.complex64.as_numpy_dtype):
+    def displacement(self, r, phi, cutoff, dtype=tf.complex64.as_numpy_dtype, tol=1e-15):
         """creates a single mode displacement matrix"""
         r = r.numpy()
         phi = phi.numpy()
-        gate = displacement_tw(r, phi, cutoff, dtype)
+        gate = displacement_tw(r, phi, cutoff, dtype) if r > tol else self.eye(cutoff)
 
         def grad(dy):  # pragma: no cover
             Dr, Dphi = grad_displacement_tw(gate, r, phi)

--- a/mrmustard/math/tensorflow.py
+++ b/mrmustard/math/tensorflow.py
@@ -364,12 +364,6 @@ class TFMath(MathInterface):
     @tf.custom_gradient
     def displacement(self, r, phi, cutoff, dtype=tf.complex64.as_numpy_dtype):
         """creates a single mode displacement matrix"""
-
-        if isinstance(cutoff, List) and len(cutoff) == 1:
-            cutoff = cutoff[0]
-        else:
-            raise NotImplementedError("Displacement is only implemented for a single mode.")
-
         r = r.numpy()
         phi = phi.numpy()
         gate = displacement_tw(r, phi, cutoff, dtype)

--- a/mrmustard/math/tensorflow.py
+++ b/mrmustard/math/tensorflow.py
@@ -119,8 +119,8 @@ class TFMath(MathInterface):
     def cosh(self, array: tf.Tensor) -> tf.Tensor:
         return tf.math.cosh(array)
 
-    def atan(self, array: tf.Tensor) -> tf.Tensor:
-        return tf.math.atan(array)
+    def atan2(self, y: tf.Tensor, x: tf.Tensor) -> tf.Tensor:
+        return tf.math.atan2(y, x)
 
     def det(self, matrix: tf.Tensor) -> tf.Tensor:
         return tf.linalg.det(matrix)

--- a/tests/test_lab/test_gates_fock.py
+++ b/tests/test_lab/test_gates_fock.py
@@ -50,11 +50,54 @@ def test_1mode_fock_equals_gaussian():
     # assert via_phase_space == via_fock_space
 
 
-@given(x=st.floats(min_value=-2, max_value=2), y=st.floats(min_value=-2, max_value=2))
-def test_fock_representation_displacement(x, y):
-    D = Dgate(x=x, y=y)
-    expected = displacement(r=np.sqrt(x**2 + y**2), phi=np.arctan2(y, x), cutoff=20)
-    assert np.allclose(expected, D.U(cutoffs=[20]), atol=1e-5)
+def test_fock_representation_displacement():
+    """Tests the correct construction of the single mode displacement operation.
+    Since the displacement uses the walrus, this is the same test as in the walrus."""
+    cutoff = 5
+    alpha = 0.3 + 0.5 * 1j
+    # This data is obtained by using qutip
+    # np.array(displace(40,alpha).data.todense())[0:5,0:5]
+    expected = np.array(
+        [
+            [
+                0.84366482 + 0.00000000e00j,
+                -0.25309944 + 4.21832408e-01j,
+                -0.09544978 - 1.78968334e-01j,
+                0.06819609 + 3.44424719e-03j,
+                -0.01109048 + 1.65323865e-02j,
+            ],
+            [
+                0.25309944 + 4.21832408e-01j,
+                0.55681878 + 0.00000000e00j,
+                -0.29708743 + 4.95145724e-01j,
+                -0.14658716 - 2.74850926e-01j,
+                0.12479885 + 6.30297236e-03j,
+            ],
+            [
+                -0.09544978 + 1.78968334e-01j,
+                0.29708743 + 4.95145724e-01j,
+                0.31873657 + 0.00000000e00j,
+                -0.29777767 + 4.96296112e-01j,
+                -0.18306015 - 3.43237787e-01j,
+            ],
+            [
+                -0.06819609 + 3.44424719e-03j,
+                -0.14658716 + 2.74850926e-01j,
+                0.29777767 + 4.96296112e-01j,
+                0.12389162 + 1.10385981e-17j,
+                -0.27646677 + 4.60777945e-01j,
+            ],
+            [
+                -0.01109048 - 1.65323865e-02j,
+                -0.12479885 + 6.30297236e-03j,
+                -0.18306015 + 3.43237787e-01j,
+                0.27646677 + 4.60777945e-01j,
+                -0.03277289 + 1.88440656e-17j,
+            ],
+        ]
+    )
+    D = Dgate(x=alpha.real, y=alpha.imag)
+    assert np.allclose(expected, D.U(cutoffs=[cutoff]), atol=1e-5)
 
 
 @given(r=st.floats(min_value=0, max_value=2), phi=st.floats(min_value=0, max_value=2 * np.pi))

--- a/tests/test_lab/test_gates_fock.py
+++ b/tests/test_lab/test_gates_fock.py
@@ -52,70 +52,19 @@ def test_1mode_fock_equals_gaussian():
     # assert via_phase_space == via_fock_space
 
 
-def test_fock_representation_displacement():
-    """Tests the correct construction of the single mode displacement operation.
-    Since the displacement uses the walrus, this is the same test as in the walrus."""
-    cutoff = 5
-    alpha = 0.3 + 0.5 * 1j
-    # This data is obtained by using qutip
-    # np.array(displace(40,alpha).data.todense())[0:5,0:5]
-    expected = np.array(
-        [
-            [
-                0.84366482 + 0.00000000e00j,
-                -0.25309944 + 4.21832408e-01j,
-                -0.09544978 - 1.78968334e-01j,
-                0.06819609 + 3.44424719e-03j,
-                -0.01109048 + 1.65323865e-02j,
-            ],
-            [
-                0.25309944 + 4.21832408e-01j,
-                0.55681878 + 0.00000000e00j,
-                -0.29708743 + 4.95145724e-01j,
-                -0.14658716 - 2.74850926e-01j,
-                0.12479885 + 6.30297236e-03j,
-            ],
-            [
-                -0.09544978 + 1.78968334e-01j,
-                0.29708743 + 4.95145724e-01j,
-                0.31873657 + 0.00000000e00j,
-                -0.29777767 + 4.96296112e-01j,
-                -0.18306015 - 3.43237787e-01j,
-            ],
-            [
-                -0.06819609 + 3.44424719e-03j,
-                -0.14658716 + 2.74850926e-01j,
-                0.29777767 + 4.96296112e-01j,
-                0.12389162 + 1.10385981e-17j,
-                -0.27646677 + 4.60777945e-01j,
-            ],
-            [
-                -0.01109048 - 1.65323865e-02j,
-                -0.12479885 + 6.30297236e-03j,
-                -0.18306015 + 3.43237787e-01j,
-                0.27646677 + 4.60777945e-01j,
-                -0.03277289 + 1.88440656e-17j,
-            ],
-        ]
-    )
-    D = Dgate(x=alpha.real, y=alpha.imag)
-    assert np.allclose(expected, D.U(cutoffs=[cutoff]), atol=1e-5)
-
-
 @pytest.mark.parametrize(
     "cutoffs,x,y",
     [
-        [[5], 1.0, 1.0],
+        [[5], 0.3, 0.5],
         [[5], 0.0, 0.0],
         [[2, 2], [0.1, 0.1], [0.25, -0.2]],
+        [[3, 3], [0.0, 0.0], [0.0, 0.0]],
         [[2, 5, 1], [0.1, 5.0, 1.0], [-0.3, 0.1, 0.0]],
         [[3, 3, 3, 3], [0.1, 0.2, 0.3, 0.4], [-0.5, -4, 3.1, 4.2]],
-        [[3, 3], [0.0, 0.0], [0.0, 0.0]],
     ],
 )
-# @pytest.mark.parametrize("cutoffs,x,y", [[[5], [10], [10]]])
-def test_fock_representation_multimode_displacement(cutoffs, x, y):
-    """Tests the correct construction of the multiple mode displacement operation."""
+def test_fock_representation_displacement(cutoffs, x, y):
+    """Tests that DGate returns the correct unitary."""
 
     # apply gate
     dgate = Dgate(x, y)

--- a/tests/test_lab/test_gates_fock.py
+++ b/tests/test_lab/test_gates_fock.py
@@ -13,7 +13,18 @@
 # limitations under the License.
 
 import pytest
-from mrmustard.lab.circuit import Circuit
+from hypothesis import given, strategies as st
+import numpy as np
+from thewalrus.fock_gradients import (
+    squeezing,
+    beamsplitter,
+    two_mode_squeezing,
+    mzgate,
+)
+
+from tests import random
+from mrmustard.physics import fock
+from mrmustard import settings
 from mrmustard.lab.states import Fock, State, SqueezedVacuum, TMSV
 from mrmustard.lab.gates import (
     Dgate,
@@ -28,18 +39,6 @@ from mrmustard.lab.gates import (
     Attenuator,
     Interferometer,
 )
-from hypothesis import given, strategies as st
-from mrmustard.physics import fock
-from thewalrus.fock_gradients import (
-    displacement,
-    squeezing,
-    beamsplitter,
-    two_mode_squeezing,
-    mzgate,
-)
-import numpy as np
-from tests import random
-import pytest
 
 
 @given(state=random.pure_state(num_modes=1), xy=random.vector(2))

--- a/tests/test_lab/test_gates_fock.py
+++ b/tests/test_lab/test_gates_fock.py
@@ -70,6 +70,8 @@ def test_fock_representation_displacement(cutoffs, x, y):
     dgate = Dgate(x, y)
     Ud = dgate.U(cutoffs)
 
+    # compare with the standard way of calculating
+    # transformation unitaries using the Choi isomorphism
     choi_state = dgate.bell >> dgate
     expected_Ud = fock.fock_representation(
         choi_state.cov,
@@ -79,7 +81,7 @@ def test_fock_representation_displacement(cutoffs, x, y):
         choi_r=settings.CHOI_R,
     )
 
-    assert np.allclose(Ud, expected_Ud)
+    assert np.allclose(Ud, expected_Ud, atol=1e-5)
 
 
 @given(r=st.floats(min_value=0, max_value=2), phi=st.floats(min_value=0, max_value=2 * np.pi))

--- a/tests/test_physics/test_fock/test_fock.py
+++ b/tests/test_physics/test_fock/test_fock.py
@@ -147,8 +147,8 @@ def test_density_matrix(num_modes):
     "state",
     [
         Vacuum(num_modes=2),
-        Fock(4),
-        Coherent(x=0.1, y=-0.4, cutoffs=[25]),
+        Fock([4, 3], modes=[0, 1]),
+        Coherent(x=[0.1, 0.2], y=[-0.4, 0.4], cutoffs=[25]),
         Gaussian(num_modes=2, cutoffs=[35]),
     ],
 )
@@ -164,7 +164,7 @@ def test_dm_to_ket(state):
 
     dm_reconstructed = ket_to_dm(ket)
     # check ket leads to same dm
-    assert np.allclose(dm, dm_reconstructed)
+    assert np.allclose(dm, dm_reconstructed, atol=1e-15)
 
 
 def test_dm_to_ket_error():


### PR DESCRIPTION
**Context:**
[The Walrus PR #351](https://github.com/XanaduAI/thewalrus/pull/351) implemented a more stable calculation of the displacement unitary.

**Description of the Change:**
The `Dgate` now uses The Walrus to calculate the unitary and gradients of the displacement gate.

Before:
![before](https://user-images.githubusercontent.com/675763/193073762-42a82fe8-7bcf-405b-ade0-e59e4fcdf270.png)

After:
![after](https://user-images.githubusercontent.com/675763/193073791-e573381f-3e97-4dc1-97e5-161897b34f0d.png)




**Benefits:**
This provides better numerical stability for larger cutoff and displacement values.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None