### PR TITLE
Implement `Measurement` abstract class 📊

### DIFF
--- a/mrmustard/lab/abstract/__init__.py
+++ b/mrmustard/lab/abstract/__init__.py
@@ -16,5 +16,5 @@
 """
 
 from .state import State
-from .measurement import FockMeasurement
+from .measurement import FockMeasurement, Measurement
 from .transformation import Transformation

--- a/mrmustard/lab/abstract/measurement.py
+++ b/mrmustard/lab/abstract/measurement.py
@@ -75,7 +75,7 @@ class Measurement(ABC):
             self.primal(other)
         else:
             raise TypeError(
-                f"Cannot apply Measurement '{type(self).__name__}' to '{type(other).__name__}'."
+                f"Cannot apply Measurement '{self.__qualname__}' to '{other.__qualname__}'."
             )
 
     def __getitem__(self, items) -> Callable:

--- a/mrmustard/lab/abstract/measurement.py
+++ b/mrmustard/lab/abstract/measurement.py
@@ -32,6 +32,13 @@ class Measurement(ABC):
         self._outcome = None
 
     @property
+    def modes(self):
+        r"""Returns the modes being measured."""
+        if self._modes is None:
+            return list(range(self.num_modes))
+        return self._modes
+
+    @property
     def outcome(self):
         return self._outcome
 
@@ -75,7 +82,7 @@ class FockMeasurement(Measurement):
 
     def __init__(self) -> None:
         super().__init__()
-        self.modes = None
+        self._modes = None
 
     def primal(self, state: State) -> Tensor:
         r"""

--- a/mrmustard/lab/abstract/measurement.py
+++ b/mrmustard/lab/abstract/measurement.py
@@ -15,7 +15,7 @@
 """This module contains the implementation of the class :class:`FockMeasurement`."""
 
 from __future__ import annotations
-from abc import ABC
+from abc import ABC, abstractmethod, abstractproperty
 from mrmustard.math import Math
 
 from mrmustard.types import Tensor, Callable, Sequence, Iterable, Optional
@@ -47,8 +47,9 @@ class Measurement(ABC):
     def outcome(self):
         return self._outcome
 
-    def _set_outcome(self, outcome):
-        self._outcome = outcome
+    def sample(self, other):
+        """stores the outcome of a measurement"""
+        ...
 
     def __lshift__(self, other) -> Tensor:
         if isinstance(other, State):
@@ -62,7 +63,6 @@ class Measurement(ABC):
         """Allows measurements to be used as ``output = meas[0,1](input)``,
         e.g. measuring modes 0 and 1.
         """
-
         if isinstance(items, int):
             modes = [items]
         elif isinstance(items, slice):
@@ -72,6 +72,7 @@ class Measurement(ABC):
         else:
             raise ValueError(f"{items} is not a valid slice or list of modes.")
         self._modes = modes
+
         return self
 
 

--- a/mrmustard/lab/abstract/measurement.py
+++ b/mrmustard/lab/abstract/measurement.py
@@ -114,7 +114,7 @@ class FockMeasurement(Measurement):
         raise NotImplementedError
 
     def _measure_gaussian(self, other: State) -> Union[State, float]:
-        raise NotImplementedError
+        return self._measure_fock(other)
 
     def _measure_fock(self, other: State) -> Union[State, float]:
         r"""

--- a/mrmustard/lab/abstract/measurement.py
+++ b/mrmustard/lab/abstract/measurement.py
@@ -28,6 +28,9 @@ math = Math()
 class Measurement(ABC):
     def __init__(self, outcome: Tensor, modes: Iterable[int]) -> None:
         super().__init__()
+
+        if modes is None:
+            raise ValueError(f"Modes not defined for {self.__class__.__name__}.")
         self._modes = modes
 
         # used to evaluate if the measurement outcome should be
@@ -37,9 +40,12 @@ class Measurement(ABC):
     @property
     def modes(self):
         r"""Returns the modes being measured."""
-        if self._modes is None:
-            return list(range(self.num_modes))
         return self._modes
+
+    @property
+    def num_modes(self):
+        r"""Returns the modes being measured."""
+        return len(self.modes)
 
     @property
     def postselected(self):

--- a/mrmustard/lab/abstract/measurement.py
+++ b/mrmustard/lab/abstract/measurement.py
@@ -87,7 +87,7 @@ class FockMeasurement(Measurement):
 
     def __init__(self, outcome: Tensor, modes: Iterable[int], cutoffs: Iterable[int]) -> None:
 
-        self._cutoffs = cutoffs or [settings.PNR_INTERNAL_CUTOFF] * num_modes
+        self._cutoffs = cutoffs or [settings.PNR_INTERNAL_CUTOFF] * len(modes)
         super().__init__(outcome, modes)
 
     def primal(self, state: State) -> Tensor:

--- a/mrmustard/lab/abstract/state.py
+++ b/mrmustard/lab/abstract/state.py
@@ -367,32 +367,9 @@ class State:
             State or float: returns the conditional state on the remaining modes
                 or the probability.
         """
-        from ..detectors import Homodyne, Heterodyne
+        remaining_modes = list(set(other.modes) - set(self.modes))
 
-        other_cutoffs = [
-            None if m not in self.modes else other.cutoffs[other.indices(m)] for m in other.modes
-        ]
-        remaining_modes = [m for m in other.modes if m not in self.modes]
-
-        projector_state = self  # projector_state is the state used to project onto
-        # Instances of `Homodyne` and `Heterodyne` define the attribute "sampling".
-        if isinstance(self, Homodyne) and getattr(self, "sample", False):
-            # build pdf and sample homodyne outcome
-            outcome, probability, projector_state = homodyne.sample_homodyne_fock(
-                state=other,
-                quadrature_angle=self.phi.value / 2,
-                mode=self.modes,
-                hbar=settings.HBAR,
-            )
-            if remaining_modes == 0:
-                return probability
-
-        if isinstance(self, Heterodyne) and getattr(self, "sample", False):
-            raise NotImplementedError(
-                "Heterodyne sampling in Fock representation is not yet implemented."
-            )
-
-        out_fock = self._contract_fock_states(other, other_cutoffs, projector_state)
+        out_fock = self._contract_fock_states(other)
         if len(remaining_modes) > 0:
             return (
                 State(dm=out_fock, modes=remaining_modes)
@@ -407,7 +384,10 @@ class State:
             else fock.math.abs(out_fock)
         )
 
-    def _contract_fock_states(self, other, other_cutoffs, projector_state):
+    def _contract_with_other(self, other):
+        other_cutoffs = [
+            None if m not in self.modes else other.cutoffs[other.indices(m)] for m in other.modes
+        ]
         if hasattr(self, "_preferred_projection"):
             out_fock = self._preferred_projection(other, other.indices(self.modes))
         else:
@@ -415,11 +395,9 @@ class State:
             self_cutoffs = [other.cutoffs[other.indices(m)] for m in self.modes]
             out_fock = fock.contract_states(
                 stateA=other.ket(other_cutoffs) if other.is_pure else other.dm(other_cutoffs),
-                stateB=projector_state.ket(self_cutoffs)
-                if projector_state.is_pure
-                else projector_state.dm(self_cutoffs),
+                stateB=self.ket(self_cutoffs) if self.is_pure else self.dm(self_cutoffs),
                 a_is_mixed=other.is_mixed,
-                b_is_mixed=projector_state.is_mixed,
+                b_is_mixed=self.is_mixed,
                 modes=other.indices(self.modes),  # TODO: change arg name to indices
                 normalize=self._normalize if hasattr(self, "_normalize") else False,
             )

--- a/mrmustard/lab/abstract/state.py
+++ b/mrmustard/lab/abstract/state.py
@@ -369,7 +369,7 @@ class State:
         """
         remaining_modes = list(set(other.modes) - set(self.modes))
 
-        out_fock = self._contract_fock_states(other)
+        out_fock = self._contract_with_other(other)
         if len(remaining_modes) > 0:
             return (
                 State(dm=out_fock, modes=remaining_modes)

--- a/mrmustard/lab/detectors.py
+++ b/mrmustard/lab/detectors.py
@@ -233,10 +233,19 @@ class Heterodyne(Measurement):
     ):
         super().__init__(modes=modes)
         # if no x and y provided, sample the outcome
+
+        if (x is None) ^ (y is None):  # XOR
+            raise ValueError("Both `x` and `y` arguments should be defined or set to `None`.")
+
         if x is None and y is None:
+            self.sample = True
             num_modes = len(modes) if modes is not None else 1
             x, y = math.zeros([num_modes]), math.zeros([num_modes])
-            self.sample = True
+        else:
+            self.sample = False
+            x = math.atleast_1d(x, dtype="float64")
+            y = math.atleast_1d(y, dtype="float64")
+            self._set_outcome(math.concat([x, y], axis=0))  # XXPP ordering
 
         self.state = Coherent(x, y, modes=modes)
 
@@ -279,6 +288,7 @@ class Homodyne(Measurement):
 
             x = result * math.cos(quadrature_angle)
             y = result * math.sin(quadrature_angle)
+            self._set_outcome(math.concat([x, y], axis=0))  # XXPP ordering
 
         self.state = DisplacedSqueezed(r=r, phi=2 * quadrature_angle, x=x, y=y, modes=modes)
 

--- a/mrmustard/lab/detectors.py
+++ b/mrmustard/lab/detectors.py
@@ -29,7 +29,7 @@ from .gates import Rgate
 
 math = Math()
 
-__all__ = ["PNRDetector", "ThresholdDetector", "Homodyne", "Heterodyne"]
+__all__ = ["PNRDetector", "ThresholdDetector", "Generaldyne", "Homodyne", "Heterodyne"]
 
 # pylint: disable=no-member
 class PNRDetector(Parametrized, FockMeasurement):
@@ -263,6 +263,7 @@ class Generaldyne(Measurement):
         outcome, prob, new_cov, new_means = gaussian.general_dyne(
             other.cov, other.means, self.state.cov, None, modes=self.modes
         )
+        self.state = State(cov=self.state.cov, means=outcome)
         self._outcome = outcome
 
         return (

--- a/mrmustard/lab/detectors.py
+++ b/mrmustard/lab/detectors.py
@@ -264,7 +264,6 @@ class Generaldyne(Measurement):
             other.cov, other.means, self.state.cov, None, modes=self.modes
         )
         self.state = State(cov=self.state.cov, means=outcome)
-        self._outcome = outcome
 
         return (
             prob

--- a/mrmustard/lab/detectors.py
+++ b/mrmustard/lab/detectors.py
@@ -213,7 +213,7 @@ class ThresholdDetector(Parametrized, FockMeasurement):
                 self._internal_stochastic_channel.append(condprob)
 
 
-class Heterodyne(Coherent):
+class Heterodyne(Measurement):
     r"""Heterodyne measurement on given modes.
 
     This class is just a thin wrapper around the :class:`Coherent`.
@@ -231,13 +231,17 @@ class Heterodyne(Coherent):
         y: Union[float, List[float]] = 0.0,
         modes: List[int] = None,
     ):
+        super().__init__(modes=modes)
         # if no x and y provided, sample the outcome
         if x is None and y is None:
             num_modes = len(modes) if modes is not None else 1
             x, y = math.zeros([num_modes]), math.zeros([num_modes])
             self.sample = True
 
-        super().__init__(x, y, modes=modes)
+        self.state = Coherent(x, y, modes=modes)
+
+    def primal(self, other):
+        return self.state.primal(other)
 
 
 class Homodyne(Measurement):
@@ -276,9 +280,7 @@ class Homodyne(Measurement):
             x = result * math.cos(quadrature_angle)
             y = result * math.sin(quadrature_angle)
 
-        self.displaced_squeezed = DisplacedSqueezed(
-            r=r, phi=2 * quadrature_angle, x=x, y=y, modes=modes
-        )
+        self.state = DisplacedSqueezed(r=r, phi=2 * quadrature_angle, x=x, y=y, modes=modes)
 
     def primal(self, other):
-        return self.displaced_squeezed.primal(other)
+        return self.state.primal(other)

--- a/mrmustard/lab/detectors.py
+++ b/mrmustard/lab/detectors.py
@@ -89,7 +89,7 @@ class PNRDetector(Parametrized, FockMeasurement):
 
         modes = modes or list(range(num_modes))
         outcome = None
-        FockMeasurement.__init__(outcome, modes, cutoffs)
+        FockMeasurement.__init__(self, outcome, modes, cutoffs)
 
         self.recompute_stochastic_channel()
 

--- a/mrmustard/lab/detectors.py
+++ b/mrmustard/lab/detectors.py
@@ -243,9 +243,6 @@ class Generaldyne(Measurement):
 
         super().__init__(outcome, modes)
 
-    def outcome(self):
-        return self._outcome
-
     def primal(self, other) -> Union[State, float]:
         if self.postselected:
             return self.state.primal(other)
@@ -318,7 +315,7 @@ class Heterodyne(Generaldyne):
 
 
 class Homodyne(Generaldyne):
-    r"""Homodyne measurement on given modes. If ``result`` is not provided then the value
+    """Homodyne measurement on given modes. If ``result`` is not provided then the value
     is sampled.
 
     Args:
@@ -331,7 +328,7 @@ class Homodyne(Generaldyne):
     def __init__(
         self,
         quadrature_angle: Union[float, List[float]],
-        result: Optional[Union[float, List[float]]],
+        result: Optional[Union[float, List[float]]] = None,
         modes: Optional[List[int]] = None,
         r: Union[float, List[float]] = settings.HOMODYNE_SQUEEZING,
     ):
@@ -358,3 +355,6 @@ class Homodyne(Generaldyne):
 
         internal_state = DisplacedSqueezed(r=r, phi=2 * quadrature_angle, x=x, y=y)
         super().__init__(state=internal_state, outcome=outcome, modes=modes)
+
+    def _sample_fock(self, other) -> Union[State, float]:
+        return super()._sample_fock(other)

--- a/mrmustard/lab/detectors.py
+++ b/mrmustard/lab/detectors.py
@@ -364,13 +364,15 @@ class Homodyne(Generaldyne):
         other >>= Rgate(-self.quadrature_angle, modes=self.modes)
         self.state >>= Rgate(-self.quadrature_angle, modes=self.modes)
 
+        # perform homodyne measurement as a generaldyne one
         out = super()._measure_gaussian(other)
 
-        # set p-outcomes to 0 and rotate back to the original basis
-        out_means = math.concat(
+        # set p-outcomes to 0 and rotate the measurement device state back to the original basis,
+        # this is in turn rotating the outcomes to the original basis
+        self_state_means = math.concat(
             [self.state.means[: self.num_modes], math.zeros((self.num_modes,))], axis=0
         )
-        self.state = State(cov=self.state.cov, means=out_means) >> Rgate(
+        self.state = State(cov=self.state.cov, means=self_state_means, modes=self.modes) >> Rgate(
             self.quadrature_angle, modes=self.modes
         )
 

--- a/mrmustard/lab/detectors.py
+++ b/mrmustard/lab/detectors.py
@@ -21,7 +21,7 @@ from mrmustard.types import Matrix
 from mrmustard.training import Parametrized
 from mrmustard import settings
 from mrmustard.math import Math
-from .abstract import FockMeasurement
+from .abstract import FockMeasurement, Measurement
 from .states import DisplacedSqueezed, Coherent
 
 math = Math()
@@ -240,7 +240,7 @@ class Heterodyne(Coherent):
         super().__init__(x, y, modes=modes)
 
 
-class Homodyne(DisplacedSqueezed):
+class Homodyne(Measurement):
     r"""Homodyne measurement on given modes. If ``result`` is not provided then the value
     is sampled.
 
@@ -258,6 +258,9 @@ class Homodyne(DisplacedSqueezed):
         modes: Optional[List[int]] = None,
         r: Union[float, List[float]] = settings.HOMODYNE_SQUEEZING,
     ):
+
+        super().__init__(modes=modes)
+
         quadrature_angle = math.atleast_1d(quadrature_angle, dtype="float64")
 
         if result is None:
@@ -273,10 +276,9 @@ class Homodyne(DisplacedSqueezed):
             x = result * math.cos(quadrature_angle)
             y = result * math.sin(quadrature_angle)
 
-        super().__init__(
-            r=r,
-            phi=2 * quadrature_angle,
-            x=x,
-            y=y,
-            modes=modes,
+        self.displaced_squeezed = DisplacedSqueezed(
+            r=r, phi=2 * quadrature_angle, x=x, y=y, modes=modes
         )
+
+    def primal(self, other):
+        return self.displaced_squeezed.primal(other)

--- a/tests/test_lab/test_detectors.py
+++ b/tests/test_lab/test_detectors.py
@@ -205,7 +205,7 @@ class TestHomodyneDetector:
         homodyne = Homodyne(quadrature_angle=angle, result=outcome, r=r)
         remaining_state = TMSV(r=np.arcsinh(np.sqrt(abs(s)))) << homodyne[0]
         denom = 1 + 2 * s * (s + 1) + (2 * s + 1) * np.cosh(2 * r)
-        cov = np.array(
+        cov = (hbar / 2) * np.array(
             [
                 [
                     1

--- a/tests/test_lab/test_detectors.py
+++ b/tests/test_lab/test_detectors.py
@@ -112,9 +112,7 @@ class TestPNRDetector:
         assert np.allclose(var_i, expected_var_i)
         assert np.allclose(covar, expected_covar)
 
-    def test_postselection(
-        self,
-    ):
+    def test_postselection(self):
         """Check the correct state is heralded for a two-mode squeezed vacuum with perfect detector"""
         n_mean = 1.0
         n_measured = 1

--- a/tests/test_lab/test_detectors.py
+++ b/tests/test_lab/test_detectors.py
@@ -311,17 +311,17 @@ class TestHomodyneDetector:
         measurements are in agreement with the expected values for the states"""
 
         tf.random.set_seed(123)
-        meas_state = SqueezedVacuum(settings.HOMODYNE_SQUEEZING, 0.0)
+        detector = Homodyne(0.0)
 
-        results = np.empty((self.N_MEAS,))
+        results = np.empty((self.N_MEAS, 2))
         for i in range(self.N_MEAS):
-            outcome, _, _, _ = gaussian.general_dyne(state.cov, state.means, meas_state.cov)
-            results[i] = outcome[0]
+            state << detector
+            results[i] = detector.outcome.numpy()
 
         mean = results.mean(axis=0)
-        assert np.allclose(mean, mean_expected, atol=self.std_10, rtol=0)
+        assert np.allclose(mean[0], mean_expected, atol=self.std_10, rtol=0)
         var = results.var(axis=0)
-        assert np.allclose(var, var_expected, atol=self.std_10, rtol=0)
+        assert np.allclose(var[0], var_expected, atol=self.std_10, rtol=0)
 
     def test_homodyne_squeezing_setting(self):
         """Check default homodyne squeezing on settings leads to the correct generaldyne

--- a/tests/test_lab/test_detectors.py
+++ b/tests/test_lab/test_detectors.py
@@ -281,36 +281,14 @@ class TestHomodyneDetector:
             (SqueezedVacuum(0.25, 0.0), 0.0, 0.25 * settings.HBAR / 2),
         ],
     )
-    def test_fock_sampling_mean_and_var(self, state, mean_expected, var_expected):
+    @pytest.mark.parametrize("gaussian_state", [True, False])
+    def test_sampling_mean_and_var(self, state, mean_expected, var_expected, gaussian_state):
         """Tests that the mean and variance estimates of many homodyne
         measurements are in agreement with the expected values for the states"""
 
         tf.random.set_seed(123)
-        state = State(dm=state.dm(cutoffs=[20]))
-
-        results = np.empty((self.N_MEAS,))
-        for i in range(self.N_MEAS):
-            outcome, _, _ = homodyne.sample_homodyne_fock(state, 0, mode=0, hbar=settings.HBAR)
-            results[i] = outcome
-
-        mean = results.mean(axis=0)
-        assert np.allclose(mean, mean_expected, atol=self.std_10, rtol=0)
-        var = results.var(axis=0)
-        assert np.allclose(var, var_expected, atol=self.std_10, rtol=0)
-
-    @pytest.mark.parametrize(
-        "state, mean_expected, var_expected",
-        [
-            (Vacuum(1), 0.0, settings.HBAR / 2),
-            (Coherent(2.0, 0.5), 2.0 * np.sqrt(2 * settings.HBAR), settings.HBAR / 2),
-            (SqueezedVacuum(0.25, 0.0), 0.0, 0.25 * settings.HBAR / 2),
-        ],
-    )
-    def test_gaussian_sampling_mean_and_var(self, state, mean_expected, var_expected):
-        """Tests that the mean and variance estimates of many homodyne
-        measurements are in agreement with the expected values for the states"""
-
-        tf.random.set_seed(123)
+        if not gaussian_state:
+            state = State(dm=state.dm(cutoffs=[40]))
         detector = Homodyne(0.0)
 
         results = np.empty((self.N_MEAS, 2))

--- a/tests/test_lab/test_detectors.py
+++ b/tests/test_lab/test_detectors.py
@@ -173,8 +173,8 @@ class TestHomodyneDetector:
     @given(s=st.floats(min_value=0.0, max_value=10.0), outcome=none_or_(st.floats(-10.0, 10.0)))
     def test_homodyne_on_2mode_squeezed_vacuum(self, s, outcome):
         """Check that homodyne detection on TMSV for q-quadrature (``quadrature_angle=0.0``)"""
-        homodyne = Homodyne(quadrature_angle=0.0, result=outcome)
-        r = homodyne.r.value
+        r = settings.HOMODYNE_SQUEEZING
+        homodyne = Homodyne(quadrature_angle=0.0, result=outcome, r=r)
         remaining_state = TMSV(r=np.arcsinh(np.sqrt(abs(s)))) << homodyne[0]
 
         # assert expected covariance matrix
@@ -199,8 +199,8 @@ class TestHomodyneDetector:
     )
     def test_homodyne_on_2mode_squeezed_vacuum_with_angle(self, s, outcome, angle):
         """Check that homodyne detection on TMSV works with an arbitrary quadrature angle"""
-        homodyne = Homodyne(quadrature_angle=angle, result=outcome)
-        r = homodyne.r.value
+        r = settings.HOMODYNE_SQUEEZING
+        homodyne = Homodyne(quadrature_angle=angle, result=outcome, r=r)
         remaining_state = TMSV(r=np.arcsinh(np.sqrt(abs(s)))) << homodyne[0]
         denom = 1 + 2 * s * (s + 1) + (2 * s + 1) * np.cosh(2 * r)
         cov = (
@@ -256,8 +256,8 @@ class TestHomodyneDetector:
     def test_homodyne_on_2mode_squeezed_vacuum_with_displacement(self, s, X, d):
         """Check that homodyne detection on displaced TMSV works"""
         tmsv = TMSV(r=np.arcsinh(np.sqrt(s))) >> Dgate(x=d[:2], y=d[2:])
-        homodyne = Homodyne(modes=[0], quadrature_angle=0.0, result=X)
-        r = homodyne.r.value
+        r = settings.HOMODYNE_SQUEEZING
+        homodyne = Homodyne(modes=[0], quadrature_angle=0.0, result=X, r=r)
         remaining_state = tmsv << homodyne[0]
         xb, xa, pb, pa = d
         means = np.array(

--- a/tests/test_lab/test_detectors.py
+++ b/tests/test_lab/test_detectors.py
@@ -374,6 +374,9 @@ class TestHeterodyneDetector:
         self, s, x, y, d
     ):  # TODO: check if this is correct
         """Check that heterodyne detection on TMSV works with an arbitrary displacement"""
+        if x is None or y is None:
+            x, y = None, None
+
         tmsv = TMSV(r=np.arcsinh(np.sqrt(s))) >> Dgate(x=d[:2], y=d[2:])
         heterodyne = Heterodyne(modes=[0], x=x, y=y)
         remaining_state = tmsv << heterodyne[0]

--- a/tests/test_lab/test_detectors.py
+++ b/tests/test_lab/test_detectors.py
@@ -256,7 +256,7 @@ class TestHomodyneDetector:
         tmsv = TMSV(r=np.arcsinh(np.sqrt(s))) >> Dgate(x=d[:2], y=d[2:])
         r = settings.HOMODYNE_SQUEEZING
         homodyne = Homodyne(modes=[0], quadrature_angle=0.0, result=X, r=r)
-        remaining_state = tmsv << homodyne[0]
+        remaining_state = tmsv << homodyne
         xb, xa, pb, pa = d
         means = np.array(
             [
@@ -315,9 +315,7 @@ class TestHomodyneDetector:
 
         results = np.empty((self.N_MEAS,))
         for i in range(self.N_MEAS):
-            outcome, _ = gaussian.general_dyne(
-                state.cov, state.means, meas_state.cov, meas_state.means, settings.HBAR, True
-            )
+            outcome, _, _, _ = gaussian.general_dyne(state.cov, state.means, meas_state.cov)
             results[i] = outcome[0]
 
         mean = results.mean(axis=0)


### PR DESCRIPTION
**Context:**
An abstract base class for measurements is implemented.

**Note**: not yet implemented for fock measurements

**Description of the Change:**
This is the diagram of the abstraction:
```mermaid
classDiagram
    Measurement <|.. Generaldyne
    Measurement <-- FockMeasurement

    class Measurement{
      +num_modes
      +postselected
      +outcome
      -_measure_gaussian(State other)
      -_measure_fock(State other)
      ~primal(State other)
      ~__lshift__(State other)
      ~__getitem__(List~int~ modes)
    }

    class Generaldyne{
      +State state
      +outcome
      ~primal(State other)
      -_measure_gaussian(State other)
      -_measure_fock(State other)
    }
    class FockMeasurement{
      (Not Integrated yet)
    }

    Generaldyne <|.. Homodyne
    Generaldyne <|.. Heterodyne
    Generaldyne *-- State

    class Homodyne{
      +State state
      -_measure_gaussian(State other)
      -_measure_fock(State other)
    }
    class Heterodyne{
      +State state
    }

    class DisplacedSqueezed{
        ...
    }
    class Coherent{
        ...
    }
    class State{
        ...
    }

    Homodyne *-- DisplacedSqueezed
    Heterodyne *-- Coherent

    FockMeasurement <|.. PNRDetector
    FockMeasurement <|.. ThresholdDetector

    class ThresholdDetector{
      (Not Integrated yet)
    }

    class PNRDetector{
      (Not Integrated yet)
    }
```

With this one can access the outcome of a measurement as
```python
detector1 = Homodyne(0.0, None)
Coherent(0.0, 0.0) << detector1
print(detector1.outcome)

detector2 = Heterodyne(None, None)
Vacuum(2) << detector2
print(detector2.outcome)

gaussian_state = Vacuum(2) >> Ggate(2)
detector3 = Generaldyne(gaussian_state)
Vacuum(2) << detector3
print(detector3.outcome)
```

- Gaussian measurements (Generaldyne, Homodyne and Heterodyne) use composition instead of inheritance for their internal state.
- Generaldyne measurements allow for projecting and sampling from any gaussian state.
- Any measurement implements the measurement and sampling logic via the private methods `_measure_fock` and `_measure_gaussian`. This is easy extensible when other representation are incorporated by implementing the new required logic.

**Benefits:**
- Given that the classes `State` and `Measurement` share very few common methods but yet their relation is necessary, composition over inheritance eases the tight coupling between states and measurements (see PR #143). In here the sampling logic is refactored so that is does not affect the `State` class.
- The above still represents well the idea that Gaussian measurements are projections onto Gaussian states. 
- The proposed abstraction creates a general framework for measurements, provides easy access to measurement outcomes when needed and respects the object flow of the operations in Mr Mustard: the `>>` operation processes `State`s and its results are always state-related — be it another `State` or a probability.

**Possible Drawbacks:**
🤷

**Related GitHub Issues:**
None