### PR TITLE
Improved autocutoff

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -157,6 +157,10 @@
 * Added multiple tests and improved the use of Hypothesis.
   [(#191)](https://github.com/XanaduAI/MrMustard/pull/191)
 
+* The `fock.autocutoff` function now uses the new diagonal methods for calculating a probability-based cutoff.
+  Use `settings.AUTOCUTOFF_PROBABILITY` to set the probability threshold.
+  [(#203)](https://github.com/XanaduAI/MrMustard/pull/203)
+
 ### Bug fixes
 
 * The `Dgate` and the `Rgate` now correctly parse the case when a single scalar is intended as the same parameter

--- a/mrmustard/__init__.py
+++ b/mrmustard/__init__.py
@@ -35,12 +35,11 @@ class Settings:
         self.HBAR = 2.0
         self.CHOI_R = 0.881373587019543  # np.arcsinh(1.0)
         self.DEBUG = False
-        # clip(mean + 5*std, min, max) when auto-detecting the Fock cutoff
-        self.AUTOCUTOFF_STDEV_FACTOR = 5
+        self.AUTOCUTOFF_NORM = 0.999  # capture at least 99.9% of the probability
         self.AUTOCUTOFF_MAX_CUTOFF = 100
         self.AUTOCUTOFF_MIN_CUTOFF = 1
         self.CIRCUIT_DECIMALS = 3
-        # using cutoff=5 for each mode when determining if two transformations in fock repr are equal
+        # use cutoff=5 for each mode when determining if two transformations in fock repr are equal
         self.EQ_TRANSFORMATION_CUTOFF = 5
         self.EQ_TRANSFORMATION_RTOL_FOCK = 1e-3
         self.EQ_TRANSFORMATION_RTOL_GAUSS = 1e-6

--- a/mrmustard/__init__.py
+++ b/mrmustard/__init__.py
@@ -35,7 +35,7 @@ class Settings:
         self.HBAR = 2.0
         self.CHOI_R = 0.881373587019543  # np.arcsinh(1.0)
         self.DEBUG = False
-        self.AUTOCUTOFF_NORM = 0.999  # capture at least 99.9% of the probability
+        self.AUTOCUTOFF_PROBABILITY = 0.999  # capture at least 99.9% of the probability
         self.AUTOCUTOFF_MAX_CUTOFF = 100
         self.AUTOCUTOFF_MIN_CUTOFF = 1
         self.CIRCUIT_DECIMALS = 3

--- a/mrmustard/lab/abstract/state.py
+++ b/mrmustard/lab/abstract/state.py
@@ -173,10 +173,7 @@ class State:
         if self._cutoffs is not None:
             return self._cutoffs  # TODO: allow self._cutoffs = [N, None]
         if self._ket is None and self._dm is None:
-            return fock.autocutoffs(
-                self.number_stdev, self.number_means
-            )  # TODO: move autocutoffs in gaussian.py and pass cov, means
-
+            return fock.autocutoffs(self.cov, self.means, settings.AUTOCUTOFF_NORM)
         return list(
             self.fock.shape[: self.num_modes]
         )  # NOTE: triggered only if the fock representation already exists
@@ -338,9 +335,11 @@ class State:
         Note that the returned state is not normalized. To normalize a state you can use
         ``mrmustard.physics.normalize``.
         """
+        # import pdb
+
+        # pdb.set_trace()
         if isinstance(other, State):
             return self._project_onto_state(other)
-
         try:
             return other.dual(self)
         except AttributeError as e:

--- a/mrmustard/lab/abstract/state.py
+++ b/mrmustard/lab/abstract/state.py
@@ -173,7 +173,7 @@ class State:
         if self._cutoffs is not None:
             return self._cutoffs  # TODO: allow self._cutoffs = [N, None]
         if self._ket is None and self._dm is None:
-            return fock.autocutoffs(self.cov, self.means, settings.AUTOCUTOFF_NORM)
+            return fock.autocutoffs(self.cov, self.means, settings.AUTOCUTOFF_PROBABILITY)
         return list(
             self.fock.shape[: self.num_modes]
         )  # NOTE: triggered only if the fock representation already exists

--- a/mrmustard/physics/fock.py
+++ b/mrmustard/physics/fock.py
@@ -57,14 +57,14 @@ def fock_state(n: Sequence[int]) -> Tensor:
     return psi
 
 
-def autocutoffs(cov: Matrix, means: Vector, norm: float):
+def autocutoffs(cov: Matrix, means: Vector, probability: float):
     r"""Returns the cutoffs of a Gaussian state by computing the 1-mode marginals until
-    the norm of the marginal is less than ``norm``.
+    the probability of the marginal is less than ``probability``.
 
     Args:
         cov: the covariance matrix
         means: the means vector
-        norm: the cutoff norm
+        probability: the cutoff probability
 
     Returns:
         Tuple[int, ...]: the suggested cutoffs
@@ -74,12 +74,12 @@ def autocutoffs(cov: Matrix, means: Vector, norm: float):
     for i in range(M):
         cov_i = np.array([[cov[i, i], cov[i, i + M]], [cov[i + M, i], cov[i + M, i + M]]])
         means_i = np.array([means[i], means[i + M]])
-        # apply 1-d recursion until norm is less than 0.99
+        # apply 1-d recursion until probability is less than 0.99
         A, B, C = [math.asnumpy(x) for x in wigner_to_bargmann_rho(cov_i, means_i)]
         diag = fock_representation_diagonal_amps(A, B, C, 1, cutoffs=[100])[0]
-        # find at what index in the cumsum the norm is more than 0.99
+        # find at what index in the cumsum the probability is more than 0.99
         for i, val in enumerate(np.cumsum(diag)):
-            if val > norm:
+            if val > probability:
                 cutoffs.append(max(i + 1, settings.AUTOCUTOFF_MIN_CUTOFF))
                 break
         else:

--- a/mrmustard/physics/fock.py
+++ b/mrmustard/physics/fock.py
@@ -56,28 +56,28 @@ def fock_state(n: Sequence[int]) -> Tensor:
     return psi
 
 
-def autocutoffs(
-    number_stdev: Matrix, number_means: Vector, max_cutoff: int = None, min_cutoff: int = None
-) -> Tuple[int, ...]:
-    r"""Returns the autocutoffs of a Wigner state.
+# def autocutoffs(
+#     number_stdev: Matrix, number_means: Vector, max_cutoff: int = None, min_cutoff: int = None
+# ) -> Tuple[int, ...]:
+#     r"""Returns the autocutoffs of a Wigner state.
 
-    Args:
-        number_stdev: the photon number standard deviation in each mode
-            (i.e. the square root of the diagonal of the covariance matrix)
-        number_means: the photon number means vector
-        max_cutoff: the maximum cutoff
+#     Args:
+#         number_stdev: the photon number standard deviation in each mode
+#             (i.e. the square root of the diagonal of the covariance matrix)
+#         number_means: the photon number means vector
+#         max_cutoff: the maximum cutoff
 
-    Returns:
-        Tuple[int, ...]: the suggested cutoffs
-    """
-    if max_cutoff is None:
-        max_cutoff = settings.AUTOCUTOFF_MAX_CUTOFF
-    if min_cutoff is None:
-        min_cutoff = settings.AUTOCUTOFF_MIN_CUTOFF
-    autocutoffs = settings.AUTOCUTOFF_MIN_CUTOFF + math.cast(
-        number_means + number_stdev * settings.AUTOCUTOFF_STDEV_FACTOR, "int32"
-    )
-    return [int(n) for n in math.clip(autocutoffs, min_cutoff, max_cutoff)]
+#     Returns:
+#         Tuple[int, ...]: the suggested cutoffs
+#     """
+#     if max_cutoff is None:
+#         max_cutoff = settings.AUTOCUTOFF_MAX_CUTOFF
+#     if min_cutoff is None:
+#         min_cutoff = settings.AUTOCUTOFF_MIN_CUTOFF
+#     autocutoffs = settings.AUTOCUTOFF_MIN_CUTOFF + math.cast(
+#         number_means + number_stdev * settings.AUTOCUTOFF_STDEV_FACTOR, "int32"
+#     )
+#     return [int(n) for n in math.clip(autocutoffs, min_cutoff, max_cutoff)]
 
 
 def wigner_to_fock_state(

--- a/mrmustard/physics/fock.py
+++ b/mrmustard/physics/fock.py
@@ -29,6 +29,7 @@ from mrmustard.physics.bargmann import (
     wigner_to_bargmann_U,
 )
 
+from mrmustard.math.numba.compactFock_diagonal_amps import fock_representation_diagonal_amps
 from mrmustard.math.mmtensor import MMTensor
 from mrmustard.math.caching import tensor_int_cache
 from mrmustard.types import List, Tuple, Tensor, Scalar, Matrix, Sequence, Vector
@@ -56,28 +57,34 @@ def fock_state(n: Sequence[int]) -> Tensor:
     return psi
 
 
-# def autocutoffs(
-#     number_stdev: Matrix, number_means: Vector, max_cutoff: int = None, min_cutoff: int = None
-# ) -> Tuple[int, ...]:
-#     r"""Returns the autocutoffs of a Wigner state.
+def autocutoffs(cov: Matrix, means: Vector, norm: float):
+    r"""Returns the cutoffs of a Gaussian state by computing the 1-mode marginals until
+    the norm of the marginal is less than ``norm``.
 
-#     Args:
-#         number_stdev: the photon number standard deviation in each mode
-#             (i.e. the square root of the diagonal of the covariance matrix)
-#         number_means: the photon number means vector
-#         max_cutoff: the maximum cutoff
+    Args:
+        cov: the covariance matrix
+        means: the means vector
+        norm: the cutoff norm
 
-#     Returns:
-#         Tuple[int, ...]: the suggested cutoffs
-#     """
-#     if max_cutoff is None:
-#         max_cutoff = settings.AUTOCUTOFF_MAX_CUTOFF
-#     if min_cutoff is None:
-#         min_cutoff = settings.AUTOCUTOFF_MIN_CUTOFF
-#     autocutoffs = settings.AUTOCUTOFF_MIN_CUTOFF + math.cast(
-#         number_means + number_stdev * settings.AUTOCUTOFF_STDEV_FACTOR, "int32"
-#     )
-#     return [int(n) for n in math.clip(autocutoffs, min_cutoff, max_cutoff)]
+    Returns:
+        Tuple[int, ...]: the suggested cutoffs
+    """
+    M = len(means) // 2
+    cutoffs = []
+    for i in range(M):
+        cov_i = np.array([[cov[i, i], cov[i, i + M]], [cov[i + M, i], cov[i + M, i + M]]])
+        means_i = np.array([means[i], means[i + M]])
+        # apply 1-d recursion until norm is less than 0.99
+        A, B, C = [math.asnumpy(x) for x in wigner_to_bargmann_rho(cov_i, means_i)]
+        diag = fock_representation_diagonal_amps(A, B, C, 1, cutoffs=[100])[0]
+        # find at what index in the cumsum the norm is more than 0.99
+        for i, val in enumerate(np.cumsum(diag)):
+            if val > norm:
+                cutoffs.append(max(i + 1, settings.AUTOCUTOFF_MIN_CUTOFF))
+                break
+        else:
+            cutoffs.append(settings.AUTOCUTOFF_MAX_CUTOFF)
+    return cutoffs
 
 
 def wigner_to_fock_state(

--- a/tests/test_lab/test_detectors.py
+++ b/tests/test_lab/test_detectors.py
@@ -390,9 +390,9 @@ class TestNormalization:
         produces a state with the expected norm."""
         leftover = Coherent(x=[2.0, 2.0]) << Fock(3, normalize=normalize)[0]
         assert np.isclose(
-            expected_norm * np.sqrt(settings.AUTOCUTOFF_NORM),
+            expected_norm * np.sqrt(settings.AUTOCUTOFF_PROBABILITY),
             physics.norm(leftover),
-            rtol=1 - settings.AUTOCUTOFF_NORM,
+            rtol=1 - settings.AUTOCUTOFF_PROBABILITY,
         )
 
     def test_norm_2mode_gaussian_normalized(self):

--- a/tests/test_lab/test_detectors.py
+++ b/tests/test_lab/test_detectors.py
@@ -389,7 +389,11 @@ class TestNormalization:
         """Checks that projecting a two-mode coherent state onto a number state
         produces a state with the expected norm."""
         leftover = Coherent(x=[2.0, 2.0]) << Fock(3, normalize=normalize)[0]
-        assert np.isclose(expected_norm, physics.norm(leftover), atol=1e-5)
+        assert np.isclose(
+            expected_norm * np.sqrt(settings.AUTOCUTOFF_NORM),
+            physics.norm(leftover),
+            rtol=1 - settings.AUTOCUTOFF_NORM,
+        )
 
     def test_norm_2mode_gaussian_normalized(self):
         """Checks that after projection the norm of the leftover state is as expected."""

--- a/tests/test_lab/test_gates_fock.py
+++ b/tests/test_lab/test_gates_fock.py
@@ -104,13 +104,13 @@ def test_single_mode_fock_equals_gaussian_ket(gate):
 def test_single_mode_fock_equals_gaussian_ket_dm_2(gate):
     """Test same state is obtained via fock representation or phase space
     for single mode circuits."""
-    cutoffs = [40]
-    gaussian_state = SqueezedVacuum(0.3)
+    cutoffs = [50]
+    gaussian_state = SqueezedVacuum(-0.1)
     fock_state = State(ket=gaussian_state.ket(cutoffs))
 
-    via_fock_space_dm = (fock_state >> gate >> Attenuator(0.2)).dm([10])
-    via_phase_space_dm = (gaussian_state >> gate >> Attenuator(0.2)).dm([10])
-    assert np.allclose(via_fock_space_dm, via_phase_space_dm)
+    via_fock_space_dm = (fock_state >> gate >> Attenuator(0.1)).dm([10])
+    via_phase_space_dm = (gaussian_state >> gate >> Attenuator(0.1)).dm([10])
+    assert np.allclose(via_fock_space_dm, via_phase_space_dm, atol=1e-5)
 
 
 @given(gate=two_mode_unitary_gate())


### PR DESCRIPTION
**Context:**
autocutoffs are a bit flimsy, it would be nice to have a norm-based autocutoff

**Description of the Change:**
Uses Robbe's new function to improve autocutoff: each mode now gets a cutoff such that if it were the marginal it would capture `settings.AUTOCUTOFF_PROBABILITY` probability (default 0.999).

**Benefits:**
Much more sensible autocutoffs

**Possible Drawbacks:**
Some users may need to update their code

**Related GitHub Issues:**
perhaps [#118](https://github.com/XanaduAI/MrMustard/issues/118)
