### PR TITLE
Update typing.py

### DIFF
--- a/mrmustard/typing.py
+++ b/mrmustard/typing.py
@@ -33,7 +33,7 @@ __all__ = [
     "Tensor",
     "Trainable",
 ]
-from typing import Iterator, Protocol, Tuple, TypeVar, Union, runtime_checkable
+from typing import Iterator, Protocol, Tuple, TypeVar, Union, Optional, runtime_checkable
 
 import numpy as np
 


### PR DESCRIPTION
**Context:** A few files import Optional from mrmustard.typing, but since we no longer import all from the typing library in that file, then Optional is no longer defined

**Description of the Change:** Add Optional to list of things imported from typing

**Benefits:** No more bug

**Possible Drawbacks:**

**Related GitHub Issues:**
