### PR TITLE
settings repr

### DIFF
--- a/mrmustard/__init__.py
+++ b/mrmustard/__init__.py
@@ -34,8 +34,7 @@ class Settings:
         self.CHOI_R = 0.881373587019543  # np.arcsinh(1.0)
         self.DEBUG = False
         # clip(mean + 5*std, min, max) when auto-detecting the Fock cutoff
-        # TODO: make fock cutoff adaptive
-        self.AUTOCUTOFF_STDEV_FACTOR = 5
+        self.AUTOCUTOFF_STDEV_FACTOR = 5 # TODO: make fock cutoff adaptive
         self.AUTOCUTOFF_MAX_CUTOFF = 100
         self.AUTOCUTOFF_MIN_CUTOFF = 1
         # using cutoff=5 for each mode when determining if two transformations in fock repr are equal

--- a/mrmustard/__init__.py
+++ b/mrmustard/__init__.py
@@ -34,7 +34,7 @@ class Settings:
         self.CHOI_R = 0.881373587019543  # np.arcsinh(1.0)
         self.DEBUG = False
         # clip(mean + 5*std, min, max) when auto-detecting the Fock cutoff
-        self.AUTOCUTOFF_STDEV_FACTOR = 5 # TODO: make fock cutoff adaptive
+        self.AUTOCUTOFF_STDEV_FACTOR = 5
         self.AUTOCUTOFF_MAX_CUTOFF = 100
         self.AUTOCUTOFF_MIN_CUTOFF = 1
         # using cutoff=5 for each mode when determining if two transformations in fock repr are equal

--- a/mrmustard/__init__.py
+++ b/mrmustard/__init__.py
@@ -14,6 +14,9 @@
 
 """This is the top-most `__init__.py` file of MrMustard package."""
 
+import rich.table
+from rich import print
+
 from ._version import __version__
 
 # pylint: disable=too-many-instance-attributes
@@ -62,9 +65,6 @@ class Settings:
     # use rich.table to print the settings
     def __repr__(self):
         """Returns a string representation of the settings."""
-        import rich.table
-        from rich import print
-
         table = rich.table.Table(title="MrMustard Settings")
         table.add_column("Setting")
         table.add_column("Value")
@@ -78,8 +78,6 @@ class Settings:
 
 settings = Settings()
 """Settings object."""
-
-settings.backend = "tensorflow"
 
 
 def version():

--- a/mrmustard/__init__.py
+++ b/mrmustard/__init__.py
@@ -20,12 +20,18 @@ from ._version import __version__
 class Settings:
     """Settings class."""
 
+    def __new__(cls): # singleton
+        if not hasattr(cls, 'instance'):
+            cls.instance = super(Settings, cls).__new__(cls)
+        return cls.instance
+
     def __init__(self):
         self._backend = "tensorflow"
         self.HBAR = 2.0
         self.CHOI_R = 0.881373587019543  # np.arcsinh(1.0)
         self.DEBUG = False
         # clip(mean + 5*std, min, max) when auto-detecting the Fock cutoff
+        # TODO: make fock cutoff adaptive
         self.AUTOCUTOFF_STDEV_FACTOR = 5
         self.AUTOCUTOFF_MAX_CUTOFF = 100
         self.AUTOCUTOFF_MIN_CUTOFF = 1
@@ -40,18 +46,34 @@ class Settings:
         self.PROGRESSBAR = True
 
     @property
-    def backend(self):
+    def BACKEND(self):
         """The backend which is used.
 
         Can be either ``'tensorflow'`` or ``'torch'``.
         """
         return self._backend
 
-    @backend.setter
-    def backend(self, backend_name: str):
+    @BACKEND.setter
+    def BACKEND(self, backend_name: str):
         if backend_name not in ["tensorflow", "torch"]:  # pragma: no cover
             raise ValueError("Backend must be either 'tensorflow' or 'torch'")
         self._backend = backend_name
+
+    # use rich.table to print the settings
+    def __repr__(self):
+        """Returns a string representation of the settings."""
+        import rich.table
+        from rich import print
+
+        table = rich.table.Table(title="MrMustard Settings")
+        table.add_column("Setting")
+        table.add_column("Value")
+        table.add_row('BACKEND', self.BACKEND)
+        for key, value in self.__dict__.items():
+            if key == key.upper():
+                table.add_row(key, str(value))
+        print(table)
+        return ""
 
 
 settings = Settings()

--- a/mrmustard/__init__.py
+++ b/mrmustard/__init__.py
@@ -20,8 +20,8 @@ from ._version import __version__
 class Settings:
     """Settings class."""
 
-    def __new__(cls): # singleton
-        if not hasattr(cls, 'instance'):
+    def __new__(cls):  # singleton
+        if not hasattr(cls, "instance"):
             cls.instance = super(Settings, cls).__new__(cls)
         return cls.instance
 
@@ -68,7 +68,7 @@ class Settings:
         table = rich.table.Table(title="MrMustard Settings")
         table.add_column("Setting")
         table.add_column("Value")
-        table.add_row('BACKEND', self.BACKEND)
+        table.add_row("BACKEND", self.BACKEND)
         for key, value in self.__dict__.items():
             if key == key.upper():
                 table.add_row(key, str(value))

--- a/mrmustard/math/__init__.py
+++ b/mrmustard/math/__init__.py
@@ -51,11 +51,11 @@ class Math:
     """
     # pylint: disable=no-else-return
     def __getattribute__(self, name):
-        if settings.backend == "tensorflow":
+        if settings.BACKEND == "tensorflow":
             return object.__getattribute__(TFMath(), name)
-        elif settings.backend == "torch":
+        elif settings.BACKEND == "torch":
             return object.__getattribute__(TorchMath(), name)
 
         raise ValueError(
-            f"No `{settings.backend}` backend found. Ensure your backend is either ``'tensorflow'`` or ``'torch'``"
+            f"No `{settings.BACKEND}` backend found. Ensure your backend is either ``'tensorflow'`` or ``'torch'``"
         )

--- a/tests/test_math/test_interface.py
+++ b/tests/test_math/test_interface.py
@@ -32,7 +32,7 @@ def test_backend_redirection_tf():
     """Test Math class is redirecting calls to the backend set on MM settings"""
     math = Math()
 
-    settings.backend = "tensorflow"
+    settings.BACKEND = "tensorflow"
     assert math._MathInterface__instance.__module__ == "mrmustard.math.tensorflow"
 
 
@@ -41,16 +41,16 @@ def test_backend_redirection_torch():
     """Test Math class is redirecting calls to the backend set on MM settings"""
     math = Math()
 
-    settings.backend = "torch"
+    settings.BACKEND = "torch"
     assert math._MathInterface__instance.__module__ == "mrmustard.math.torch"
 
 
 def test_error_for_wrong_backend():
     """Test error is raise when using a backend that is not allowed"""
-    backend = settings.backend
+    backend = settings.BACKEND
     with pytest.raises(ValueError) as exception_info:
-        settings.backend = "unexisting_backend"
+        settings.BACKEND = "unexisting_backend"
         assert exception_info.value.args[0] == f"Backend must be either 'tensorflow' or 'torch'"
 
-    # set back to initial value to avoir side effects
-    settings.backend = backend
+    # set back to initial value to avoid side effects
+    settings.BACKEND = backend


### PR DESCRIPTION
**Context:**
settings are not easy do discover

**Description of the Change:**
the settings object has now a nice repr

**Benefits:**
users can see al the settings at once

**Possible Drawbacks:**
None I can think of

**Related GitHub Issues:**
None

<img width="513" alt="Screen Shot 2022-11-08 at 9 55 08 AM" src="https://user-images.githubusercontent.com/8944955/200597522-66ebfa0f-dd87-4109-982f-c8d3231823f8.png">
