### PR TITLE
Fock projection bugfix

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -80,7 +80,7 @@
 ### Bug fixes
 
 * When projecting a Gaussian state onto a Fock state, the upper limit of the autocutoff now respect the Fock projection.
-  [(#240)](https://github.com/XanaduAI/MrMustard/pull/240)
+  [(#245)](https://github.com/XanaduAI/MrMustard/pull/245)
 
 ### Documentation
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -79,6 +79,9 @@
 
 ### Bug fixes
 
+* When projecting a Gaussian state onto a Fock state, the upper limit of the autocutoff now respect the Fock projection.
+  [(#240)](https://github.com/XanaduAI/MrMustard/pull/240)
+
 ### Documentation
 
 ### Contributors

--- a/mrmustard/lab/states.py
+++ b/mrmustard/lab/states.py
@@ -486,22 +486,29 @@ class Fock(Parametrized, State):
     def _preferred_projection(self, other: State, mode_indices: Sequence[int]):
         r"""Preferred method to perform a projection onto this state (rather than the default one).
 
-        E.g. ``ket << Fock(1, modes=[3])`` is equivalent to ``ket[:,:,:,1]`` if ``ket`` has 4 modes
-        E.g. ``dm << Fock(1, modes=[1])`` is equivalent to ``dm[:,1,:,1]`` if ``dm`` has 2 modes
+        E.g. ``ket << Fock([1], modes=[3])`` is equivalent to ``ket[:,:,:,1]`` if ``ket`` has 4 modes
+        E.g. ``dm << Fock([1], modes=[1])`` is equivalent to ``dm[:,1,:,1]`` if ``dm`` has 2 modes
 
         Args:
             other: the state to project onto this state
             mode_indices: the indices of the modes of other that we want to project onto self
         """
         getitem = []
+        cutoffs = []
         used = 0
         for i, _ in enumerate(other.modes):
             if i in mode_indices:
                 getitem.append(self._n[used])
+                cutoffs.append(self._n[used] + 1)
                 used += 1
             else:
                 getitem.append(slice(None))
-        output = other.fock[tuple(getitem)] if other.is_pure else other.fock[tuple(getitem) * 2]
+                cutoffs.append(other.cutoffs[i])
+        output = (
+            other.ket(cutoffs)[tuple(getitem)]
+            if other.is_pure
+            else other.dm(cutoffs)[tuple(getitem) * 2]
+        )
         if self._normalize:
             return fock.normalize(output, is_dm=other.is_mixed)
         return output

--- a/tests/test_lab/test_gates_fock.py
+++ b/tests/test_lab/test_gates_fock.py
@@ -213,3 +213,20 @@ def test_raise_interferometer_error():
 def test_choi_cutoffs():
     output = State(dm=Coherent([1.0, 1.0]).dm([5, 8])) >> Attenuator(0.5, modes=[1])
     assert output.cutoffs == [5, 8]  # cutoffs are respected by the gate
+
+
+def test_measure_with_fock():
+    cov = np.array(
+        [
+            [1.08341848, 0.26536937, 0.0, 0.0],
+            [0.26536937, 1.05564949, 0.0, 0.0],
+            [0.0, 0.0, 0.98356475, -0.24724869],
+            [0.0, 0.0, -0.24724869, 1.00943755],
+        ]
+    )
+
+    state = State(means=np.zeros(4), cov=cov)
+
+    n_detect = 2
+    state_out = state << Fock([n_detect], modes=[1])
+    assert np.allclose(state_out.ket(), np.array([0.00757899, 0.0]))

--- a/tests/test_lab/test_gates_fock.py
+++ b/tests/test_lab/test_gates_fock.py
@@ -216,6 +216,7 @@ def test_choi_cutoffs():
 
 
 def test_measure_with_fock():
+    "tests that the autocutoff respects the fock projection cutoff"
     cov = np.array(
         [
             [1.08341848, 0.26536937, 0.0, 0.0],


### PR DESCRIPTION
**Context:**
When projecting onto Fock the autocutoff doesn't check the photon number of the Fock projection.

**Description of the Change:**
Now it does. Added a test too.

**Benefits:**
No unnecessary cutoff errors when projecting onto a Fock state

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None