### PR TITLE
Implement base 10 logarithm

### DIFF
--- a/mrmustard/math/math_interface.py
+++ b/mrmustard/math/math_interface.py
@@ -469,6 +469,17 @@ class MathInterface(ABC):
         """
 
     @abstractmethod
+    def log10(self, x: Tensor) -> Tensor:
+        r"""Returns the base 10 logarithm of ``x``.
+
+        Args:
+            x (array): array to take the base 10 logarithm of
+
+        Returns:
+            array: base 10 logarithm of ``x``
+        """
+
+    @abstractmethod
     def matmul(
         self,
         a: Tensor,

--- a/mrmustard/math/tensorflow.py
+++ b/mrmustard/math/tensorflow.py
@@ -186,6 +186,11 @@ class TFMath(MathInterface):
     def log(self, x: tf.Tensor) -> tf.Tensor:
         return tf.math.log(x)
 
+    def log10(self, x: tf.Tensor) -> tf.Tensor:
+        numerator = self.log(x)
+        denominator = self.log(tf.constant(10, dtype=numerator.dtype))
+        return numerator / denominator
+
     @Autocast()
     def matmul(
         self,

--- a/tests/test_math/test_special.py
+++ b/tests/test_math/test_special.py
@@ -16,6 +16,8 @@
 
 import numpy as np
 from scipy.special import eval_hermite, factorial
+
+from hypothesis import given, strategies as st
 from mrmustard.math import Math
 
 math = Math()
@@ -32,3 +34,12 @@ def test_reduction_to_renorm_physicists_polys():
     ).T
     expected = np.array([eval_hermite(i, x) / np.sqrt(factorial(i)) for i in range(len(vals))])
     assert np.allclose(vals, expected)
+
+
+@given(x=st.floats(0, 10))
+def test_log10(x):
+    """Tests base 10 logarithm."""
+    result = math.log10(x)
+    expected = np.log10(x)
+
+    assert np.isclose(result.numpy(), expected)


### PR DESCRIPTION
**Context:**
There is no log10 function in tensorflow, only the loge exist ([ref](https://github.com/tensorflow/tensorflow/issues/1666))

**Description of the Change:**
Implements log base 10.

**Benefits:**
Well... a 10/10 implementation of log_10

**Possible Drawbacks:**
Could use `tf.function` to compile it but this function is not used in any performance-critical code so far.

**Related GitHub Issues:**
None