### PR TITLE
Check if changelog entry is created on PRs

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -204,10 +204,6 @@ transposing the indices of the input tensor. Now `math.dagger` appropriately cal
 Hermitian conjugate of an operator.
   [(#156)](https://github.com/XanaduAI/MrMustard/pull/156)
 
-* The application of a Choi operator to a density matrix was resulting in a transposed dm. Now
-the order of the indices in the application of a choi operator to dm and ket is correct.
-  [(#188)](https://github.com/XanaduAI/MrMustard/pull/188)
-
 ### Documentation
 
 * The centralized [Xanadu Sphinx Theme](https://github.com/XanaduAI/xanadu-sphinx-theme)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -204,6 +204,10 @@ transposing the indices of the input tensor. Now `math.dagger` appropriately cal
 Hermitian conjugate of an operator.
   [(#156)](https://github.com/XanaduAI/MrMustard/pull/156)
 
+* The application of a Choi operator to a density matrix was resulting in a transposed dm. Now
+the order of the indices in the application of a choi operator to dm and ket is correct.
+  [(#188)](https://github.com/XanaduAI/MrMustard/pull/188)
+
 ### Documentation
 
 * The centralized [Xanadu Sphinx Theme](https://github.com/XanaduAI/xanadu-sphinx-theme)

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -15,6 +15,6 @@ jobs:
 
     - name: check changelog entry
       run: |
-        has_changelog=$(git diff --name-only -r HEAD^1 HEAD | grep .github/CHANGELOG.md)
-        [  -z "$has_changelog" ] && echo "No CHANGELOG entry detected 🛑" || echo "There's a CHANGELOG entry! 🎉"
-        [  -z "$has_changelog" ] && exit 1 || exit 0
+        has_changelog=$(git diff --name-only -r HEAD^1 HEAD | grep -q .github/CHANGELOG.md)
+        [  -z "$has_changelog" ] && echo "There's a CHANGELOG entry! 🎉" || echo "No CHANGELOG entry detected 🛑"
+        [  -z "$has_changelog" ] && exit 0 || exit 1

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,10 +1,12 @@
-name: Changelog entry
+name: changelog entry
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 jobs:
-  cahngelog:
+  changelog:
     runs-on: ubuntu-latest
+    if: contains( github.event.pull_request.labels.*.name, 'no changelog') != true
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,4 +1,4 @@
-name: changelog entry
+name: Changelog entry
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,17 @@
+name: Changelog entry
+on:
+  pull_request:
+
+jobs:
+  cahngelog:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 2
+
+    - name: check changelog entry
+      run: |
+        has_changelog=$(git diff --name-only -r HEAD^1 HEAD | grep .github/CHANGELOG.md)
+        [  -z "$has_changelog" ] && exit 0 || exit 1

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -16,5 +16,5 @@ jobs:
     - name: check changelog entry
       run: |
         has_changelog=$(git diff --name-only -r HEAD^1 HEAD | grep .github/CHANGELOG.md)
-        echo $has_changelog
+        [  -z "$has_changelog" ] && echo "No CHANGELOG entry detected 🛑" || echo "There's a CHANGELOG entry! 🎉"
         [  -z "$has_changelog" ] && exit 1 || exit 0

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -16,4 +16,5 @@ jobs:
     - name: check changelog entry
       run: |
         has_changelog=$(git diff --name-only -r HEAD^1 HEAD | grep .github/CHANGELOG.md)
+        echo $has_changelog
         [  -z "$has_changelog" ] && exit 0 || exit 1

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -17,4 +17,4 @@ jobs:
       run: |
         has_changelog=$(git diff --name-only -r HEAD^1 HEAD | grep .github/CHANGELOG.md)
         echo $has_changelog
-        [  -z "$has_changelog" ] && exit 0 || exit 1
+        [  -z "$has_changelog" ] && exit 1 || exit 0

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -15,6 +15,4 @@ jobs:
 
     - name: check changelog entry
       run: |
-        has_changelog=$(git diff --name-only -r HEAD^1 HEAD | grep -q .github/CHANGELOG.md)
-        [  -z "$has_changelog" ] && echo "There's a CHANGELOG entry! 🎉" || echo "No CHANGELOG entry detected 🛑"
-        [  -z "$has_changelog" ] && exit 0 || exit 1
+        git diff --name-only -r HEAD^1 HEAD | grep .github/CHANGELOG.md


### PR DESCRIPTION
**Context:**
Always forgetting to add entries to the CHANGELOG file?

**Description of the Change:**
Now github will remind you to do so — this PR implements a new CI workflow checking if an entry has been added to the CHANGELOG file. This check is not mandatory meaning it won't block the ability to merge the PR, however checks will appear as failed. In case no changelog entry is needed one can use the `no changelog` label to disable the check.

This PR also adds the changelog entry for PR #188.

**Benefits:**
No more PRs without CHANGELOG entries

**Possible Drawbacks:**
None