### PR TITLE
allows for full cutoff specification

### DIFF
--- a/mrmustard/lab/abstract/transformation.py
+++ b/mrmustard/lab/abstract/transformation.py
@@ -234,7 +234,7 @@ class Transformation:
         return fock.fock_representation(
             choi_state.cov,
             choi_state.means,
-            shape=cutoffs * 2,
+            shape=cutoffs * 2 if len(cutoffs) == self.num_modes else cutoffs,
             return_unitary=True,
             choi_r=settings.CHOI_R,
         )
@@ -249,7 +249,7 @@ class Transformation:
         choi_op = fock.fock_representation(
             choi_state.cov,
             choi_state.means,
-            shape=cutoffs * 4,
+            shape=cutoffs * 4 if len(cutoffs) == self.num_modes else cutoffs,
             return_unitary=False,
             choi_r=settings.CHOI_R,
         )


### PR DESCRIPTION
**Context:**
sometimes it's useful to compute the fock representation using different cutoffs for input-output indices of the same mode

**Description of the Change:**
transformations (gates, circuit) now accept also a list of double (or quadruple for choi) length which specifies the cutoffs per index (rather than per mode)

**Benefits:**
saves runtime if one needs e.g. to input fock states into a gaussian circuit

**Possible Drawbacks:**
none

**Related GitHub Issues:**
