### PR TITLE
Mux

### DIFF
--- a/mrmustard/lab/gates.py
+++ b/mrmustard/lab/gates.py
@@ -751,16 +751,15 @@ class MUX:
 
     def rebalance_ket(self, ket):
         old_probs = math.sum(math.abs(ket) ** 2, axes=[0])
-        order = math.argsort(
-            [self.value_function(ket[:, i] / math.norm(ket[:, i])) for i in range(ket.shape[1])]
-        )[::-1]
+        renorm_ket = ket / math.sqrt(old_probs[None, :], dtype=ket.dtype)
+        order = math.argsort([self.value_function(renorm_ket[:,i]) for i in range(ket.shape[1])])[::-1]
         old_probs_reordered = math.gather(old_probs, order)
         new_probs_reordered = self.muximize(old_probs_reordered)
         rescaling_old_order = math.gather(
             math.sqrt(new_probs_reordered / old_probs_reordered, dtype=ket.dtype),
             math.argsort(order),
         )
-        return ket * rescaling_old_order
+        return ket * rescaling_old_order[None, :]
 
     def muximize(self, probs):
         P = math.cumsum(math.concat([math.zeros(1), probs], axis=0))

--- a/mrmustard/lab/gates.py
+++ b/mrmustard/lab/gates.py
@@ -728,7 +728,7 @@ class MUX:
     The selection takes place by evaluating a value function on the conditional outputs of an N-mode 
     circuit, with the assumption that all but the first mode are measured by PNR detectors.
     It effectively changes the probability of the conditional outcomes, making better outcomes
-    more likely. At the moment it works only for N = 2.
+    more likely. At the moment it works only for N = 2 and for pure states.
 
     Arguments:
         value_function (callable): a function that evaluates the value of a conditional state

--- a/mrmustard/lab/gates.py
+++ b/mrmustard/lab/gates.py
@@ -798,10 +798,10 @@ class MUX:
         ket_rescaling_ranked = math.sqrt(new_probs_ranked, dtype=ket.dtype)
         swap_in_ket = self.swap_in.ket(cutoffs=[ket.shape[0]])
         swap_in_rescaling = math.sqrt(swap_in_prob, dtype=ket.dtype)
-        ket_t = math.transpose(ket, (len(cutoffs), *range(len(cutoffs)))) # 1st mode at the end
-        rebalanced_ket_t = math.tile(swap_in_ket.__getitem__(*([None]*len(cutoffs)), slice(None)), (*cutoffs, 1)) * swap_in_rescaling
-        rebalanced_pnr_columns = math.astensor([self.normalize(ket_t[pnr]) * ket_rescaling_ranked[i] for i,pnr in enumerate(self.pnr_ranking)])
-        pnr_indices = math.astensor(self.pnr_ranking)[:,None].__getitem__(slice(None), *([None]*(len(cutoffs)-1)))
+        ket_t = math.transpose(ket, (*range(1,len(cutoffs)+1), 0)) # 1st mode at the end
+        rebalanced_ket_t = math.tile(math.reshape(swap_in_ket,((1,)*len(cutoffs)+(swap_in_ket.shape[0],))), (*cutoffs, 1)) * swap_in_rescaling
+        rebalanced_pnr_columns = [self.normalize(ket_t[pnr]) * ket_rescaling_ranked[i] for i,pnr in enumerate(self.pnr_ranking)]
+        pnr_indices = math.reshape(math.astensor(self.pnr_ranking), (len(self.pnr_ranking), -1))
         rebalanced_ket_t = math.update_tensor(rebalanced_ket_t, pnr_indices, rebalanced_pnr_columns)
         return math.transpose(rebalanced_ket_t, (len(cutoffs), *range(len(cutoffs)))) # 1st mode at the beginning
 

--- a/mrmustard/math/math_interface.py
+++ b/mrmustard/math/math_interface.py
@@ -96,6 +96,17 @@ class MathInterface(ABC):
         # NOTE: is float64 by default
 
     @abstractmethod
+    def argsort(self, array: Tensor) -> Tensor:
+        r"""Returns the indices that would sort an array.
+
+        Args:
+            array (array): array to sort
+
+        Returns:
+            array: indices that would sort the array
+        """
+
+    @abstractmethod
     def asnumpy(self, tensor: Tensor) -> Tensor:
         r"""Converts a tensor to a NumPy array.
 
@@ -250,6 +261,18 @@ class MathInterface(ABC):
 
         Returns:
             array: hyperbolic cosine of array
+        """
+
+    @abstractmethod
+    def cumsum(self, array: Tensor, axis: int = None) -> Tensor:
+        r"""Returns the cumulative sum of array along the given axis.
+
+        Args:
+            array (array): array to take the cumulative sum of
+            axis (int): axis along which to take the cumulative sum
+
+        Returns:
+            array: cumulative sum of array
         """
 
     @abstractmethod

--- a/mrmustard/math/tensorflow.py
+++ b/mrmustard/math/tensorflow.py
@@ -56,6 +56,9 @@ class TFMath(MathInterface):
     def arange(self, start: int, limit: int = None, delta: int = 1, dtype=tf.float64) -> tf.Tensor:
         return tf.range(start, limit, delta, dtype=dtype)
 
+    def argsort(self, array: tf.Tensor, axis: int = -1) -> tf.Tensor:
+        return tf.argsort(array, axis=axis)
+
     def asnumpy(self, tensor: tf.Tensor) -> Tensor:
         return np.array(tensor)
 
@@ -114,6 +117,9 @@ class TFMath(MathInterface):
 
     def cosh(self, array: tf.Tensor) -> tf.Tensor:
         return tf.math.cosh(array)
+
+    def cumsum(self, array: tf.Tensor, axis: int = 0) -> tf.Tensor:
+        return tf.math.cumsum(array, axis=axis)
 
     def det(self, matrix: tf.Tensor) -> tf.Tensor:
         return tf.linalg.det(matrix)

--- a/tests/test_physics/test_fock/test_fock.py
+++ b/tests/test_physics/test_fock/test_fock.py
@@ -173,3 +173,23 @@ def test_dm_to_ket_error():
 
     with pytest.raises(ValueError):
         dm_to_ket(state)
+
+
+def test_MUX_1copy():
+    value_fn = lambda ket: np.abs(ket[0]) ** 2  # look at vacuum amplitude
+    # [(sqrt(1/2)|0> + sqrt(1/2)|1>)|0> + (sqrt(1/3)|0> + sqrt(2/3)|1>)|1>]/sqrt(2)
+    ket = np.sqrt(np.array([[1/2,1/2],[1/3,2/3]])) # pure state 
+    ket /= np.sqrt(2) # normalize
+
+    # 1 copy does nothing
+    assert State(ket=ket) >> MUX(value_fn, 1) == State(ket = ket)
+
+
+def test_MUX_1000copies(): # TODO fix this test
+    value_fn = lambda ket: np.abs(ket[0]) ** 2  # look at vacuum amplitude
+    # (sqrt(1/2)|0> + sqrt(1/2)|1>)|0> + (sqrt(1/3)|0> + sqrt(2/3)|1>)|1>
+    ket = np.sqrt(np.array([[1/2,1/2],[1/3,2/3]])) # pure state 
+    ket /= np.sqrt(2) # normalize
+
+    # 1000 copies always yields the 1st mode
+    assert State(ket=ket) >> MUX(value_fn, 1000) == State(ket=ket[:,0]/np.linalg.norm(ket[:,0])) & Vacuum(1)


### PR DESCRIPTION
Adds the MUX "gate", which is a custom transformation that emulates the process of taking many copies of a pure 2-mode state (for the moment), sample from a PNR measurement on the 2nd mode and keep the "best" result on the 1st mode.

It needs two parameters: a value function to order the conditional states on the 1st mode and a number of copies.

Example:

```python
state_after_mux = Vacuum(2) >> Sgate(r=[1.15, -1.15]) >> BSgate(theta=1.4) >> MUX(lambda x: -cost_fn(x), 16)
```