### PR TITLE
bugfix, test and changelog entry

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -89,6 +89,9 @@
 * The displacement of the dual of an operation had the wrong sign
   [(#239)](https://github.com/XanaduAI/MrMustard/pull/239)
 
+* When projecting a Gaussian state onto a Fock state, the upper limit of the autocutoff now respect the Fock projection.
+  [(#246)](https://github.com/XanaduAI/MrMustard/pull/246)
+
 ### Documentation
 
 ### Contributors

--- a/mrmustard/lab/states.py
+++ b/mrmustard/lab/states.py
@@ -81,7 +81,7 @@ class Coherent(Parametrized, State):
         x_bounds (float or None, float or None): The bounds of the x-displacement.
         y_bounds (float or None, float or None): The bounds of the y-displacement.
         modes (optional List[int]): The modes of the coherent state.
-        cutoffs (Sequence[int], default=None): set to force the fock cutoffs of the state
+        cutoffs (Sequence[int], default=None): set to force the cutoff dimensions of the state
         normalize (bool, default False): whether to normalize the leftover state when projecting onto ``Coherent``
     """
 

--- a/tests/test_lab/test_gates_fock.py
+++ b/tests/test_lab/test_gates_fock.py
@@ -299,3 +299,21 @@ def test_raise_interferometer_error():
 def test_choi_cutoffs():
     output = State(dm=Coherent([1.0, 1.0]).dm([5, 8])) >> Attenuator(0.5, modes=[1])
     assert output.cutoffs == [5, 8]  # cutoffs are respected by the gate
+
+
+def test_measure_with_fock():
+    "tests that the autocutoff respects the fock projection cutoff"
+    cov = np.array(
+        [
+            [1.08341848, 0.26536937, 0.0, 0.0],
+            [0.26536937, 1.05564949, 0.0, 0.0],
+            [0.0, 0.0, 0.98356475, -0.24724869],
+            [0.0, 0.0, -0.24724869, 1.00943755],
+        ]
+    )
+
+    state = State(means=np.zeros(4), cov=cov)
+
+    n_detect = 2
+    state_out = state << Fock([n_detect], modes=[1])
+    assert np.allclose(state_out.ket(), np.array([0.00757899, 0.0]))


### PR DESCRIPTION
**Context:**
When projecting onto Fock the autocutoff doesn't check the photon number of the Fock projection. Thanks to Jacob for spotting it.

**Description of the Change:**
Now it does. Added a test too.

**Benefits:**
No unnecessary cutoff errors when projecting onto a Fock state

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None