### PR TITLE
Auto instantiating the Math class when importing math

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -136,7 +136,6 @@ html_theme = "xanadu"
 html_theme_options = {
     "navbar_name": "Mr Mustard",
     "navbar_logo_path": "_static/mm_logo.png",
-
     "navbar_right_links": [
         {
             "name": "GitHub",
@@ -144,14 +143,10 @@ html_theme_options = {
             "icon": "fab fa-github",
         }
     ],
-
     "extra_copyrights": [
-        "TensorFlow, the TensorFlow logo, and any related marks are trademarks "
-        "of Google Inc."
+        "TensorFlow, the TensorFlow logo, and any related marks are trademarks " "of Google Inc."
     ],
-
     "google_analytics_tracking_id": "UA-116279123-2",
-
     "prev_next_button_colour": "#b79226",
     "prev_next_button_hover_colour": "#d7b348",
     "toc_marker_colour": "#b79226",

--- a/doc/introduction/basic_reference.md
+++ b/doc/introduction/basic_reference.md
@@ -182,8 +182,7 @@ The math module is the backbone of Mr Mustard, which consists in the [Math](http
 Mr Mustard comes with a plug-and-play backends through a math interface. You can use it as a drop-in replacement for tensorflow or pytorch and your code will be plug-and-play too!
 ```python
 from mrmustard import settings
-from mrmustard.math import Math
-math = Math()
+from mrmustard import math
 
 math.cos(0.1)  # tensorflow
 

--- a/mrmustard/lab/abstract/measurement.py
+++ b/mrmustard/lab/abstract/measurement.py
@@ -23,8 +23,6 @@ from mrmustard import settings
 from .state import State
 
 
-
-
 class FockMeasurement(ABC):
     r"""A Fock measurement projecting onto a Fock measurement pattern.
 

--- a/mrmustard/lab/abstract/measurement.py
+++ b/mrmustard/lab/abstract/measurement.py
@@ -16,13 +16,13 @@
 
 from __future__ import annotations
 from abc import ABC
-from mrmustard.math import Math
+from mrmustard import math
 
 from mrmustard.types import Tensor, Callable, Sequence, Iterable
 from mrmustard import settings
 from .state import State
 
-math = Math()
+
 
 
 class FockMeasurement(ABC):

--- a/mrmustard/lab/abstract/state.py
+++ b/mrmustard/lab/abstract/state.py
@@ -41,7 +41,6 @@ if TYPE_CHECKING:
     from .transformation import Transformation
 
 
-
 # pylint: disable=too-many-instance-attributes
 class State:
     r"""Base class for quantum states."""

--- a/mrmustard/lab/abstract/state.py
+++ b/mrmustard/lab/abstract/state.py
@@ -35,12 +35,12 @@ from mrmustard.types import (
 from mrmustard.utils import graphics
 from mrmustard import settings
 from mrmustard.physics import gaussian, fock
-from mrmustard.math import Math
+from mrmustard import math
 
 if TYPE_CHECKING:
     from .transformation import Transformation
 
-math = Math()
+
 
 # pylint: disable=too-many-instance-attributes
 class State:

--- a/mrmustard/lab/abstract/transformation.py
+++ b/mrmustard/lab/abstract/transformation.py
@@ -36,8 +36,6 @@ from mrmustard.training.parameter import Parameter
 from .state import State
 
 
-
-
 class Transformation:
     r"""Base class for all Transformations."""
     _bell = None  # single-mode TMSV state for gaussian-to-fock conversion

--- a/mrmustard/lab/abstract/transformation.py
+++ b/mrmustard/lab/abstract/transformation.py
@@ -31,11 +31,11 @@ from mrmustard.types import (
     Union,
 )
 from mrmustard import settings
-from mrmustard.math import Math
+from mrmustard import math
 from mrmustard.training.parameter import Parameter
 from .state import State
 
-math = Math()
+
 
 
 class Transformation:

--- a/mrmustard/lab/detectors.py
+++ b/mrmustard/lab/detectors.py
@@ -25,7 +25,6 @@ from mrmustard import settings
 from mrmustard import math
 
 
-
 __all__ = ["PNRDetector", "ThresholdDetector", "Homodyne", "Heterodyne"]
 
 # pylint: disable=no-member

--- a/mrmustard/lab/detectors.py
+++ b/mrmustard/lab/detectors.py
@@ -22,9 +22,9 @@ from mrmustard.training import Parametrized
 from mrmustard.lab.abstract import FockMeasurement
 from mrmustard.lab.states import DisplacedSqueezed, Coherent
 from mrmustard import settings
-from mrmustard.math import Math
+from mrmustard import math
 
-math = Math()
+
 
 __all__ = ["PNRDetector", "ThresholdDetector", "Homodyne", "Heterodyne"]
 

--- a/mrmustard/lab/gates.py
+++ b/mrmustard/lab/gates.py
@@ -28,7 +28,6 @@ from mrmustard.physics import gaussian
 from mrmustard import math
 
 
-
 __all__ = [
     "Dgate",
     "Sgate",

--- a/mrmustard/lab/gates.py
+++ b/mrmustard/lab/gates.py
@@ -25,9 +25,9 @@ from mrmustard.lab.abstract import Transformation
 from mrmustard.training import Parametrized
 from mrmustard.physics import gaussian
 
-from mrmustard.math import Math
+from mrmustard import math
 
-math = Math()
+
 
 __all__ = [
     "Dgate",

--- a/mrmustard/lab/states.py
+++ b/mrmustard/lab/states.py
@@ -22,9 +22,9 @@ from mrmustard import settings
 from mrmustard.lab.abstract import State
 from mrmustard.physics import gaussian, fock
 from mrmustard.training import Parametrized
-from mrmustard.math import Math
+from mrmustard import math
 
-math = Math()
+
 
 
 __all__ = [

--- a/mrmustard/lab/states.py
+++ b/mrmustard/lab/states.py
@@ -25,8 +25,6 @@ from mrmustard.training import Parametrized
 from mrmustard import math
 
 
-
-
 __all__ = [
     "Vacuum",
     "SqueezedVacuum",

--- a/mrmustard/math/__init__.py
+++ b/mrmustard/math/__init__.py
@@ -15,8 +15,6 @@
 r"""
 The ``math`` module contains low-level functions for performing mathematical operations.
 
-It is recommended that users access the backends using the an instance of the :class:`Math` class rather than the backends themselves.
-
 The Math class is a wrapper that passes the calls to the currently active backend, which is determined by
 the ``BACKEND`` parameter in ``mrmustard.settings`` (the default is ``tensorflow``).
 
@@ -25,8 +23,7 @@ greater degree of flexibility and code reuse.
 
 .. code-block::
 
-    from mrmustard.math import Math
-    math = Math()
+    from mrmustard import math
     math.cos(x)  # tensorflow backend
 
     from mrmustard import settings

--- a/mrmustard/math/__init__.py
+++ b/mrmustard/math/__init__.py
@@ -59,7 +59,8 @@ class Math:
         raise ValueError(
             f"No `{settings.backend}` backend found. Ensure your backend is either ``'tensorflow'`` or ``'torch'``"
         )
-    
-    __all__ = list(set(vars().keys()) - {'__module__', '__qualname__'})    
+
+    __all__ = list(set(vars().keys()) - {"__module__", "__qualname__"})
+
 
 sys.modules[__name__] = Math()

--- a/mrmustard/math/__init__.py
+++ b/mrmustard/math/__init__.py
@@ -35,7 +35,7 @@ greater degree of flexibility and code reuse.
     math.cos(x)  # torch backend
 """
 
-
+import sys
 import importlib
 from mrmustard import settings
 
@@ -59,3 +59,7 @@ class Math:
         raise ValueError(
             f"No `{settings.backend}` backend found. Ensure your backend is either ``'tensorflow'`` or ``'torch'``"
         )
+    
+    __all__ = list(set(vars().keys()) - {'__module__', '__qualname__'})    
+
+sys.modules[__name__] = Math()

--- a/mrmustard/math/math_interface.py
+++ b/mrmustard/math/math_interface.py
@@ -48,7 +48,7 @@ class MathInterface(ABC):
     def __new__(cls, *args, **kwargs):
         if cls.__instance is None:
             cls.__instance = super().__new__(cls)
-        return cls.__instance    
+        return cls.__instance
 
     @abstractmethod
     def __getattr__(self, name):
@@ -1086,4 +1086,3 @@ class MathInterface(ABC):
         Jmat = self.J(S.shape[-1] // 2)
         Z = self.matmul(self.transpose(S), dS_euclidean)
         return 0.5 * (Z + self.matmul(self.matmul(Jmat, self.transpose(Z)), Jmat))
-

--- a/mrmustard/math/math_interface.py
+++ b/mrmustard/math/math_interface.py
@@ -48,7 +48,7 @@ class MathInterface(ABC):
     def __new__(cls, *args, **kwargs):
         if cls.__instance is None:
             cls.__instance = super().__new__(cls)
-        return cls.__instance
+        return cls.__instance    
 
     @abstractmethod
     def __getattr__(self, name):
@@ -1086,3 +1086,4 @@ class MathInterface(ABC):
         Jmat = self.J(S.shape[-1] // 2)
         Z = self.matmul(self.transpose(S), dS_euclidean)
         return 0.5 * (Z + self.matmul(self.matmul(Jmat, self.transpose(Z)), Jmat))
+

--- a/mrmustard/physics/fock.py
+++ b/mrmustard/physics/fock.py
@@ -22,9 +22,9 @@ import numpy as np
 
 from mrmustard.types import List, Tuple, Tensor, Scalar, Matrix, Sequence, Vector
 from mrmustard import settings
-from mrmustard.math import Math
+from mrmustard import math
 
-math = Math()
+
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/mrmustard/physics/fock.py
+++ b/mrmustard/physics/fock.py
@@ -25,8 +25,6 @@ from mrmustard import settings
 from mrmustard import math
 
 
-
-
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # ~~~~~~~~~~~~~~ static functions ~~~~~~~~~~~~~~
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/mrmustard/physics/gaussian.py
+++ b/mrmustard/physics/gaussian.py
@@ -22,9 +22,9 @@ from thewalrus.quantum import is_pure_cov
 from mrmustard.types import Matrix, Vector, Scalar
 from mrmustard.utils.xptensor import XPMatrix, XPVector
 from mrmustard import settings
-from mrmustard.math import Math
+from mrmustard import math
 
-math = Math()
+
 
 
 #  ~~~~~~

--- a/mrmustard/physics/gaussian.py
+++ b/mrmustard/physics/gaussian.py
@@ -25,8 +25,6 @@ from mrmustard import settings
 from mrmustard import math
 
 
-
-
 #  ~~~~~~
 #  States
 #  ~~~~~~

--- a/mrmustard/training/__init__.py
+++ b/mrmustard/training/__init__.py
@@ -32,9 +32,8 @@ many-photon setting.
     from mrmustard.lab.states import Vacuum
     from mrmustard.lab.circuit import Circuit
     from mrmustard.training import Optimizer
-    from mrmustard.math import Math
+    from mrmustard import math
 
-    math = Math()
 
     r = np.arcsinh(1.0)
     s2_0 = S2gate(r=r, phi=0.0, phi_trainable=True)[0, 1]

--- a/mrmustard/training/optimizer.py
+++ b/mrmustard/training/optimizer.py
@@ -20,12 +20,12 @@ from itertools import chain, groupby
 from typing import List, Callable, Sequence
 from mrmustard.utils import graphics
 from mrmustard.logger import create_logger
-from mrmustard.math import Math
+from mrmustard import math
 from .parameter import Parameter, Trainable
 from .parametrized import Parametrized
 from .parameter_update import param_update_method
 
-math = Math()
+
 
 __all__ = ["Optimizer"]
 

--- a/mrmustard/training/optimizer.py
+++ b/mrmustard/training/optimizer.py
@@ -26,7 +26,6 @@ from .parametrized import Parametrized
 from .parameter_update import param_update_method
 
 
-
 __all__ = ["Optimizer"]
 
 # pylint: disable=disallowed-name

--- a/mrmustard/training/parameter.py
+++ b/mrmustard/training/parameter.py
@@ -84,10 +84,10 @@ There are three basic types of parameters:
 from abc import ABC, abstractmethod
 
 from typing import Optional, Sequence, Any
-from mrmustard.math import Math
+from mrmustard import math
 from mrmustard.types import Tensor
 
-math = Math()
+
 
 __all__ = [
     "Parameter",

--- a/mrmustard/training/parameter.py
+++ b/mrmustard/training/parameter.py
@@ -88,7 +88,6 @@ from mrmustard import math
 from mrmustard.types import Tensor
 
 
-
 __all__ = [
     "Parameter",
     "Trainable",

--- a/mrmustard/training/parameter_update.py
+++ b/mrmustard/training/parameter_update.py
@@ -20,8 +20,6 @@ from mrmustard import math
 from .parameter import Trainable
 
 
-
-
 def update_symplectic(grads_and_vars: Sequence[Tuple[Tensor, Trainable]], symplectic_lr: float):
 
     r"""Updates the symplectic parameters using the given symplectic gradients.

--- a/mrmustard/training/parameter_update.py
+++ b/mrmustard/training/parameter_update.py
@@ -16,10 +16,10 @@
 """
 
 from mrmustard.types import Sequence, Tensor, Tuple
-from mrmustard.math import Math
+from mrmustard import math
 from .parameter import Trainable
 
-math = Math()
+
 
 
 def update_symplectic(grads_and_vars: Sequence[Tuple[Tensor, Trainable]], symplectic_lr: float):

--- a/mrmustard/training/parametrized.py
+++ b/mrmustard/training/parametrized.py
@@ -23,7 +23,6 @@ from mrmustard import math
 from .parameter import create_parameter, Trainable, Constant, Parameter
 
 
-
 __all__ = ["Parametrized"]
 
 

--- a/mrmustard/training/parametrized.py
+++ b/mrmustard/training/parametrized.py
@@ -19,10 +19,10 @@ of the class.
 """
 
 from typing import Sequence, List, Generator, Any
-from mrmustard.math import Math
+from mrmustard import math
 from .parameter import create_parameter, Trainable, Constant, Parameter
 
-math = Math()
+
 
 __all__ = ["Parametrized"]
 

--- a/mrmustard/utils/xptensor.py
+++ b/mrmustard/utils/xptensor.py
@@ -22,8 +22,6 @@ from mrmustard.types import Optional, Union, Matrix, Vector, List, Tensor, Tuple
 from mrmustard import math
 
 
-
-
 class XPTensor(ABC):
     r"""A representation of Matrices and Vectors in phase space.
 

--- a/mrmustard/utils/xptensor.py
+++ b/mrmustard/utils/xptensor.py
@@ -19,9 +19,9 @@
 from __future__ import annotations
 from abc import ABC, abstractmethod
 from mrmustard.types import Optional, Union, Matrix, Vector, List, Tensor, Tuple, Scalar
-from mrmustard.math import Math
+from mrmustard import math
 
-math = Math()
+
 
 
 class XPTensor(ABC):

--- a/tests/test_fidelity.py
+++ b/tests/test_fidelity.py
@@ -10,8 +10,6 @@ from mrmustard.physics import gaussian as gp, fock as fp
 from mrmustard import math
 
 
-
-
 class TestGaussianStates:
     @pytest.mark.parametrize("hbar", [1 / 2, 1.0, 2.0, 1.6])
     @pytest.mark.parametrize("num_modes", np.arange(5, 10))

--- a/tests/test_fidelity.py
+++ b/tests/test_fidelity.py
@@ -7,9 +7,9 @@ from thewalrus.random import random_covariance
 from thewalrus.quantum import real_to_complex_displacements
 from mrmustard.physics import gaussian as gp, fock as fp
 
-from mrmustard.math import Math
+from mrmustard import math
 
-math = Math()
+
 
 
 class TestGaussianStates:

--- a/tests/test_lab/test_detectors.py
+++ b/tests/test_lab/test_detectors.py
@@ -19,7 +19,7 @@ import numpy as np
 import tensorflow as tf
 from scipy.stats import poisson
 
-from mrmustard.math import Math
+from mrmustard import math
 from mrmustard.lab import (
     PNRDetector,
     Coherent,
@@ -37,7 +37,7 @@ from mrmustard.lab import (
 from mrmustard import physics
 from mrmustard import settings
 
-math = Math()
+
 np.random.seed(137)
 
 

--- a/tests/test_lab/test_states.py
+++ b/tests/test_lab/test_states.py
@@ -35,8 +35,6 @@ from tests.random import pure_state
 from mrmustard import math
 
 
-
-
 @st.composite
 def xy_arrays(draw):
     length = draw(st.integers(2, 10))

--- a/tests/test_lab/test_states.py
+++ b/tests/test_lab/test_states.py
@@ -32,9 +32,9 @@ from mrmustard.lab.abstract import State
 from mrmustard import settings
 from tests.random import pure_state
 
-from mrmustard.math import Math
+from mrmustard import math
 
-math = Math()
+
 
 
 @st.composite

--- a/tests/test_training/test_opt.py
+++ b/tests/test_training/test_opt.py
@@ -35,9 +35,9 @@ from mrmustard.lab.states import Vacuum
 from mrmustard.physics.gaussian import trace, von_neumann_entropy
 from mrmustard import settings
 
-from mrmustard.math import Math
+from mrmustard import math
 
-math = Math()
+
 
 
 @given(n=st.integers(0, 3))

--- a/tests/test_training/test_opt.py
+++ b/tests/test_training/test_opt.py
@@ -38,8 +38,6 @@ from mrmustard import settings
 from mrmustard import math
 
 
-
-
 @given(n=st.integers(0, 3))
 def test_S2gate_coincidence_prob(n):
     """Testing the optimal probability of obtaining |n,n> from a two mode squeezed vacuum"""

--- a/tests/test_training/test_parameter.py
+++ b/tests/test_training/test_parameter.py
@@ -28,8 +28,6 @@ from mrmustard.training.parameter import (
 from mrmustard import math
 
 
-
-
 @pytest.mark.parametrize("from_backend", [True, False])
 def test_create_constant(from_backend):
     """Checks if the factory function `create_parameter`

--- a/tests/test_training/test_parameter.py
+++ b/tests/test_training/test_parameter.py
@@ -25,9 +25,9 @@ from mrmustard.training.parameter import (
     Symplectic,
     Trainable,
 )
-from mrmustard.math import Math
+from mrmustard import math
 
-math = Math()
+
 
 
 @pytest.mark.parametrize("from_backend", [True, False])

--- a/tests/test_training/test_parametrized.py
+++ b/tests/test_training/test_parametrized.py
@@ -23,8 +23,6 @@ from mrmustard.lab.gates import BSgate, S2gate
 from mrmustard.training.parameter import Constant, Orthogonal, Euclidean, Symplectic, Trainable
 
 
-
-
 @pytest.mark.parametrize("kwargs", [{"a": 5}, {"b": 4.5}])
 def test_attribute_assignment(kwargs):
     """Test that arguments are converted into Trainable or Constant and

--- a/tests/test_training/test_parametrized.py
+++ b/tests/test_training/test_parametrized.py
@@ -17,12 +17,12 @@
 import pytest
 
 from mrmustard.training import Parametrized
-from mrmustard.math import Math
+from mrmustard import math
 from mrmustard.lab.circuit import Circuit
 from mrmustard.lab.gates import BSgate, S2gate
 from mrmustard.training.parameter import Constant, Orthogonal, Euclidean, Symplectic, Trainable
 
-math = Math()
+
 
 
 @pytest.mark.parametrize("kwargs", [{"a": 5}, {"b": 4.5}])


### PR DESCRIPTION
**Context:**
Makes it possible to use backends by running `from mrmustard import math`

**Description of the Change:**
Auto instantiates the `Math` class hence the following steps are not needed `from mrmustard.math import Math; math = Math()` 

**Benefits:**
Allows using backends by simply running `from mrmustard import math` instead of the steps given above

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None
