### PR TITLE
Simpler access to the backends functionalities

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -38,6 +38,14 @@
 * Adds the new trainable gate `RealInterferometer`: an interferometer that doesn't mix the q and p quadratures
   [(#132)](https://github.com/XanaduAI/MrMustard/pull/132)
 
+* Makes it possible to use backends by simply running
+    ```python
+    from mrmustard import math
+
+    math.cos(x)
+    ```
+  [(#150)](https://github.com/XanaduAI/MrMustard/pull/150)
+
 ### Breaking changes
 
 ### Improvements

--- a/README.md
+++ b/README.md
@@ -218,8 +218,7 @@ The math module is the backbone of Mr Mustard, which consists in the [`Math`](ht
 Mr Mustard comes with a plug-and-play backends through a math interface. You can use it as a drop-in replacement for tensorflow or pytorch and your code will be plug-and-play too!
 ```python
 from mrmustard import settings
-from mrmustard.math import Math
-math = Math()
+from mrmustard import math
 
 math.cos(0.1)  # tensorflow
 

--- a/doc/introduction/basic_reference.md
+++ b/doc/introduction/basic_reference.md
@@ -182,8 +182,7 @@ The math module is the backbone of Mr Mustard, which consists in the [Math](http
 Mr Mustard comes with a plug-and-play backends through a math interface. You can use it as a drop-in replacement for tensorflow or pytorch and your code will be plug-and-play too!
 ```python
 from mrmustard import settings
-from mrmustard.math import Math
-math = Math()
+from mrmustard import math
 
 math.cos(0.1)  # tensorflow
 

--- a/mrmustard/__init__.py
+++ b/mrmustard/__init__.py
@@ -51,6 +51,7 @@ settings.BACKEND = "tensorflow"
 math = Math(backend=settings.backend)
 """Singleton Math class object."""
 
+
 def version():
     r"""Version number of Mr Mustard.
 

--- a/mrmustard/__init__.py
+++ b/mrmustard/__init__.py
@@ -50,6 +50,7 @@ settings.BACKEND = "tensorflow"
 
 math = Math(backend=settings.backend)
 
+
 def version():
     r"""Version number of Mr Mustard.
 

--- a/mrmustard/__init__.py
+++ b/mrmustard/__init__.py
@@ -49,7 +49,7 @@ settings = Settings()
 settings.BACKEND = "tensorflow"
 
 math = Math(backend=settings.backend)
-
+"""Singleton Math class object."""
 
 def version():
     r"""Version number of Mr Mustard.

--- a/mrmustard/__init__.py
+++ b/mrmustard/__init__.py
@@ -2,6 +2,7 @@
 
 # from rich.pretty import install  # NOTE: just for the looks
 # install()
+from mrmustard.math import Math
 from ._version import __version__
 
 # pylint: disable=too-many-instance-attributes
@@ -9,7 +10,7 @@ class Settings:
     """Settings class."""
 
     def __init__(self):
-        self._backend = "tensorflow"
+        self.backend = ["tensorflow"]
         self.HBAR = 2.0
         self.CHOI_R = 0.881373587019543  # np.arcsinh(1.0)
         self.DEBUG = False
@@ -28,25 +29,26 @@ class Settings:
         self.PROGRESSBAR = True
 
     @property
-    def backend(self):
+    def BACKEND(self):
         """The backend which is used.
 
         Can be either ``'tensorflow'`` or ``'torch'``.
         """
-        return self._backend
+        return self.backend[0]
 
-    @backend.setter
-    def backend(self, backend_name: str):
+    @BACKEND.setter
+    def BACKEND(self, backend_name: str):
         if backend_name not in ["tensorflow", "torch"]:
             raise ValueError("Backend must be either 'tensorflow' or 'torch'")
-        self._backend = backend_name
+        self.backend[0] = backend_name
 
 
 settings = Settings()
 """Settings object."""
 
-settings.backend = "tensorflow"
+settings.BACKEND = "tensorflow"
 
+math = Math(backend=settings.backend)
 
 def version():
     r"""Version number of Mr Mustard.

--- a/mrmustard/lab/abstract/measurement.py
+++ b/mrmustard/lab/abstract/measurement.py
@@ -16,13 +16,11 @@
 
 from __future__ import annotations
 from abc import ABC
-from mrmustard.math import Math
+from mrmustard import math
 
 from mrmustard.types import Tensor, Callable, Sequence, Iterable
 from mrmustard import settings
 from .state import State
-
-math = Math()
 
 
 class FockMeasurement(ABC):

--- a/mrmustard/lab/abstract/state.py
+++ b/mrmustard/lab/abstract/state.py
@@ -35,12 +35,10 @@ from mrmustard.types import (
 from mrmustard.utils import graphics
 from mrmustard import settings
 from mrmustard.physics import gaussian, fock
-from mrmustard.math import Math
+from mrmustard import math
 
 if TYPE_CHECKING:
     from .transformation import Transformation
-
-math = Math()
 
 # pylint: disable=too-many-instance-attributes
 class State:

--- a/mrmustard/lab/abstract/transformation.py
+++ b/mrmustard/lab/abstract/transformation.py
@@ -31,11 +31,9 @@ from mrmustard.types import (
     Union,
 )
 from mrmustard import settings
-from mrmustard.math import Math
+from mrmustard import math
 from mrmustard.training.parameter import Parameter
 from .state import State
-
-math = Math()
 
 
 class Transformation:

--- a/mrmustard/lab/detectors.py
+++ b/mrmustard/lab/detectors.py
@@ -22,9 +22,7 @@ from mrmustard.training import Parametrized
 from mrmustard.lab.abstract import FockMeasurement
 from mrmustard.lab.states import DisplacedSqueezed, Coherent
 from mrmustard import settings
-from mrmustard.math import Math
-
-math = Math()
+from mrmustard import math
 
 __all__ = ["PNRDetector", "ThresholdDetector", "Homodyne", "Heterodyne"]
 

--- a/mrmustard/lab/gates.py
+++ b/mrmustard/lab/gates.py
@@ -25,9 +25,7 @@ from mrmustard.lab.abstract import Transformation
 from mrmustard.training import Parametrized
 from mrmustard.physics import gaussian
 
-from mrmustard.math import Math
-
-math = Math()
+from mrmustard import math
 
 __all__ = [
     "Dgate",

--- a/mrmustard/lab/states.py
+++ b/mrmustard/lab/states.py
@@ -22,9 +22,7 @@ from mrmustard import settings
 from mrmustard.lab.abstract import State
 from mrmustard.physics import gaussian, fock
 from mrmustard.training import Parametrized
-from mrmustard.math import Math
-
-math = Math()
+from mrmustard import math
 
 
 __all__ = [

--- a/mrmustard/math/__init__.py
+++ b/mrmustard/math/__init__.py
@@ -49,11 +49,11 @@ class Math:
     """
     # pylint: disable=no-else-return
 
-    def __init__(self, backend=['tensorflow']):
+    def __init__(self, backend=["tensorflow"]):
         self._backend = backend
 
     def __getattribute__(self, name):
-        if name == '_backend':
+        if name == "_backend":
             return object.__getattribute__(self, name)
         else:
             if self._backend == ["tensorflow"]:

--- a/mrmustard/math/__init__.py
+++ b/mrmustard/math/__init__.py
@@ -25,8 +25,7 @@ greater degree of flexibility and code reuse.
 
 .. code-block::
 
-    from mrmustard.math import Math
-    math = Math()
+    from mrmustard import math
     math.cos(x)  # tensorflow backend
 
     from mrmustard import settings
@@ -37,7 +36,6 @@ greater degree of flexibility and code reuse.
 
 
 import importlib
-from mrmustard import settings
 
 if importlib.util.find_spec("tensorflow"):
     from mrmustard.math.tensorflow import TFMath
@@ -50,12 +48,19 @@ class Math:
     This class is a switcher for performing math operations on the currently active backend.
     """
     # pylint: disable=no-else-return
+
+    def __init__(self, backend=['tensorflow']):
+        self._backend = backend
+
     def __getattribute__(self, name):
-        if settings.backend == "tensorflow":
-            return object.__getattribute__(TFMath(), name)
-        elif settings.backend == "torch":
-            return object.__getattribute__(TorchMath(), name)
+        if name == '_backend':
+            return object.__getattribute__(self, name)
+        else:
+            if self._backend == ["tensorflow"]:
+                return object.__getattribute__(TFMath(), name)
+            elif self._backend == ["torch"]:
+                return object.__getattribute__(TorchMath(), name)
 
         raise ValueError(
-            f"No `{settings.backend}` backend found. Ensure your backend is either ``'tensorflow'`` or ``'torch'``"
+            f"No `{self._backend[0]}` backend found. Ensure your backend is either ``'tensorflow'`` or ``'torch'``"
         )

--- a/mrmustard/math/__init__.py
+++ b/mrmustard/math/__init__.py
@@ -61,6 +61,6 @@ class Math:
             elif self._backend == ["torch"]:
                 return object.__getattribute__(TorchMath(), name)
 
-        raise ValueError(
-            f"No `{self._backend[0]}` backend found. Ensure your backend is either ``'tensorflow'`` or ``'torch'``"
-        )
+            raise ValueError(
+                f"No `{self._backend[0]}` backend found. Ensure your backend is either ``'tensorflow'`` or ``'torch'``"
+            )

--- a/mrmustard/physics/fock.py
+++ b/mrmustard/physics/fock.py
@@ -22,9 +22,7 @@ import numpy as np
 
 from mrmustard.types import List, Tuple, Tensor, Scalar, Matrix, Sequence, Vector
 from mrmustard import settings
-from mrmustard.math import Math
-
-math = Math()
+from mrmustard import math
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/mrmustard/physics/gaussian.py
+++ b/mrmustard/physics/gaussian.py
@@ -22,9 +22,7 @@ from thewalrus.quantum import is_pure_cov
 from mrmustard.types import Matrix, Vector, Scalar
 from mrmustard.utils.xptensor import XPMatrix, XPVector
 from mrmustard import settings
-from mrmustard.math import Math
-
-math = Math()
+from mrmustard import math
 
 
 #  ~~~~~~

--- a/mrmustard/training/optimizer.py
+++ b/mrmustard/training/optimizer.py
@@ -20,12 +20,10 @@ from itertools import chain, groupby
 from typing import List, Callable, Sequence
 from mrmustard.utils import graphics
 from mrmustard.logger import create_logger
-from mrmustard.math import Math
+from mrmustard import math
 from .parameter import Parameter, Trainable
 from .parametrized import Parametrized
 from .parameter_update import param_update_method
-
-math = Math()
 
 __all__ = ["Optimizer"]
 

--- a/mrmustard/training/parameter.py
+++ b/mrmustard/training/parameter.py
@@ -84,10 +84,8 @@ There are three basic types of parameters:
 from abc import ABC, abstractmethod
 
 from typing import Optional, Sequence, Any
-from mrmustard.math import Math
+from mrmustard import math
 from mrmustard.types import Tensor
-
-math = Math()
 
 __all__ = [
     "Parameter",

--- a/mrmustard/training/parameter_update.py
+++ b/mrmustard/training/parameter_update.py
@@ -16,10 +16,8 @@
 """
 
 from mrmustard.types import Sequence, Tensor, Tuple
-from mrmustard.math import Math
+from mrmustard import math
 from .parameter import Trainable
-
-math = Math()
 
 
 def update_symplectic(grads_and_vars: Sequence[Tuple[Tensor, Trainable]], symplectic_lr: float):

--- a/mrmustard/training/parametrized.py
+++ b/mrmustard/training/parametrized.py
@@ -19,10 +19,8 @@ of the class.
 """
 
 from typing import Sequence, List, Generator, Any
-from mrmustard.math import Math
+from mrmustard import math
 from .parameter import create_parameter, Trainable, Constant, Parameter
-
-math = Math()
 
 __all__ = ["Parametrized"]
 

--- a/mrmustard/utils/xptensor.py
+++ b/mrmustard/utils/xptensor.py
@@ -19,9 +19,7 @@
 from __future__ import annotations
 from abc import ABC, abstractmethod
 from mrmustard.types import Optional, Union, Matrix, Vector, List, Tensor, Tuple, Scalar
-from mrmustard.math import Math
-
-math = Math()
+from mrmustard import math
 
 
 class XPTensor(ABC):

--- a/tests/test_fidelity.py
+++ b/tests/test_fidelity.py
@@ -7,9 +7,7 @@ from thewalrus.random import random_covariance
 from thewalrus.quantum import real_to_complex_displacements
 from mrmustard.physics import gaussian as gp, fock as fp
 
-from mrmustard.math import Math
-
-math = Math()
+from mrmustard import math
 
 
 class TestGaussianStates:

--- a/tests/test_lab/test_detectors.py
+++ b/tests/test_lab/test_detectors.py
@@ -19,7 +19,7 @@ import numpy as np
 import tensorflow as tf
 from scipy.stats import poisson
 
-from mrmustard.math import Math
+from mrmustard import math
 from mrmustard.lab import (
     PNRDetector,
     Coherent,
@@ -37,7 +37,6 @@ from mrmustard.lab import (
 from mrmustard import physics
 from mrmustard import settings
 
-math = Math()
 np.random.seed(137)
 
 

--- a/tests/test_lab/test_states.py
+++ b/tests/test_lab/test_states.py
@@ -32,9 +32,7 @@ from mrmustard.lab.abstract import State
 from mrmustard import settings
 from tests.random import pure_state
 
-from mrmustard.math import Math
-
-math = Math()
+from mrmustard import math
 
 
 @st.composite

--- a/tests/test_training/test_opt.py
+++ b/tests/test_training/test_opt.py
@@ -35,9 +35,7 @@ from mrmustard.lab.states import Vacuum
 from mrmustard.physics.gaussian import trace, von_neumann_entropy
 from mrmustard import settings
 
-from mrmustard.math import Math
-
-math = Math()
+from mrmustard import math
 
 
 @given(n=st.integers(0, 3))

--- a/tests/test_training/test_parameter.py
+++ b/tests/test_training/test_parameter.py
@@ -25,9 +25,7 @@ from mrmustard.training.parameter import (
     Symplectic,
     Trainable,
 )
-from mrmustard.math import Math
-
-math = Math()
+from mrmustard import math
 
 
 @pytest.mark.parametrize("from_backend", [True, False])

--- a/tests/test_training/test_parametrized.py
+++ b/tests/test_training/test_parametrized.py
@@ -17,12 +17,10 @@
 import pytest
 
 from mrmustard.training import Parametrized
-from mrmustard.math import Math
+from mrmustard import math
 from mrmustard.lab.circuit import Circuit
 from mrmustard.lab.gates import BSgate, S2gate
 from mrmustard.training.parameter import Constant, Orthogonal, Euclidean, Symplectic, Trainable
-
-math = Math()
 
 
 @pytest.mark.parametrize("kwargs", [{"a": 5}, {"b": 4.5}])


### PR DESCRIPTION
**Context:**
Change in the API to access to the math backends functionalities. 

**Description of the Change:**
- One instantiates the Math class at the level of `mrmusrtard/__init__.py`. 
- In order to avoid circular import issues with the `mrmustard.math` package, instead of importing `mrmustard.settings` in `mrmusrtard/math/__init__.py`, pass the backend information to a newly defined constructor of the `mrmustard.math.Math` class.
- To reflect changes in the value of `settings.BACKEND`, we ensure that this variable behaves like a *pointer* using the following trick: given an __immutable__ string variable `s`, it can be treated as a pointer by interpreting it as the index 0 element of the __mutable__ list `[s]`. 
- No ambiguity between the `math` object and the `math` package can occur in the import
```python
from mrmustard import math
```
since, according to the [python documentation](https://docs.python.org/3/tutorial/modules.html#packages-in-multiple-directories) concerning the precedence of `import` statements:
> The import statement first tests whether the item is defined in the package; if not, it assumes it is a module and attempts to load it.

**Benefits:**
- Instead of having to explicitly instantiate  the `mrmustard.math.Math` class as follows:
```python
from mrmustard.math import Math
math = Math()
math.cos(x)
```
one can simply run:
```python
from mrmustard import math
math.cos(x)
```
- Changes to the code are kept minimal.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None
