### PR TITLE
MMTensor wrapper

### DIFF
--- a/mrmustard/lab/abstract/state.py
+++ b/mrmustard/lab/abstract/state.py
@@ -132,9 +132,8 @@ class State:
         if self._purity is None:
             if self.is_gaussian:
                 self._purity = gaussian.purity(self.cov, settings.HBAR)
-                # TODO: add symplectic representation
             else:
-                self._purity = fock.purity(self.fock)  # has to be dm
+                self._purity = fock.purity(self._dm)
         return self._purity
 
     @property

--- a/mrmustard/lab/abstract/state.py
+++ b/mrmustard/lab/abstract/state.py
@@ -227,14 +227,16 @@ class State:
         r"""Returns the norm of the state."""
         if self.is_gaussian:
             return self._norm
-        return fock.norm(self.fock, self.is_mixed)
+        array = self.fock
+        return fock.norm(array, self._dm is not None)
 
     @property
     def probability(self) -> float:
         r"""Returns the probability of the state."""
-        if self.is_pure:
-            return self.norm**2
-        return self.norm
+        norm = self.norm
+        if self.is_pure and self._ket is not None:
+            return norm**2
+        return norm
 
     def ket(self, cutoffs: List[int] = None) -> Optional[Tensor]:
         r"""Returns the ket of the state in Fock representation or ``None`` if the state is mixed.

--- a/mrmustard/math/__init__.py
+++ b/mrmustard/math/__init__.py
@@ -49,13 +49,13 @@ class Math:
     r"""
     This class is a switcher for performing math operations on the currently active backend.
     """
-    # pylint: disable=no-else-return
     def __getattribute__(self, name):
         if settings.BACKEND == "tensorflow":
             return object.__getattribute__(TFMath(), name)
         elif settings.BACKEND == "torch":
             return object.__getattribute__(TorchMath(), name)
+        else:
+            raise ValueError(
+                f"No `{settings.BACKEND}` backend found. Ensure your backend is either ``'tensorflow'`` or ``'torch'``"
+            )
 
-        raise ValueError(
-            f"No `{settings.BACKEND}` backend found. Ensure your backend is either ``'tensorflow'`` or ``'torch'``"
-        )

--- a/mrmustard/math/__init__.py
+++ b/mrmustard/math/__init__.py
@@ -49,6 +49,7 @@ class Math:
     r"""
     This class is a switcher for performing math operations on the currently active backend.
     """
+
     def __getattribute__(self, name):
         if settings.BACKEND == "tensorflow":
             return object.__getattribute__(TFMath(), name)
@@ -58,4 +59,3 @@ class Math:
             raise ValueError(
                 f"No `{settings.BACKEND}` backend found. Ensure your backend is either ``'tensorflow'`` or ``'torch'``"
             )
-

--- a/mrmustard/math/mmtensor.py
+++ b/mrmustard/math/mmtensor.py
@@ -98,7 +98,7 @@ class MMTensor:
             relabeling = self.axis_labels
         elif len(relabeling) != len(self.axis_labels):
             raise ValueError("The number of labels must be equal to the number of axes.")
-        
+
         self.axis_labels = relabeling
 
         # Find all unique labels
@@ -108,7 +108,7 @@ class MMTensor:
         # Turn labels into consecutive ascii lower-case letters, with same letters corresponding to the same label
         label_map = {label: string.ascii_lowercase[i] for i, label in enumerate(unique_labels)}
         labels = [label_map[label] for label in self.axis_labels]
-        
+
         # create einsum string from labels
         einsum_str = "".join(labels)
 

--- a/mrmustard/math/mmtensor.py
+++ b/mrmustard/math/mmtensor.py
@@ -20,7 +20,10 @@ This module contains the implementation of a tensor wrapper class.
 
 from typing import List
 import string
-from mrmustard.math import Math; math = Math()
+from mrmustard.math import Math
+
+math = Math()
+
 
 class MMTensor:
     r"""A Mr Mustard tensor (a wrapper around an array that implements the numpy array API)."""
@@ -43,33 +46,37 @@ class MMTensor:
         """
         Implement the NumPy ufunc interface.
         """
-        if method == '__call__':
+        if method == "__call__":
             return MMTensor(ufunc(*inputs, **kwargs), self.axis_labels)
         else:
             return NotImplemented
-    
+
     def __matmul__(self, other):
         """
         Overload the @ operator to perform tensor contractions.
         """
         if not isinstance(other, MMTensor):
             raise TypeError(f"Cannot contract with object of type {type(other)}")
-        
+
         # Find common axis labels
         common_labels = set(self.axis_labels) & set(other.axis_labels)
-        
+
         if not common_labels:
             raise ValueError("No common axis labels found")
-        
+
         # Determine the indices to contract along
         left_indices = [self.axis_labels.index(label) for label in common_labels]
         right_indices = [other.axis_labels.index(label) for label in common_labels]
-        
+
         # Create a list of the new axis labels
-        new_axis_labels = [label for label in self.axis_labels if label not in common_labels] + \
-                          [label for label in other.axis_labels if label not in common_labels]
-        
-        return MMTensor(math.tensordot(self.array, other.array, axes=(left_indices, right_indices)), new_axis_labels)
+        new_axis_labels = [label for label in self.axis_labels if label not in common_labels] + [
+            label for label in other.axis_labels if label not in common_labels
+        ]
+
+        return MMTensor(
+            math.tensordot(self.array, other.array, axes=(left_indices, right_indices)),
+            new_axis_labels,
+        )
 
     def contract(self, relabeling: List[str]):
         """
@@ -99,7 +106,6 @@ class MMTensor:
 
         # Contract the tensor
         return MMTensor(math.einsum(einsum_string, self.array), new_axis_labels)
-       
 
     def transpose(self, perm):
         """
@@ -112,13 +118,13 @@ class MMTensor:
         Reshape the tensor. Allows to change the axis labels.
         """
         return MMTensor(math.reshape(self.array, shape), axis_labels or self.axis_labels)
-    
+
     def __array__(self):
         """
         Implement the NumPy array interface.
         """
         return self.array
-    
+
     def __getitem__(self, indices):
         """
         Implement indexing into the tensor.
@@ -136,11 +142,13 @@ class MMTensor:
             return MMTensor(self.array[indices], axis_labels)
         else:
             # Index along a single axis and take care of the axis labels
-            return MMTensor(self.array[indices], self.axis_labels[:indices] + self.axis_labels[indices+1:])
+            return MMTensor(
+                self.array[indices], self.axis_labels[:indices] + self.axis_labels[indices + 1 :]
+            )
 
     def __repr__(self):
         return f"MMTensor({self.array}, {self.axis_labels})"
-        
+
     def __getattribute__(self, name):
         """
         Implement the underlying array's methods.

--- a/mrmustard/math/mmtensor.py
+++ b/mrmustard/math/mmtensor.py
@@ -21,7 +21,6 @@ This module contains the implementation of a tensor wrapper class.
 from typing import List, Optional
 import string
 from mrmustard.math import Math
-
 math = Math()
 
 

--- a/mrmustard/math/mmtensor.py
+++ b/mrmustard/math/mmtensor.py
@@ -158,4 +158,3 @@ class MMTensor:
             return super().__getattribute__(name)
         except AttributeError:
             return getattr(self.tensor, name)
-

--- a/mrmustard/math/mmtensor.py
+++ b/mrmustard/math/mmtensor.py
@@ -36,11 +36,11 @@ class MMTensor:
         else:
             self.tensor = array
             self.axis_labels = axis_labels
-        
+
         # If axis labels are not provided, generate default labels
         if self.axis_labels is None:
             self.axis_labels = [str(n) for n in range(len(self.tensor.shape))]
-        
+
         # Validate the number of axis labels
         if len(self.axis_labels) != len(self.tensor.shape):
             raise ValueError("The number of axis labels must be equal to the number of axes.")
@@ -118,7 +118,10 @@ class MMTensor:
         einsum_str = "".join(labels)
 
         # Contract the tensor and assign new axis labels (unique labels except for the contracted ones)
-        return MMTensor(math.einsum(einsum_str, self.tensor), [label for label in unique_labels if label not in repeated])
+        return MMTensor(
+            math.einsum(einsum_str, self.tensor),
+            [label for label in unique_labels if label not in repeated],
+        )
 
     def transpose(self, perm):
         """

--- a/mrmustard/math/mmtensor.py
+++ b/mrmustard/math/mmtensor.py
@@ -29,6 +29,9 @@ class MMTensor:
     r"""A Mr Mustard tensor (a wrapper around an array that implements the numpy array API)."""
 
     def __init__(self, array, axis_labels=None):
+        if axis_labels is not None:
+            if len(axis_labels) != len(array.shape):
+                raise ValueError("The number of axis labels must be equal to the number of axes.")
         if isinstance(array, MMTensor):
             self.array = array.array
             self.axis_labels = array.axis_labels

--- a/mrmustard/math/mmtensor.py
+++ b/mrmustard/math/mmtensor.py
@@ -21,6 +21,7 @@ This module contains the implementation of a tensor wrapper class.
 from typing import List, Optional
 import string
 from mrmustard.math import Math
+
 math = Math()
 
 

--- a/mrmustard/math/mmtensor.py
+++ b/mrmustard/math/mmtensor.py
@@ -29,15 +29,17 @@ class MMTensor:
     r"""A Mr Mustard tensor (a wrapper around an array that implements the numpy array API)."""
 
     def __init__(self, array, axis_labels=None):
-        if axis_labels is not None:
-            if len(axis_labels) != len(array.shape):
-                raise ValueError("The number of axis labels must be equal to the number of axes.")
         if isinstance(array, MMTensor):
             self.array = array.array
-            self.axis_labels = array.axis_labels
+            self.axis_labels = axis_labels or array.axis_labels
         else:
-            self.array = array
-            self.axis_labels = axis_labels
+            if axis_labels is not None:
+                if len(axis_labels) != len(array.shape):
+                    raise ValueError("The number of axis labels must be equal to the number of axes.")
+            if axis_labels is None:
+                axis_labels = [str(n) for n in range(len(array.shape))]
+                self.array = array
+                self.axis_labels = axis_labels
 
     def __array__(self):
         """

--- a/mrmustard/math/mmtensor.py
+++ b/mrmustard/math/mmtensor.py
@@ -1,0 +1,151 @@
+# Copyright 2023 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=redefined-outer-name
+
+"""
+This module contains the implementation of a tensor wrapper class.
+"""
+
+from typing import List
+import string
+from mrmustard.math import Math; math = Math()
+
+class MMTensor:
+    r"""A Mr Mustard tensor (a wrapper around an array that implements the numpy array API)."""
+
+    def __init__(self, array, axis_labels=None):
+        if isinstance(array, MMTensor):
+            self.array = array.array
+            self.axis_labels = array.axis_labels
+        else:
+            self.array = array
+            self.axis_labels = axis_labels
+
+    def __array__(self):
+        """
+        Implement the NumPy array interface.
+        """
+        return self.array
+
+    def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+        """
+        Implement the NumPy ufunc interface.
+        """
+        if method == '__call__':
+            return MMTensor(ufunc(*inputs, **kwargs), self.axis_labels)
+        else:
+            return NotImplemented
+    
+    def __matmul__(self, other):
+        """
+        Overload the @ operator to perform tensor contractions.
+        """
+        if not isinstance(other, MMTensor):
+            raise TypeError(f"Cannot contract with object of type {type(other)}")
+        
+        # Find common axis labels
+        common_labels = set(self.axis_labels) & set(other.axis_labels)
+        
+        if not common_labels:
+            raise ValueError("No common axis labels found")
+        
+        # Determine the indices to contract along
+        left_indices = [self.axis_labels.index(label) for label in common_labels]
+        right_indices = [other.axis_labels.index(label) for label in common_labels]
+        
+        # Create a list of the new axis labels
+        new_axis_labels = [label for label in self.axis_labels if label not in common_labels] + \
+                          [label for label in other.axis_labels if label not in common_labels]
+        
+        return MMTensor(math.tensordot(self.array, other.array, axes=(left_indices, right_indices)), new_axis_labels)
+
+    def contract(self, relabeling: List[str]):
+        """
+        Contract the tensor along the specified indices using einsum.
+
+        Args:
+            relabeling (list[str]): A list of axis labels. The tensor is contracted along all
+                groups of axes with matching labels.
+        """
+        # check that labels are valid
+        if not len(relabeling) == len(self.axis_labels):
+            raise ValueError("The number of labels must be equal to the number of axes.")
+
+        # Find all unique labels
+        unique_labels = set(relabeling)
+
+        # Find the indices of the axes to contract
+        indices_to_contract = {}
+        for label in unique_labels:
+            indices_to_contract[label] = [i for i, l in enumerate(relabeling) if l == label]
+
+        # Create the new axis labels
+        new_axis_labels = [label for label in self.axis_labels if label not in unique_labels]
+
+        # create einsum string from indices_to_contract using letters a-z
+        einsum_string = "".join([string.ascii_lowercase[i] for i in indices_to_contract])
+
+        # Contract the tensor
+        return MMTensor(math.einsum(einsum_string, self.array), new_axis_labels)
+       
+
+    def transpose(self, perm):
+        """
+        Transpose the tensor. Permutes also the axis labels accordingly.
+        """
+        return MMTensor(math.transpose(self.array, perm), [self.axis_labels[i] for i in perm])
+
+    def reshape(self, shape, axis_labels=None):
+        """
+        Reshape the tensor. Allows to change the axis labels.
+        """
+        return MMTensor(math.reshape(self.array, shape), axis_labels or self.axis_labels)
+    
+    def __array__(self):
+        """
+        Implement the NumPy array interface.
+        """
+        return self.array
+    
+    def __getitem__(self, indices):
+        """
+        Implement indexing into the tensor.
+        """
+        if isinstance(indices, tuple):
+            axis_labels = []
+            for i, ind in enumerate(indices):
+                if ind is Ellipsis and i == 0:
+                    axis_labels += self.axis_labels[:i]
+                elif isinstance(ind, slice):
+                    axis_labels += self.axis_labels[i]
+                elif ind is Ellipsis and i > 0:
+                    axis_labels += self.axis_labels[i:]
+                    break
+            return MMTensor(self.array[indices], axis_labels)
+        else:
+            # Index along a single axis and take care of the axis labels
+            return MMTensor(self.array[indices], self.axis_labels[:indices] + self.axis_labels[indices+1:])
+
+    def __repr__(self):
+        return f"MMTensor({self.array}, {self.axis_labels})"
+        
+    def __getattribute__(self, name):
+        """
+        Implement the underlying array's methods.
+        """
+        try:
+            return object.__getattribute__(self, name)
+        except AttributeError:
+            return getattr(self.array, name)

--- a/mrmustard/math/mmtensor.py
+++ b/mrmustard/math/mmtensor.py
@@ -35,7 +35,9 @@ class MMTensor:
         else:
             if axis_labels is not None:
                 if len(axis_labels) != len(array.shape):
-                    raise ValueError("The number of axis labels must be equal to the number of axes.")
+                    raise ValueError(
+                        "The number of axis labels must be equal to the number of axes."
+                    )
             if axis_labels is None:
                 axis_labels = [str(n) for n in range(len(array.shape))]
                 self.array = array

--- a/mrmustard/math/mmtensor.py
+++ b/mrmustard/math/mmtensor.py
@@ -126,12 +126,6 @@ class MMTensor:
         """
         return MMTensor(math.reshape(self.array, shape), axis_labels or self.axis_labels)
 
-    def __array__(self):
-        """
-        Implement the NumPy array interface.
-        """
-        return self.array
-
     def __getitem__(self, indices):
         """
         Implement indexing into the tensor.

--- a/mrmustard/physics/fock.py
+++ b/mrmustard/physics/fock.py
@@ -546,7 +546,13 @@ def trace(dm, keep: List[int]):
         dm: the density matrix
         keep: the modes to keep (0-based)
     """
-    dm = MMTensor(dm, axis_labels=[f"out_{i}" if i in keep else f"contract_{i}" for i in range(len(dm.shape)//2)] + [f"in_{i}" if i in keep else f"contract_{i}" for i in range(len(dm.shape)//2)])
+    dm = MMTensor(
+        dm,
+        axis_labels=[
+            f"out_{i}" if i in keep else f"contract_{i}" for i in range(len(dm.shape) // 2)
+        ]
+        + [f"in_{i}" if i in keep else f"contract_{i}" for i in range(len(dm.shape) // 2)],
+    )
     return dm.contract().tensor
 
 

--- a/mrmustard/physics/fock.py
+++ b/mrmustard/physics/fock.py
@@ -21,6 +21,7 @@ This module contains functions for performing calculations on Fock states.
 from functools import lru_cache
 import numpy as np
 
+from mrmustard.math.mmtensor import MMTensor
 from mrmustard.math.caching import tensor_int_cache
 from mrmustard.types import List, Tuple, Tensor, Scalar, Matrix, Sequence, Vector
 from mrmustard import settings
@@ -351,8 +352,6 @@ def apply_op_to_dm(op, dm, op_modes):
     Returns:
         array: the resulting density matrix
     """
-    from mrmustard.math.mmtensor import MMTensor
-
     dm = MMTensor(
         dm,
         axis_labels=["left_" + str(i) for i in range(dm.ndim // 2)]
@@ -399,8 +398,6 @@ def apply_op_to_ket(op, ket, op_indices):
     Returns:
         array: the resulting ket
     """
-    from mrmustard.math.mmtensor import MMTensor
-
     ket = MMTensor(ket, axis_labels=["left_" + str(i) for i in range(ket.ndim)])
 
     if op.ndim == 2 * len(op_indices):

--- a/mrmustard/physics/fock.py
+++ b/mrmustard/physics/fock.py
@@ -358,7 +358,7 @@ def apply_op_to_dm(op, dm, op_modes):
 
     if op.ndim == 2 * len(op_modes):
         op = MMTensor(op, axis_labels=["left_" + str(m) + "_op" for m in op_modes] + ["left_" + str(m) for m in op_modes])
-        op_conj = MMTensor(math.conj(op), axis_labels=["right_" + str(m) + "_op" for m in op_modes] + ["right_" + str(m) for m in op_modes])
+        op_conj = MMTensor(math.conj(op.array), axis_labels=["right_" + str(m) + "_op" for m in op_modes] + ["right_" + str(m) for m in op_modes])
         return (op @ dm @ op_conj).array
     
     if op.ndim == 4 * len(op_modes):

--- a/mrmustard/physics/fock.py
+++ b/mrmustard/physics/fock.py
@@ -327,6 +327,7 @@ def purity(dm: Tensor) -> Scalar:
     cutoffs = dm.shape[: len(dm.shape) // 2]
     d = int(np.prod(cutoffs))  # combined cutoffs in all modes
     dm = math.reshape(dm, (d, d))
+    dm = dm / math.trace(dm)
     return math.abs(math.sum(math.transpose(dm) * dm))  # tr(rho^2)
 
 

--- a/mrmustard/physics/fock.py
+++ b/mrmustard/physics/fock.py
@@ -381,6 +381,8 @@ def apply_op_to_dm(op, dm, op_modes):
         )
         return (op @ dm).array
 
+    raise ValueError("Operator should either have 2 or 4 times as many indices as the number of modes it acts on.")
+
 
 def apply_op_to_ket(op, ket, op_indices):
     r"""Applies an operator to a ket.
@@ -407,6 +409,8 @@ def apply_op_to_ket(op, ket, op_indices):
             + ["left_" + str(m) for m in op_indices],
         )
         return (op @ ket).array
+
+    raise ValueError("Operator should either have 2 times as many indices as the number of modes it acts on.")
 
 
 def CPTP(transformation, fock_state, transformation_is_unitary: bool, state_is_dm: bool) -> Tensor:

--- a/mrmustard/physics/fock.py
+++ b/mrmustard/physics/fock.py
@@ -381,7 +381,9 @@ def apply_op_to_dm(op, dm, op_modes):
         )
         return (op @ dm).array
 
-    raise ValueError("Operator should either have 2 or 4 times as many indices as the number of modes it acts on.")
+    raise ValueError(
+        "Operator should either have 2 or 4 times as many indices as the number of modes it acts on."
+    )
 
 
 def apply_op_to_ket(op, ket, op_indices):
@@ -410,7 +412,9 @@ def apply_op_to_ket(op, ket, op_indices):
         )
         return (op @ ket).array
 
-    raise ValueError("Operator should either have 2 times as many indices as the number of modes it acts on.")
+    raise ValueError(
+        "Operator should either have 2 times as many indices as the number of modes it acts on."
+    )
 
 
 def CPTP(transformation, fock_state, transformation_is_unitary: bool, state_is_dm: bool) -> Tensor:

--- a/mrmustard/physics/fock.py
+++ b/mrmustard/physics/fock.py
@@ -548,15 +548,6 @@ def trace(dm, keep: List[int]):
     """
     dm = MMTensor(dm, axis_labels=[f"out_{i}" if i in keep else f"contract_{i}" for i in range(len(dm.shape)//2)] + [f"in_{i}" if i in keep else f"contract_{i}" for i in range(len(dm.shape)//2)])
     return dm.contract().tensor
-    # N = len(dm.shape) // 2
-    # trace = [m for m in range(N) if m not in keep]
-    # # put at the end all of the indices to trace over
-    # keep_idx = keep + [i + N for i in keep]
-    # trace_idx = trace + [i + N for i in trace]
-    # dm = math.transpose(dm, keep_idx + trace_idx)
-    # d = int(np.prod([dm.shape[t] for t in trace]))
-    # dm = math.reshape(dm, dm.shape[: 2 * len(keep)] + (d, d))
-    # return math.trace(dm)
 
 
 @tensor_int_cache

--- a/mrmustard/physics/fock.py
+++ b/mrmustard/physics/fock.py
@@ -329,7 +329,6 @@ def purity(dm: Tensor) -> Scalar:
     return math.abs(math.sum(math.transpose(dm) * dm))  # tr(rho^2)
 
 
-
 def apply_op_to_dm(op, dm, op_modes):
     r"""Applies an operator to a density matrix.
     It assumes that the density matrix is indexed as out_1, ..., out_n, in_1, ..., in_n.
@@ -354,15 +353,33 @@ def apply_op_to_dm(op, dm, op_modes):
     """
     from mrmustard.math.mmtensor import MMTensor
 
-    dm = MMTensor(dm, axis_labels=["left_" + str(i) for i in range(dm.ndim // 2)] + ["right_" + str(i) for i in range(dm.ndim // 2)])
+    dm = MMTensor(
+        dm,
+        axis_labels=["left_" + str(i) for i in range(dm.ndim // 2)]
+        + ["right_" + str(i) for i in range(dm.ndim // 2)],
+    )
 
     if op.ndim == 2 * len(op_modes):
-        op = MMTensor(op, axis_labels=["left_" + str(m) + "_op" for m in op_modes] + ["left_" + str(m) for m in op_modes])
-        op_conj = MMTensor(math.conj(op.array), axis_labels=["right_" + str(m) + "_op" for m in op_modes] + ["right_" + str(m) for m in op_modes])
+        op = MMTensor(
+            op,
+            axis_labels=["left_" + str(m) + "_op" for m in op_modes]
+            + ["left_" + str(m) for m in op_modes],
+        )
+        op_conj = MMTensor(
+            math.conj(op.array),
+            axis_labels=["right_" + str(m) + "_op" for m in op_modes]
+            + ["right_" + str(m) for m in op_modes],
+        )
         return (op @ dm @ op_conj).array
-    
+
     if op.ndim == 4 * len(op_modes):
-        op = MMTensor(op, axis_labels =[ "left_" + str(m) + "_op" for m in op_modes] + ["left_" + str(m) for m in op_modes] + ["right_" + str(m) + "_op" for m in op_modes] + ["right_" + str(m) for m in op_modes])
+        op = MMTensor(
+            op,
+            axis_labels=["left_" + str(m) + "_op" for m in op_modes]
+            + ["left_" + str(m) for m in op_modes]
+            + ["right_" + str(m) + "_op" for m in op_modes]
+            + ["right_" + str(m) for m in op_modes],
+        )
         return (op @ dm).array
 
 
@@ -378,7 +395,7 @@ def apply_op_to_ket(op, ket, op_indices):
         op (array): the operator to be applied, either a unitary, a kraus operator, or a channel
         ket (array): the ket to which the operator is applied
         op_modes (list): the modes the operator acts on (counting from 0)
-    
+
     Returns:
         array: the resulting ket
     """
@@ -387,7 +404,11 @@ def apply_op_to_ket(op, ket, op_indices):
     ket = MMTensor(ket, axis_labels=["left_" + str(i) for i in range(ket.ndim)])
 
     if op.ndim == 2 * len(op_indices):
-        op = MMTensor(op, axis_labels=["left_" + str(m) + "_op" for m in op_indices] + ["left_" + str(m) for m in op_indices])
+        op = MMTensor(
+            op,
+            axis_labels=["left_" + str(m) + "_op" for m in op_indices]
+            + ["left_" + str(m) for m in op_indices],
+        )
         return (op @ ket).array
 
 

--- a/mrmustard/physics/fock.py
+++ b/mrmustard/physics/fock.py
@@ -365,11 +365,11 @@ def apply_op_to_dm(op, dm, op_modes):
             + ["left_" + str(m) for m in op_modes],
         )
         op_conj = MMTensor(
-            math.conj(op.array),
+            math.conj(op.tensor),
             axis_labels=["right_" + str(m) + "_op" for m in op_modes]
             + ["right_" + str(m) for m in op_modes],
         )
-        return (op @ dm @ op_conj).array
+        return (op @ dm @ op_conj).tensor
 
     if op.ndim == 4 * len(op_modes):
         op = MMTensor(
@@ -379,7 +379,7 @@ def apply_op_to_dm(op, dm, op_modes):
             + ["right_" + str(m) + "_op" for m in op_modes]
             + ["right_" + str(m) for m in op_modes],
         )
-        return (op @ dm).array
+        return (op @ dm).tensor
 
     raise ValueError(
         "Operator should either have 2 or 4 times as many indices as the number of modes it acts on."
@@ -410,7 +410,7 @@ def apply_op_to_ket(op, ket, op_indices):
             axis_labels=["left_" + str(m) + "_op" for m in op_indices]
             + ["left_" + str(m) for m in op_indices],
         )
-        return (op @ ket).array
+        return (op @ ket).tensor
 
     raise ValueError(
         "Operator should either have 2 times as many indices as the number of modes it acts on."

--- a/tests/test_lab/test_states.py
+++ b/tests/test_lab/test_states.py
@@ -268,3 +268,33 @@ def test_ket_from_pure_dm(n, cutoffs):
 
     # check test state calculated the same ket as the original state
     assert np.allclose(test_ket, fock_state.ket())
+
+
+def test_ket_probability():
+    state = State(ket = np.array([0.5, 0.5]))
+    assert np.isclose(state.probability, 2 * 0.5 ** 2)
+
+def test_dm_probability():
+    state = State(dm = np.array([[0.4, 0.1], [0.1, 0.4]]))
+    assert np.isclose(state.probability, 0.8)
+
+def test_padding_ket():
+    state = State(ket = SqueezedVacuum(r=1.0).ket(cutoffs=[20]))
+    assert len(state.ket(cutoffs=[10])) == 10
+    assert len(state._ket) == 20
+
+def test_padding_dm():
+    state = State(dm = (SqueezedVacuum(r=1.0) >> Attenuator(0.6)).dm(cutoffs=[20]))
+    assert tuple(int(c) for c in state.dm(cutoffs=[10]).shape) == (10,10)
+    assert tuple(int(c) for c in state._dm.shape) == (20,20)
+
+def test_state_repr_small_prob():
+    state = State(ket = np.array([0.0001, 0.0001]))
+    table = state._repr_markdown_()
+    assert '2.000e-06 %' in table
+
+def test_state_repr_big_prob():
+    state = State(ket = np.array([0.5, 0.5]))
+    table = state._repr_markdown_()
+    assert '50.000%' in table
+

--- a/tests/test_math/test_mmtensor.py
+++ b/tests/test_math/test_mmtensor.py
@@ -15,13 +15,12 @@
 """
 Unit tests for the :class:`MMTensor`.
 """
-
+import pytest
 from mrmustard.math.mmtensor import MMTensor
 from mrmustard.math import Math
-
 math = Math()
 import numpy as np
-import pytest
+
 
 
 def test_mmtensor_creation():

--- a/tests/test_math/test_mmtensor.py
+++ b/tests/test_math/test_mmtensor.py
@@ -1,0 +1,60 @@
+# Copyright 2023 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for the :class:`MMTensor`.
+"""
+
+from mrmustard.math.mmtensor import MMTensor
+from mrmustard.math import Math; math = Math()
+import numpy as np
+import pytest
+
+def test_mmtensor_creation():
+    """Test creation of MMTensor"""
+    array = np.array([[1, 2, 3]])
+    mmtensor = MMTensor(array)
+    assert isinstance(mmtensor, MMTensor)
+    assert isinstance(mmtensor.tensor, np.ndarray)
+    assert mmtensor.axis_labels == ["0", "1"]
+
+def test_mmtensor_creation_with_axis_labels():
+    """Test creation of MMTensor with axis labels"""
+    array = np.array([[[1, 2, 3]]])
+    mmtensor = MMTensor(array, axis_labels=["a", "b", "c"])
+    assert isinstance(mmtensor, MMTensor)
+    assert isinstance(mmtensor.tensor, np.ndarray)
+    assert mmtensor.axis_labels == ["a", "b", "c"]
+
+def test_mmtensor_creation_with_axis_labels_wrong_length():
+    """Test creation of MMTensor with axis labels of wrong length"""
+    array = np.array([1, 2, 3])
+    with pytest.raises(ValueError):
+        MMTensor(array, axis_labels=["a", "b"])
+
+def test_mmtensor_transposes_labels_too():
+    """Test that MMTensor transposes axis labels"""
+    array = np.array([[1, 2, 3], [4, 5, 6]])
+    mmtensor = MMTensor(array, axis_labels=["a", "b"])
+    mmtensor = mmtensor.transpose([1, 0])
+    assert mmtensor.axis_labels == ["b", "a"]
+
+def test_mmtensor_contract():
+    """Test that MMTensor contracts correctly"""
+    array = np.array([[1, 2], [3, 4]])
+    trace = MMTensor(array, axis_labels=["a", "a"]).contract().tensor
+    assert trace == 5
+
+
+

--- a/tests/test_math/test_mmtensor.py
+++ b/tests/test_math/test_mmtensor.py
@@ -17,9 +17,12 @@ Unit tests for the :class:`MMTensor`.
 """
 
 from mrmustard.math.mmtensor import MMTensor
-from mrmustard.math import Math; math = Math()
+from mrmustard.math import Math
+
+math = Math()
 import numpy as np
 import pytest
+
 
 def test_mmtensor_creation():
     """Test creation of MMTensor"""
@@ -29,6 +32,7 @@ def test_mmtensor_creation():
     assert isinstance(mmtensor.tensor, np.ndarray)
     assert mmtensor.axis_labels == ["0", "1"]
 
+
 def test_mmtensor_creation_with_axis_labels():
     """Test creation of MMTensor with axis labels"""
     array = np.array([[[1, 2, 3]]])
@@ -37,11 +41,13 @@ def test_mmtensor_creation_with_axis_labels():
     assert isinstance(mmtensor.tensor, np.ndarray)
     assert mmtensor.axis_labels == ["a", "b", "c"]
 
+
 def test_mmtensor_creation_with_axis_labels_wrong_length():
     """Test creation of MMTensor with axis labels of wrong length"""
     array = np.array([1, 2, 3])
     with pytest.raises(ValueError):
         MMTensor(array, axis_labels=["a", "b"])
+
 
 def test_mmtensor_transposes_labels_too():
     """Test that MMTensor transposes axis labels"""
@@ -50,11 +56,9 @@ def test_mmtensor_transposes_labels_too():
     mmtensor = mmtensor.transpose([1, 0])
     assert mmtensor.axis_labels == ["b", "a"]
 
+
 def test_mmtensor_contract():
     """Test that MMTensor contracts correctly"""
     array = np.array([[1, 2], [3, 4]])
     trace = MMTensor(array, axis_labels=["a", "a"]).contract().tensor
     assert trace == 5
-
-
-

--- a/tests/test_math/test_mmtensor.py
+++ b/tests/test_math/test_mmtensor.py
@@ -32,6 +32,16 @@ def test_mmtensor_creation():
     assert mmtensor.axis_labels == ["0", "1"]
 
 
+def test_mmtensor_creation_using_mmtensor():
+    """Test creation of MMTensor using MMTensor"""
+    array = np.array([[1, 2, 3]])
+    mmtensor = MMTensor(array)
+    mmtensor2 = MMTensor(mmtensor)
+    assert isinstance(mmtensor2, MMTensor)
+    assert mmtensor2.tensor is mmtensor.tensor
+    assert mmtensor2.axis_labels == ["0", "1"]
+
+
 def test_mmtensor_creation_with_axis_labels():
     """Test creation of MMTensor with axis labels"""
     array = np.array([[[1, 2, 3]]])

--- a/tests/test_math/test_mmtensor.py
+++ b/tests/test_math/test_mmtensor.py
@@ -18,9 +18,9 @@ Unit tests for the :class:`MMTensor`.
 import pytest
 from mrmustard.math.mmtensor import MMTensor
 from mrmustard.math import Math
+
 math = Math()
 import numpy as np
-
 
 
 def test_mmtensor_creation():

--- a/tests/test_physics/test_fock/test_fock.py
+++ b/tests/test_physics/test_fock/test_fock.py
@@ -193,7 +193,7 @@ def test_fock_trace_mode1():
     """tests that the Fock state is correctly traced out from mode 1"""
     state = Vacuum(2) >> Ggate(2) >> Attenuator([0.1, 0.1])
     from_gaussian = state.get_modes(0).dm([3])
-    from_fock = State(dm=state.dm([3,30])).get_modes(0).dm([3])
+    from_fock = State(dm=state.dm([3, 30])).get_modes(0).dm([3])
     assert np.allclose(from_gaussian, from_fock, atol=1e-5)
 
 
@@ -201,7 +201,7 @@ def test_fock_trace_mode0():
     """tests that the Fock state is correctly traced out from mode 0"""
     state = Vacuum(2) >> Ggate(2) >> Attenuator([0.1, 0.1])
     from_gaussian = state.get_modes(1).dm([3])
-    from_fock = State(dm=state.dm([30,3])).get_modes(1).dm([3])
+    from_fock = State(dm=state.dm([30, 3])).get_modes(1).dm([3])
     assert np.allclose(from_gaussian, from_fock, atol=1e-5)
 
 

--- a/tests/test_physics/test_fock/test_fock.py
+++ b/tests/test_physics/test_fock/test_fock.py
@@ -191,23 +191,23 @@ def test_dm_to_ket_error():
 
 def test_fock_trace_mode1():
     """tests that the Fock state is correctly traced out from mode 1"""
-    state = Vacuum(2) >> Ggate(2)
+    state = Vacuum(2) >> Ggate(2) >> Attenuator([0.1, 0.1])
     from_gaussian = state.get_modes(0).dm([3])
-    from_fock = State(dm=state.dm([40])).get_modes(0).dm([3])
+    from_fock = State(dm=state.dm([3,30])).get_modes(0).dm([3])
     assert np.allclose(from_gaussian, from_fock, atol=1e-5)
 
 
 def test_fock_trace_mode0():
     """tests that the Fock state is correctly traced out from mode 0"""
-    state = Vacuum(2) >> Ggate(2)
+    state = Vacuum(2) >> Ggate(2) >> Attenuator([0.1, 0.1])
     from_gaussian = state.get_modes(1).dm([3])
-    from_fock = State(dm=state.dm([40])).get_modes(1).dm([3])
+    from_fock = State(dm=state.dm([30,3])).get_modes(1).dm([3])
     assert np.allclose(from_gaussian, from_fock, atol=1e-5)
 
 
 def test_fock_trace_function():
     """tests that the Fock state is correctly traced"""
-    state = Vacuum(2) >> Ggate(2)
-    dm = state.dm([10, 10])
+    state = Vacuum(2) >> Ggate(2) >> Attenuator([0.1, 0.1])
+    dm = state.dm([3, 20])
     dm_traced = trace(dm, keep=[0])
     assert np.allclose(dm_traced, State(dm=dm).get_modes(0).dm(), atol=1e-5)


### PR DESCRIPTION
**Context:**
In MM we work with tensors all the time and we need to contract indices that have physical meaning. 
Wouldn't it be great if we could assign names to the indices and have an easy time contracting them?
This can be a good starting point for the TN project.

**Description of the Change:**
** drumroll **  introducing `MMTensor`, a wrapper around tensors that allows for an `axis_label` keyword and that overrides `__matmul__` in order to implement the index contraction.
As a first use case I use it in `apply_op_to_dm` and `apply_op_to_ket`, which are used somewhere in the `Transformation` class.

**Benefits:**
Very easy to contract tensors now.

**Possible Drawbacks:**
One needs to remember to extract the wrapped array for some applications.

**Related GitHub Issues:**
None
