### PR TITLE
adds eye_like function to interface and tf backend

### DIFF
--- a/mrmustard/math/math_interface.py
+++ b/mrmustard/math/math_interface.py
@@ -373,6 +373,17 @@ class MathInterface(ABC):
         """
 
     @abstractmethod
+    def eye_like(self, array: Tensor) -> Tensor:
+        r"""Returns the identity matrix of the same shape and dtype as array.
+
+        Args:
+            array (array): array to create the identity matrix of
+
+        Returns:
+            matrix: identity matrix
+        """
+
+    @abstractmethod
     def from_backend(self, value: Any) -> bool:
         r"""Returns whether the given tensor is a tensor of the concrete backend."""
 

--- a/mrmustard/math/tensorflow.py
+++ b/mrmustard/math/tensorflow.py
@@ -150,6 +150,9 @@ class TFMath(MathInterface):
     def eye(self, size: int, dtype=tf.float64) -> tf.Tensor:
         return tf.eye(size, dtype=dtype)
 
+    def eye_like(self, array: tf.Tensor) -> Tensor:
+        return tf.eye(array.shape[-1], dtype=array.dtype)
+
     def from_backend(self, value) -> bool:
         return isinstance(value, (tf.Tensor, tf.Variable))
 


### PR DESCRIPTION
------------------------------------------------------------------------------------------------------------

**Context:**
Math interface

**Description of the Change:**
Adds `eye_like` function, which returns the identity matrix to match the shape and dtype of the argument.

**Benefits:**
Simpler to get the identity of the right size and dtype

**Possible Drawbacks:**
Not standard

**Related GitHub Issues:**
None