### PR TITLE
Refactor Wigner function into module

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -3,9 +3,9 @@
 ### New features
 
 * Sampling for homodyne measurements is now integrated in Mr Mustard: when no measurement outcome value is
-specified by the user, a value is sampled from the reduced state probability distribution and the
-conditional state on the remaining modes is generated.
-[(#143)](https://github.com/XanaduAI/MrMustard/pull/143)
+  specified by the user, a value is sampled from the reduced state probability distribution and the
+  conditional state on the remaining modes is generated.
+  [(#143)](https://github.com/XanaduAI/MrMustard/pull/143)
 
     ```python
     import numpy as np
@@ -23,7 +23,16 @@ conditional state on the remaining modes is generated.
 ### Improvements
 
 * The `Dgate` now uses The Walrus to calculate the unitary and gradients of the displacement gate in fock representation,
-  providing better numerical stability for larger cutoff and displacement values. [(#147)](https://github.com/XanaduAI/MrMustard/pull/147)
+  providing better numerical stability for larger cutoff and displacement values.
+  [(#147)](https://github.com/XanaduAI/MrMustard/pull/147)
+
+* Now the Wigner function is implemented in its own module and uses numba for speed.
+  [(#171)](https://github.com/XanaduAI/MrMustard/pull/171)
+
+    ```python
+      from mrmustard.utils.wigner import wigner_discretized
+      W, Q, P = wigner_discretized(dm, q, p) # dm is a density matrix
+    ```
 
 ### Bug fixes
 

--- a/mrmustard/utils/graphics.py
+++ b/mrmustard/utils/graphics.py
@@ -20,8 +20,8 @@ from rich.progress import Progress, TextColumn, BarColumn, TimeRemainingColumn
 import matplotlib.pyplot as plt
 from matplotlib import cm
 import numpy as np
-from .wigner import wigner_discretized
 from mrmustard import settings
+from .wigner import wigner_discretized
 
 # pylint: disable=disallowed-name
 class Progressbar:

--- a/mrmustard/utils/graphics.py
+++ b/mrmustard/utils/graphics.py
@@ -20,6 +20,7 @@ from rich.progress import Progress, TextColumn, BarColumn, TimeRemainingColumn
 import matplotlib.pyplot as plt
 from matplotlib import cm
 import numpy as np
+from .wigner import wigner_discretized
 from mrmustard import settings
 
 # pylint: disable=disallowed-name
@@ -120,9 +121,10 @@ def mikkel_plot(rho: np.ndarray, xbounds: Tuple[int] = (-6, 6), ybounds: Tuple[i
         xbounds (Tuple[int]): range of the x axis
         ybounds (Tuple[int]): range of the y axis
     """
+
     X = np.linspace(xbounds[0], xbounds[1], 200)
     P = np.linspace(ybounds[0], ybounds[1], 200)
-    W = plot_wigner(rho, X, P, settings.HBAR)
+    W, _, _ = wigner_discretized(rho, X, P, settings.HBAR)
     ProbX = np.sum(W, axis=0)
     ProbP = np.sum(W, axis=1)
 

--- a/mrmustard/utils/graphics.py
+++ b/mrmustard/utils/graphics.py
@@ -65,54 +65,6 @@ class Progressbar:
         return self.bar.__exit__(exc_type, exc_val, exc_tb)
 
 
-def plot_wigner(rho, xvec, pvec, hbar):
-    r"""Calculates the discretized Wigner function of the specified mode.
-
-    Lifted from `strawberryfields <https://github.com/XanaduAI/strawberryfields/blob/master/strawberryfields/backends/states.py#L725>`_
-
-    Args:
-        rho (complex array): the state in Fock representation (can be pure or mixed)
-        xvec (array): array of discretized :math:`x` quadrature values
-        pvec (array): array of discretized :math:`p` quadrature values
-        hbar (float): the value of ``\hbar``
-    """
-
-    Q, P = np.meshgrid(xvec, pvec)
-    cutoff = rho.shape[-1]
-    A = (Q + P * 1.0j) / (2 * np.sqrt(hbar / 2))
-
-    Wlist = np.array([np.zeros(np.shape(A), dtype=complex) for k in range(cutoff)])
-
-    # Wigner function for |0><0|
-    Wlist[0] = np.exp(-2.0 * np.abs(A) ** 2) / np.pi
-
-    # W = rho(0,0)W(|0><0|)
-    W = np.real(rho[0, 0]) * np.real(Wlist[0])
-
-    for n in range(1, cutoff):
-        Wlist[n] = (2.0 * A * Wlist[n - 1]) / np.sqrt(n)
-        W += 2 * np.real(rho[0, n] * Wlist[n])
-
-    for m in range(1, cutoff):
-        temp = copy(Wlist[m])
-        # Wlist[m] = Wigner function for |m><m|
-        Wlist[m] = (2 * np.conj(A) * temp - np.sqrt(m) * Wlist[m - 1]) / np.sqrt(m)
-
-        # W += rho(m,m)W(|m><m|)
-        W += np.real(rho[m, m] * Wlist[m])
-
-        for n in range(m + 1, cutoff):
-            temp2 = (2 * A * Wlist[n - 1] - np.sqrt(m) * temp) / np.sqrt(n)
-            temp = copy(Wlist[n])
-            # Wlist[n] = Wigner function for |m><n|
-            Wlist[n] = temp2
-
-            # W += rho(m,n)W(|m><n|) + rho(n,m)W(|n><m|)
-            W += 2 * np.real(rho[m, n] * Wlist[n])
-
-    return W / hbar
-
-
 def mikkel_plot(rho: np.ndarray, xbounds: Tuple[int] = (-6, 6), ybounds: Tuple[int] = (-6, 6)):
     """Plots the Wigner function of a state given its density matrix.
 

--- a/mrmustard/utils/graphics.py
+++ b/mrmustard/utils/graphics.py
@@ -73,11 +73,11 @@ def mikkel_plot(rho: np.ndarray, xbounds: Tuple[int] = (-6, 6), ybounds: Tuple[i
         ybounds (Tuple[int]): range of the y axis
     """
 
-    X = np.linspace(xbounds[0], xbounds[1], 200)
-    P = np.linspace(ybounds[0], ybounds[1], 200)
-    W, _, _ = wigner_discretized(rho, X, P, settings.HBAR)
-    ProbX = np.sum(W, axis=0)
-    ProbP = np.sum(W, axis=1)
+    xvec = np.linspace(*xbounds, 200)
+    pvec = np.linspace(*ybounds, 200)
+    W, X, P = wigner_discretized(rho, xvec, pvec, settings.HBAR)
+    ProbX = np.sum(W, axis=1)
+    ProbP = np.sum(W, axis=0)
 
     ### PLOTTING ###
 
@@ -85,8 +85,6 @@ def mikkel_plot(rho: np.ndarray, xbounds: Tuple[int] = (-6, 6), ybounds: Tuple[i
         2, 2, figsize=(6, 6), gridspec_kw={"width_ratios": [2, 1], "height_ratios": [1, 2]}
     )
     ticks = [-5, 0, 5]
-    xlim = [X[0], X[-1]]
-    plim = [P[0], P[-1]]
     grid = False
     plt.subplots_adjust(wspace=0.05, hspace=0.05)
 
@@ -97,32 +95,32 @@ def mikkel_plot(rho: np.ndarray, xbounds: Tuple[int] = (-6, 6), ybounds: Tuple[i
     ax[1][0].get_xaxis().set_ticks(ticks)
     ax[1][0].get_yaxis().set_ticks(ticks)
     ax[1][0].tick_params(direction="in")
-    ax[1][0].set_xlim(xlim)
-    ax[1][0].set_ylim(plim)
+    ax[1][0].set_xlim(xbounds)
+    ax[1][0].set_ylim(ybounds)
     ax[1][0].grid(grid)
 
     # X quadrature probability distribution
-    ax[0][0].fill(X, ProbX, color=cm.RdBu(0.5))
-    ax[0][0].plot(X, ProbX)
+    ax[0][0].fill(xvec, ProbX, color=cm.RdBu(0.5))
+    ax[0][0].plot(xvec, ProbX)
     ax[0][0].get_xaxis().set_ticks(ticks)
     ax[0][0].xaxis.set_ticklabels([])
     ax[0][0].get_yaxis().set_ticks([])
     ax[0][0].tick_params(direction="in")
     ax[0][0].set_ylabel("Prob($x$)", fontsize=12)
-    ax[0][0].set_xlim(xlim)
+    ax[0][0].set_xlim(xbounds)
     ax[0][0].set_ylim([0, 1.1 * max(ProbX)])
     ax[0][0].grid(grid)
 
     # P quadrature probability distribution
-    ax[1][1].fill(ProbP, P, color=cm.RdBu(0.5))
-    ax[1][1].plot(ProbP, P)
+    ax[1][1].fill(ProbP, pvec, color=cm.RdBu(0.5))
+    ax[1][1].plot(ProbP, pvec)
     ax[1][1].get_xaxis().set_ticks([])
     ax[1][1].get_yaxis().set_ticks(ticks)
     ax[1][1].yaxis.set_ticklabels([])
     ax[1][1].tick_params(direction="in")
     ax[1][1].set_xlabel("Prob($p$)", fontsize=12)
     ax[1][1].set_xlim([0, 1.1 * max(ProbP)])
-    ax[1][1].set_ylim(plim)
+    ax[1][1].set_ylim(ybounds)
     ax[1][1].grid(grid)
 
     # Density matrix
@@ -131,6 +129,6 @@ def mikkel_plot(rho: np.ndarray, xbounds: Tuple[int] = (-6, 6), ybounds: Tuple[i
     ax[0][1].tick_params(direction="in")
     ax[0][1].get_xaxis().set_ticks([])
     ax[0][1].get_yaxis().set_ticks([])
-    ax[0][1].set_aspect("auto")  # if not set to auto, pytho
+    ax[0][1].set_aspect("auto")
     ax[0][1].set_ylabel(f"cutoff = {len(rho)}", fontsize=12)
     ax[0][1].yaxis.set_label_position("right")

--- a/mrmustard/utils/graphics.py
+++ b/mrmustard/utils/graphics.py
@@ -14,7 +14,6 @@
 
 """A module containing utility classes and functions for graphical display."""
 
-from copy import copy
 from typing import Tuple
 from rich.progress import Progress, TextColumn, BarColumn, TimeRemainingColumn
 import matplotlib.pyplot as plt

--- a/mrmustard/utils/wigner.py
+++ b/mrmustard/utils/wigner.py
@@ -29,20 +29,20 @@ def wigner_discretized(rho, qvec, pvec, hbar=settings.HBAR):
         rho (complex array): the density matrix of the state in Fock representation
         xvec (array): array of discretized :math:`x` quadrature values
         pvec (array): array of discretized :math:`p` quadrature values
-        hbar (float): the value of ``\hbar``
+        hbar (optional float): the value of `\hbar`, defaults to ``settings.HBAR``.
 
     Retunrs:
-        tuple(array, array, array): array containing the discretized Wigner function, and the P and
-            Q coordinates in meshgrid form
+        tuple(array, array, array): array containing the discretized Wigner function, and the Q and
+            P coordinates (in meshgrid form) in which the function is calculated
     """
 
-    Q = np.outer(pvec, np.ones_like(qvec))
-    P = np.outer(np.ones_like(pvec), qvec)
+    Q = np.outer(qvec, np.ones_like(pvec))
+    P = np.outer(np.ones_like(qvec), pvec)
 
     cutoff = rho.shape[-1]
     A = (Q + P * 1.0j) / (2 * np.sqrt(hbar / 2))
 
-    Wmat = np.zeros((2, cutoff) + A.shape, dtype=np.complex128)
+    Wmat = np.zeros((2, cutoff) + A.shape, dtype=rho.dtype)
 
     # Wigner function for |0><0|
     Wmat[0, 0] = np.exp(-2.0 * np.abs(A) ** 2) / np.pi
@@ -63,4 +63,4 @@ def wigner_discretized(rho, qvec, pvec, hbar=settings.HBAR):
             W += 2 * np.real(rho[m, n] * Wmat[1, n])
         Wmat[0] = Wmat[1]
 
-    return W.transpose() / hbar, P, Q
+    return W / hbar, Q, P

--- a/mrmustard/utils/wigner.py
+++ b/mrmustard/utils/wigner.py
@@ -1,0 +1,67 @@
+# Copyright 2022 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""This module contains the calculation of the Wigner function."""
+
+from numba import njit
+import numpy as np
+from mrmustard import settings
+
+
+@njit
+def wigner_discretized(rho, qvec, pvec, hbar=settings.HBAR):
+    r"""Calculates the discretized Wigner function
+
+    Adapted from `strawberryfields <https://github.com/XanaduAI/strawberryfields/blob/master/strawberryfields/backends/states.py#L725>`
+
+    Args:
+        rho (complex array): the density matrix of the state in Fock representation
+        xvec (array): array of discretized :math:`x` quadrature values
+        pvec (array): array of discretized :math:`p` quadrature values
+        hbar (float): the value of ``\hbar``
+
+    Retunrs:
+        array: array containing the discretized Wigner function
+    """
+
+    Q = np.outer(pvec, np.ones_like(qvec))
+    P = np.outer(np.ones_like(pvec), qvec)
+    cutoff = rho.shape[-1]
+    A = (Q + P * 1.0j) / (2 * np.sqrt(hbar / 2))
+
+    cutoff = rho.shape[-1]
+    A = (Q + P * 1.0j) / (2 * np.sqrt(hbar / 2))
+
+    Wmat = np.zeros((2, cutoff) + A.shape, dtype=np.complex128)
+
+    # Wigner function for |0><0|
+    Wmat[0, 0] = np.exp(-2.0 * np.abs(A) ** 2) / np.pi
+    W = np.real(rho[0, 0]) * np.real(Wmat[0, 0])
+
+    for n in range(1, cutoff):
+        Wmat[0, n] = (2.0 * A * Wmat[0, n - 1]) / np.sqrt(n)
+        W += 2 * np.real(rho[0, n] * Wmat[0, n])
+
+    for m in range(1, cutoff):
+        # Wigner function for |m><m|
+        Wmat[1, m] = (2 * np.conj(A) * Wmat[0, m] - np.sqrt(m) * Wmat[0, m - 1]) / np.sqrt(m)
+        W += np.real(rho[m, m] * Wmat[1, m])
+
+        for n in range(m + 1, cutoff):
+            # Wigner function for |m><n|
+            Wmat[1, n] = (2 * A * Wmat[1, n - 1] - np.sqrt(m) * Wmat[0, n - 1]) / np.sqrt(n)
+            W += 2 * np.real(rho[m, n] * Wmat[1, n])
+        Wmat[0] = Wmat[1]
+
+    return W.transpose() / hbar, P, Q

--- a/mrmustard/utils/wigner.py
+++ b/mrmustard/utils/wigner.py
@@ -21,7 +21,7 @@ from mrmustard import settings
 
 @njit
 def wigner_discretized(rho, qvec, pvec, hbar=settings.HBAR):
-    r"""Calculates the discretized Wigner function
+    r"""Calculates the discretized Wigner function for a single mode.
 
     Adapted from `strawberryfields <https://github.com/XanaduAI/strawberryfields/blob/master/strawberryfields/backends/states.py#L725>`
 

--- a/mrmustard/utils/wigner.py
+++ b/mrmustard/utils/wigner.py
@@ -32,13 +32,12 @@ def wigner_discretized(rho, qvec, pvec, hbar=settings.HBAR):
         hbar (float): the value of ``\hbar``
 
     Retunrs:
-        array: array containing the discretized Wigner function
+        tuple(array, array, array): array containing the discretized Wigner function, and the P and
+            Q coordinates in meshgrid form
     """
 
     Q = np.outer(pvec, np.ones_like(qvec))
     P = np.outer(np.ones_like(pvec), qvec)
-    cutoff = rho.shape[-1]
-    A = (Q + P * 1.0j) / (2 * np.sqrt(hbar / 2))
 
     cutoff = rho.shape[-1]
     A = (Q + P * 1.0j) / (2 * np.sqrt(hbar / 2))

--- a/tests/test_utils/test_wigner.py
+++ b/tests/test_utils/test_wigner.py
@@ -1,0 +1,15 @@
+# Copyright 2022 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""This module contains test for the calculation of the discretized Wigner function."""

--- a/tests/test_utils/test_wigner.py
+++ b/tests/test_utils/test_wigner.py
@@ -14,7 +14,6 @@
 
 """This module contains test for the calculation of the discretized Wigner function."""
 
-from hypothesis import given
 import pytest
 import numpy as np
 from scipy.stats import multivariate_normal
@@ -29,7 +28,6 @@ from mrmustard.lab import (
     Fock,
 )
 from mrmustard import settings
-from tests import random
 
 
 def multivariate_normal_pdf(qvec, pvec, means, cov):

--- a/tests/test_utils/test_wigner.py
+++ b/tests/test_utils/test_wigner.py
@@ -13,3 +13,113 @@
 # limitations under the License.
 
 """This module contains test for the calculation of the discretized Wigner function."""
+
+from hypothesis import given
+import pytest
+import numpy as np
+from scipy.stats import multivariate_normal
+from mrmustard.utils.wigner import wigner_discretized
+from mrmustard.lab import (
+    Vacuum,
+    Coherent,
+    SqueezedVacuum,
+    Thermal,
+    DisplacedSqueezed,
+    Gaussian,
+    Fock,
+)
+from mrmustard import settings
+from tests import random
+
+
+def multivariate_normal_pdf(qvec, pvec, means, cov):
+    """generates the PDF of a multivariate normal distribution"""
+    mvn = multivariate_normal(means, cov, allow_singular=True)
+    grid = np.meshgrid(qvec, pvec)
+    return mvn.pdf(grid)
+
+
+@pytest.mark.parametrize(
+    "state",
+    [
+        Vacuum(1),
+        Coherent(0.3, -0.5),
+        SqueezedVacuum(0.5, 0.45),
+        Thermal(0.25),
+        DisplacedSqueezed(0.3, 0.1, -0.1, 0.1),
+        Gaussian(1),
+    ],
+)
+def test_wigner_gaussian_states(state):
+    """test Wigner function for Gaussian states is a standard normal distribution"""
+
+    # calculate Wigner from state dm
+    qvec = np.arange(-5, 5, 100)
+    pvec = qvec
+    dm = state.dm(cutoffs=[5]).numpy()
+    W_calc, _, _ = wigner_discretized(dm, qvec, pvec)
+
+    # calculate exact
+    cov = state.cov.numpy()
+    means = state.means.numpy()
+    W_exact = multivariate_normal_pdf(qvec, pvec, means, cov)
+
+    assert np.allclose(W_calc, W_exact, atol=0.001, rtol=0)
+
+
+# Exact marginal probability distributions for various states
+hbar = settings.HBAR
+
+
+def fock1_marginal(qvec):
+    """q and p marginal distributions for the Fock state |1>"""
+    x = (
+        0.5
+        * np.sqrt(1 / (np.pi * hbar))
+        * np.exp(-1 * (qvec**2) / hbar)
+        * (4 / hbar)
+        * (qvec**2)
+    )
+    p = x
+    return x, p
+
+
+def vacuum_marginal(qvec):
+    """q and p marginal distributions for the vacuum state"""
+    x = np.sqrt(1 / (np.pi * hbar)) * np.exp(-1 * (qvec**2) / hbar)
+    p = x
+    return x, p
+
+
+def coherent_marginal(qvec):
+    r"""q and p marginal distributions for the coherent state with `\alpha=1`"""
+    x = np.sqrt(1 / (np.pi * hbar)) * np.exp(-1 * ((qvec - 0.5 * np.sqrt(2 * hbar)) ** 2) / hbar)
+    p = np.sqrt(1 / (np.pi * hbar)) * np.exp(-1 * (qvec**2) / hbar)
+    return x, p
+
+
+@pytest.mark.parametrize(
+    "state, f_marginal",
+    [
+        (Vacuum(1), vacuum_marginal),
+        (Coherent(1.0, 0.0), coherent_marginal),
+        (Fock([1]), fock1_marginal),
+    ],
+)
+def test_marginal_wigner(state, f_marginal):
+    """test marginals of Wigner function agree with the expected ones"""
+
+    # calculate Wigner from state dm
+    qvec = np.arange(-5, 5, 100)
+    pvec = qvec
+    dm = state.dm(cutoffs=[5]).numpy()
+    W_calc, _, _ = wigner_discretized(dm, qvec, pvec)
+
+    # calculate marginals
+    q_marginal = np.sum(W_calc, axis=1)
+    p_marginal = np.sum(W_calc, axis=0)
+
+    expected_q_marginal, expected_p_marginal = f_marginal(qvec)
+
+    assert np.allclose(q_marginal, expected_q_marginal, atol=0.001, rtol=0)
+    assert np.allclose(p_marginal, expected_p_marginal, atol=0.001, rtol=0)


### PR DESCRIPTION
**Context:**
Calculation of the Wigner function is already included in Mr Mustard but hidden in the graphics module

**Description of the Change:**
This PR moves the Wigner function calculation to its own module and numbifies it.

**Benefits:**
Now you can calculate the Wigner function using
```python
from mrmustard.utils.wigner import wigner_discretized

wigner_discretized(dm, q, p) # dm is a density matrix
```

It should be faster as well because it uses numba jit.

**Possible Drawbacks:**
None