### PR TITLE
Include backend variables in optimization

### DIFF
--- a/mrmustard/training/optimizer.py
+++ b/mrmustard/training/optimizer.py
@@ -103,17 +103,24 @@ class Optimizer:
 
     @staticmethod
     def _get_trainable_params(trainable_items):
+        """Returns a list of trainable parameters from instances of Parametrized or
+        items that belong to the backend and are trainable
+        """
         trainables = []
         for item in trainable_items:
             if isinstance(item, Parametrized):
                 trainables.append(item.trainable_parameters)
             elif math.from_backend(item) and math.is_trainable(item):
-                trainables.append([create_parameter(item, name = "from_backend", is_trainable = True)])
+                # the created parameter is wrapped into a list because the case above
+                # returns a list, hence ensuring we have a list of lists
+                trainables.append([create_parameter(item, name="from_backend", is_trainable=True)])
 
         return list(chain(*trainables))
 
     @staticmethod
     def _group_vars_and_grads_by_type(trainable_params, grads):
+        """Groups `trainable_params` and `grads` by type into a dict of the form
+        `{"euclidean": [...], "orthogonal": [...], "symplectic": [...]}`."""
         sorted_grads_and_vars = sorted(
             zip(grads, trainable_params), key=lambda grads_vars: grads_vars[1].type
         )


### PR DESCRIPTION
**Context:**
Mr Mustard optimizer can optimize gate parameters but not values directly defined in the backend.

**Description of the Change:**
This PR allows the optimizer to keep track of variables directly defined in the backend, for example

```python
# %%
from mrmustard.lab import Dgate, Sgate, Attenuator, Vacuum, Coherent, SqueezedVacuum, Rgate
from mrmustard.physics import fidelity
from mrmustard.training import Optimizer
from mrmustard.math import Math; math = Math()
import numpy as np

# rotated displaced squeezed state
rotation_angle = np.pi/2
target_state = SqueezedVacuum(r=1.0, phi=rotation_angle)

# angle of rotation gate
r_angle = math.new_variable(0, bounds = (0, np.pi), name='r_angle')
# trainable squeezing
S = Sgate(r = 0.1, phi=0, r_trainable = True, phi_trainable=False)

def cost_fn_sympl():
    state_out = Vacuum(1) >> S >> Rgate(angle = r_angle)
    return 1 - fidelity(state_out, target_state)

opt = Optimizer(symplectic_lr=0.1, euclidean_lr=0.1)
opt.minimize(cost_fn_sympl, by_optimizing=[S, r_angle])  

print(np.allclose(r_angle.numpy(), rotation_angle/2, atol=1e-3))
```
here `r_angle` is defined outside of a gate.

**Benefits:**
Allows for writing and then optimizing complicated functions that defines a parameter.

```python
def my_param(x,y,z):
    # some very long and complex function

x = math.new_variable(...)
y = math.new_variable(...)
z = math.new_variable(...)

def cost_fn():
    state = Vacuum(...) >> SomeGate(param=my_param(x,y,z), param_trainable=True)
    # process

opt.Optimize(cost_fn, by_optimizing=[x,y,z])
```

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None