### PR TITLE
Fix displacement gate gradient

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -19,7 +19,7 @@
 
   def cost_fn():
       ...
-  
+
   def as_dB(cost):
       delta = np.sqrt(np.log(1 / (abs(cost) ** 2)) / (2 * np.pi))
       cost_dB = -10 * np.log10(delta**2)
@@ -43,6 +43,9 @@
 ### Improvements
 
 ### Bug fixes
+
+* Exposes the `numpy_function` method of the Tensorflow backend, fixing a bug with the `Dgate` optimization.
+  [(#230)](https://github.com/XanaduAI/MrMustard/pull/230)
 
 ### Documentation
 

--- a/mrmustard/math/tensorflow.py
+++ b/mrmustard/math/tensorflow.py
@@ -547,6 +547,20 @@ class TFMath(MathInterface):
         """Decorator to define a function with a custom gradient."""
         return tf.custom_gradient(func)
 
+    @staticmethod
+    def numpy_function(func, inp, Tout):
+        """Wraps a python function and uses it as a TensorFlow op.
+
+        Args:
+            func: A Python function, which accepts numpy.ndarray objects as arguments and returns a list of numpy.ndarray objects (or a single numpy.ndarray).
+            inp: A list of tf.Tensor objects.
+            Tout: A list or tuple of tensorflow data types or a single tensorflow data
+
+        Returns:
+            Single or list of tf.Tensor which func computes.
+        """
+        return tf.numpy_function(func, inp, Tout)
+
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     # Extras (not in the Interface)
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/mrmustard/math/tensorflow.py
+++ b/mrmustard/math/tensorflow.py
@@ -547,20 +547,6 @@ class TFMath(MathInterface):
         """Decorator to define a function with a custom gradient."""
         return tf.custom_gradient(func)
 
-    @staticmethod
-    def numpy_function(func, inp, Tout):
-        """Wraps a python function and uses it as a TensorFlow op.
-
-        Args:
-            func: A Python function, which accepts numpy.ndarray objects as arguments and returns a list of numpy.ndarray objects (or a single numpy.ndarray).
-            inp: A list of tf.Tensor objects.
-            Tout: A list or tuple of tensorflow data types or a single tensorflow data
-
-        Returns:
-            Single or list of tf.Tensor which func computes.
-        """
-        return tf.numpy_function(func, inp, Tout)
-
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     # Extras (not in the Interface)
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/mrmustard/physics/fock.py
+++ b/mrmustard/physics/fock.py
@@ -932,8 +932,8 @@ def displacement(r, phi, cutoff, tol=1e-15):
 
     def grad(dy):  # pragma: no cover
         Dr, Dphi = math.numpy_function(_grad_displacement, (gate, r, phi), (gate.dtype,) * 2)
-        grad_r = math.real(math.reduce_sum(dy * math.conj(Dr)))
-        grad_phi = math.real(math.reduce_sum(dy * math.conj(Dphi)))
+        grad_r = math.real(math.sum(dy * math.conj(Dr)))
+        grad_phi = math.real(math.sum(dy * math.conj(Dphi)))
         return grad_r, grad_phi, None
 
     return gate, grad

--- a/mrmustard/physics/fock.py
+++ b/mrmustard/physics/fock.py
@@ -931,7 +931,7 @@ def displacement(r, phi, cutoff, tol=1e-15):
         gate = math.eye(cutoff, dtype="complex128")
 
     def grad(dy):  # pragma: no cover
-        Dr, Dphi = math.numpy_function(_grad_displacement, (gate, r, phi), (gate.dtype,) * 2)
+        Dr, Dphi = _grad_displacement(math.asnumpy(gate), math.asnumpy(r), math.asnumpy(phi))
         grad_r = math.real(math.sum(dy * math.conj(Dr)))
         grad_phi = math.real(math.sum(dy * math.conj(Dphi)))
         return grad_r, grad_phi, None

--- a/tests/test_training/test_opt.py
+++ b/tests/test_training/test_opt.py
@@ -362,4 +362,3 @@ def test_dgate_optimization():
 
     opt = Optimizer()
     opt.minimize(cost_fn, by_optimizing=[dgate])
-

--- a/tests/test_training/test_opt.py
+++ b/tests/test_training/test_opt.py
@@ -29,10 +29,11 @@ from mrmustard.lab.gates import (
     Ggate,
     Interferometer,
     RealInterferometer,
+    Dgate
 )
 from mrmustard.lab.circuit import Circuit
 from mrmustard.training import Optimizer, Parametrized
-from mrmustard.lab.states import Vacuum, SqueezedVacuum
+from mrmustard.lab.states import Vacuum, SqueezedVacuum, DisplacedSqueezed
 from mrmustard.physics import fidelity
 from mrmustard.physics.gaussian import trace, von_neumann_entropy
 from mrmustard import settings
@@ -347,3 +348,18 @@ def test_opt_backend_param():
     opt.minimize(cost_fn_sympl, by_optimizing=[S, r_angle])
 
     assert np.allclose(r_angle.numpy(), rotation_angle / 2, atol=1e-2)
+
+def test_dgate_optimization():
+    """Test that Dgate is optimized correctly."""
+    settings.SEED = 24
+
+    dgate = Dgate(x_trainable=True, y_trainable=True)
+    target_state = DisplacedSqueezed(r=0.0, x=1.0, y=1.0)
+
+    def cost_fn():
+        state_out = Vacuum(1) >> dgate
+        return 1 - fidelity(state_out, target_state)
+
+    opt = Optimizer()
+    opt.minimize(cost_fn, by_optimizing=[dgate])
+

--- a/tests/test_training/test_opt.py
+++ b/tests/test_training/test_opt.py
@@ -29,7 +29,7 @@ from mrmustard.lab.gates import (
     Ggate,
     Interferometer,
     RealInterferometer,
-    Dgate
+    Dgate,
 )
 from mrmustard.lab.circuit import Circuit
 from mrmustard.training import Optimizer, Parametrized
@@ -368,6 +368,7 @@ def test_opt_backend_param():
     opt.minimize(cost_fn_sympl, by_optimizing=[S, r_angle])
 
     assert np.allclose(r_angle.numpy(), rotation_angle / 2, atol=1e-2)
+
 
 def test_dgate_optimization():
     """Test that Dgate is optimized correctly."""


### PR DESCRIPTION
**Context:**
Recently the `Dgate` was moved from The Walrus into MrMustard. The method `numpy_function` of the tf backend is required to compute the gradients and it was not exposed in the interface hence generating an error when trying to optimize the gate.

**Description of the Change:**
Exposes the `numpy_function` method of the tf backend.

**Benefits:**
Dgate can be optimized

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None