### PR TITLE
bugfix - hermitian conjugate 🐛

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -59,6 +59,11 @@
 * Fixed a bug in the `State.ket()` method. An attribute was called with a typo in its name.
   [(#135)](https://github.com/XanaduAI/MrMustard/pull/135)
 
+* The `math.dagger` function applying the hermitian conjugate to an operator was incorrectly
+transposing the indices of the input tensor. Now `math.dagger` appropiately calculates the
+Hermitian conjugate of an operator.
+  [(#156)](https://github.com/XanaduAI/MrMustard/pull/156)
+
 ### Documentation
 
 * The centralized [Xanadu Sphinx Theme](https://github.com/XanaduAI/xanadu-sphinx-theme)

--- a/mrmustard/math/math_interface.py
+++ b/mrmustard/math/math_interface.py
@@ -832,7 +832,8 @@ class MathInterface(ABC):
         return self.concat(rows, axis=axes[0])
 
     def dagger(self, array: Tensor) -> Tensor:
-        r"""Returns the adjoint of ``array``.
+        """Returns the adjoint of ``array``. This operation swaps the first
+        and second half of the indexes and then conjugates the matrix.
 
         Args:
             array (array): array to take the adjoint of
@@ -840,7 +841,9 @@ class MathInterface(ABC):
         Returns:
             array: adjoint of ``array``
         """
-        return self.conj(self.transpose(array))
+        N = len(array.shape) // 2
+        perm = list(range(N, 2 * N)) + list(range(0, N))
+        return self.conj(self.transpose(array, perm=perm))
 
     def unitary_to_orthogonal(self, U):
         r"""Unitary to orthogonal mapping.

--- a/tests/test_lab/test_gates_fock.py
+++ b/tests/test_lab/test_gates_fock.py
@@ -12,9 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 from mrmustard.lab.circuit import Circuit
-from mrmustard.lab.states import Fock
-from mrmustard.lab.gates import Dgate, Sgate, BSgate, MZgate, S2gate, Attenuator
+from mrmustard.lab.states import Fock, State, SqueezedVacuum, TMSV
+from mrmustard.lab.gates import (
+    Dgate,
+    Sgate,
+    Pgate,
+    Rgate,
+    CZgate,
+    CXgate,
+    BSgate,
+    MZgate,
+    S2gate,
+    Attenuator,
+)
 from hypothesis import given, strategies as st
 from thewalrus.fock_gradients import (
     displacement,
@@ -46,14 +58,32 @@ def test_Dgate_2mode(state, xxyy):
     assert state_out == state
 
 
-def test_1mode_fock_equals_gaussian():
-    pass  # TODO: implement with weak states and gates
-    # gate = Ggate(num_modes=1)  # too much squeezing probably
-    # gstate = Gaussian(num_modes=1)  # too much squeezing probably
-    # fstate = State(fock=gstate.ket(cutoffs=[40]))
-    # via_phase_space = gate(gstate)
-    # via_fock_space = gate(fstate)
-    # assert via_phase_space == via_fock_space
+@pytest.mark.parametrize("gate", [Sgate(r=1), Dgate(1, 0.5), Pgate(10), Rgate(np.pi / 2)])
+def test_single_mode_fock_equals_gaussian(gate):
+    """Test same state is obtained via fock representation or phase space
+    for single mode circuits."""
+    cutoffs = [20]
+    gaussian_state = SqueezedVacuum(0.5) >> Attenuator(0.5)
+    fock_state = State(dm=gaussian_state.dm(cutoffs))
+
+    via_fock_space_dm = (fock_state >> gate).dm(cutoffs).numpy()
+    via_phase_space_dm = (gaussian_state >> gate).dm(cutoffs).numpy()
+    assert np.allclose(via_fock_space_dm, via_phase_space_dm)
+
+
+@pytest.mark.parametrize(
+    "gate", [BSgate(np.pi / 2), MZgate(np.pi / 2), CZgate(0.1), CXgate(0.1), S2gate(0.1)]
+)
+def test_two_mode_fock_equals_gaussian(gate):
+    """Test same state is obtained via fock representation or phase space
+    for two modes circuits."""
+    cutoffs = [20, 20]
+    gaussian_state = TMSV(0.1) >> BSgate(np.pi / 2) >> Attenuator(0.5)
+    fock_state = State(dm=gaussian_state.dm(cutoffs))
+
+    via_fock_space_dm = (fock_state >> gate).dm(cutoffs).numpy()
+    via_phase_space_dm = (gaussian_state >> gate).dm(cutoffs).numpy()
+    assert np.allclose(via_fock_space_dm, via_phase_space_dm)
 
 
 @given(x=st.floats(min_value=-2, max_value=2), y=st.floats(min_value=-2, max_value=2))

--- a/tests/test_lab/test_gates_fock.py
+++ b/tests/test_lab/test_gates_fock.py
@@ -58,11 +58,11 @@ def test_Dgate_2mode(state, xxyy):
     assert state_out == state
 
 
-@pytest.mark.parametrize("gate", [Sgate(r=1), Dgate(1, 0.5), Pgate(10), Rgate(np.pi / 2)])
+@pytest.mark.parametrize("gate", [Sgate(r=1), Dgate(1.0, 1.0), Pgate(10), Rgate(np.pi / 2)])
 def test_single_mode_fock_equals_gaussian(gate):
     """Test same state is obtained via fock representation or phase space
     for single mode circuits."""
-    cutoffs = [20]
+    cutoffs = [30]
     gaussian_state = SqueezedVacuum(0.5) >> Attenuator(0.5)
     fock_state = State(dm=gaussian_state.dm(cutoffs))
 


### PR DESCRIPTION
**Context:**
The transposition operation from the math module reverses all indexes by default.
```python
math.transpose(M[[1,2,3,4]]) = M[[4,3,2,1]]
```
This is not the desired behaviour when calculating the hermitian conjugate of an operator — because the function `math.dagger` uses `math.transpose` with default args under the hood meaning the result is incorrect. Currently,
```python
math.dagger(M[[1,2,3,4]]) = math.conjugate(math.transpose(M[[1,2,3,4]])) = math.conjugate(M[[4,3,2,1]])
```

**Description of the Change:**
To fix the issue, the dagger operation now swaps the 1st and 2nd half of indices of a tensor as is expected for a transposition on the dagger operation. Now,
```python
math.dagger(M[[1,2,3,4]]) = math.conjugate(M[[3,4,1,2]])
```

**Benefits:**
Appropriate dagger operation, fixing a bug for transformations acting on density matrices. 

**Possible Drawbacks:**
None