### PR TITLE
changes norm to probability in repr of State

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -45,6 +45,9 @@ within the defined window. Also, expose some plot parameters and return the figu
 * Added two functions in the `fock` module to apply operators to ket and dm. When used by the circuit it avoid having to fall back to unitaries as large as the whole circuit.
   [(#180)](https://github.com/XanaduAI/MrMustard/pull/180)
 
+* Replaced norm with probability in the repr of `State`. This improves consistency over the old behaviour (norm was the sqrt of prob if the state was pure and prob if the state was mixed).
+  [(#182)](https://github.com/XanaduAI/MrMustard/pull/182)
+
 ### Bug fixes
 
 * The `Dgate` and the `Rgate` now correctly parse the case when a single scalar is intended as the same parameter of a number of gates in pallel.

--- a/mrmustard/lab/abstract/state.py
+++ b/mrmustard/lab/abstract/state.py
@@ -233,7 +233,7 @@ class State:
     def probability(self) -> float:
         r"""Returns the probability of the state."""
         if self.is_pure:
-            return self.norm ** 2
+            return self.norm**2
         return self.norm
 
     def ket(self, cutoffs: List[int] = None) -> Optional[Tensor]:

--- a/mrmustard/lab/abstract/state.py
+++ b/mrmustard/lab/abstract/state.py
@@ -227,8 +227,14 @@ class State:
         r"""Returns the norm of the state."""
         if self.is_gaussian:
             return self._norm
-
         return fock.norm(self.fock, self.is_mixed)
+
+    @property
+    def probability(self) -> float:
+        r"""Returns the probability of the state."""
+        if self.is_pure:
+            return self.norm ** 2
+        return self.norm
 
     def ket(self, cutoffs: List[int] = None) -> Optional[Tensor]:
         r"""Returns the ket of the state in Fock representation or ``None`` if the state is mixed.
@@ -592,12 +598,21 @@ class State:
             return State(ket=self.ket() / other, modes=self.modes)
         raise ValueError("No fock representation available")
 
+    @staticmethod
+    def _format_probability(prob: float) -> str:
+        if prob < 0.001:
+            return f"{100*prob:.3e} %"
+        else:
+            return f"{prob:.3%}"
+
     def _repr_markdown_(self):
         table = (
             f"#### {self.__class__.__qualname__}\n\n"
-            + "| Purity | Norm | Num modes | Bosonic size | Gaussian | Fock |\n"
+            + "| Purity | Probability | Num modes | Bosonic size | Gaussian | Fock |\n"
             + "| :----: | :----: | :----: | :----: | :----: | :----: |\n"
-            + f"| {self.purity :.2e} | {self.norm :.2e} | {self.num_modes} | {'1' if self.is_gaussian else 'N/A'} | {'✅' if self.is_gaussian else '❌'} | {'✅' if self._ket is not None or self._dm is not None else '❌'} |"
+            + f"| {self.purity :.2e} | "
+            + self._format_probability(self.probability)
+            + f" | {self.num_modes} | {'1' if self.is_gaussian else 'N/A'} | {'✅' if self.is_gaussian else '❌'} | {'✅' if self._ket is not None or self._dm is not None else '❌'} |"
         )
 
         if self.num_modes == 1:


### PR DESCRIPTION
**Context:**
norm is confusing field in the repr of `State` (it's the sqrt of the probability if the state is pure and the probability if it's mixed).

**Description of the Change:**
Replace norm with probability 

**Benefits:**
Consistent meaning and also more practically useful

**Possible Drawbacks:**
some users may miss the good old norm?

**Related GitHub Issues:**
