### PR TITLE
displays sign correctly

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -188,6 +188,9 @@
 * Various minor bug fixes.
 [(#202)](https://github.com/XanaduAI/MrMustard/pull/202)
 
+* The sign of parameters in the circuit drawer are now displayed correctly.
+  [(#209)](https://github.com/XanaduAI/MrMustard/pull/209)
+
 ### Documentation
 
 ### Contributors 

--- a/mrmustard/training/parametrized.py
+++ b/mrmustard/training/parametrized.py
@@ -81,10 +81,11 @@ class Parametrized:
         for _, value in self.kw_parameters:
             value = math.asnumpy(value)
             if value.ndim == 0:  # don't show arrays
-                value = np.round(value, decimals)
+                sign = "-" if value < 0 else ""
+                value = np.abs(np.round(value, decimals))
                 int_part = int(value)
                 decimal_part = np.round(value - int_part, decimals)
-                string = str(int_part) + f"{decimal_part:.{decimals}g}"[1:]
+                string = sign + str(int_part) + f"{decimal_part:.{decimals}g}"[1:]
             strings.append(string)
         return ", ".join(strings)
 


### PR DESCRIPTION
**Context:**
negative parameters were showing a 0 instead of the minus sign.

**Description of the Change:**
Fixes this issue

**Benefits:**
Correct parameters!

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None