### PR TITLE
Compact fock correction

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -95,6 +95,9 @@
 * When projecting a Gaussian state onto a Fock state, the upper limit of the autocutoff now respect the Fock projection.
   [(#246)](https://github.com/XanaduAI/MrMustard/pull/246)
 
+* Fixed a bug for the algorithms that allow faster PNR sampling from Gaussian circuits using density matrices. When the 
+cutoff of the first detector is equal to 1, the resulting density matrix is now correct.
+
 ### Documentation
 
 ### Contributors

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -101,7 +101,8 @@ cutoff of the first detector is equal to 1, the resulting density matrix is now 
 ### Documentation
 
 ### Contributors
-[Filippo Miatto](https://github.com/ziofil), [Zeyue Niu](https://github.com/zeyueN)
+[Filippo Miatto](https://github.com/ziofil), [Zeyue Niu](https://github.com/zeyueN), 
+[Robbe De Prins](https://github.com/rdprins)
 
 ---
 

--- a/mrmustard/math/numba/compactFock_1leftoverMode_amps.py
+++ b/mrmustard/math/numba/compactFock_1leftoverMode_amps.py
@@ -261,7 +261,8 @@ def fock_representation_1leftoverMode_amps_NUMBA(
     for sum_params in range(sum(cutoffs_tail)):
         for params in dict_params[sum_params]:
             # diagonal pivots: aa,bb,cc,dd,...
-            if params[0] < cutoffs_tail[0] - 1:
+            if (cutoffs_tail[0] == 1) or (params[0] < cutoffs_tail[0] - 1):
+
                 arr1 = use_diag_pivot(
                     A, B, M - 1, cutoff_leftoverMode, cutoffs_tail, params, arr0, arr1
                 )

--- a/mrmustard/math/numba/compactFock_1leftoverMode_amps.py
+++ b/mrmustard/math/numba/compactFock_1leftoverMode_amps.py
@@ -262,7 +262,6 @@ def fock_representation_1leftoverMode_amps_NUMBA(
         for params in dict_params[sum_params]:
             # diagonal pivots: aa,bb,cc,dd,...
             if (cutoffs_tail[0] == 1) or (params[0] < cutoffs_tail[0] - 1):
-
                 arr1 = use_diag_pivot(
                     A, B, M - 1, cutoff_leftoverMode, cutoffs_tail, params, arr0, arr1
                 )

--- a/mrmustard/math/numba/compactFock_1leftoverMode_grad.py
+++ b/mrmustard/math/numba/compactFock_1leftoverMode_grad.py
@@ -655,7 +655,7 @@ def fock_representation_1leftoverMode_grad_NUMBA(
     for sum_params in range(sum(cutoffs_tail)):
         for params in dict_params[sum_params]:
             # diagonal pivots: aa,bb,cc,dd,...
-            if params[0] < cutoffs_tail[0] - 1:
+            if (cutoffs_tail[0] == 1) or (params[0] < cutoffs_tail[0] - 1):
                 arr1_dA, arr1_dB = use_diag_pivot_grad(
                     A,
                     B,

--- a/mrmustard/math/numba/compactFock_diagonal_amps.py
+++ b/mrmustard/math/numba/compactFock_diagonal_amps.py
@@ -142,7 +142,7 @@ def fock_representation_diagonal_amps_NUMBA(
     for sum_params in range(sum(cutoffs)):
         for params in dict_params[sum_params]:
             # diagonal pivots: aa,bb,cc,dd,...
-            if params[0] < cutoffs[0] - 1:
+            if (cutoffs[0] == 1) or (params[0] < cutoffs[0] - 1):
                 arr1 = use_diag_pivot(A, B, M, cutoffs, params, arr0, arr1)
             # off-diagonal pivots: d=0: (a+1)a,bb,cc,dd,... | d=1: 00,(b+1)b,cc,dd | 00,00,(c+1)c,dd | ...
             for d in range(M):

--- a/mrmustard/math/numba/compactFock_diagonal_grad.py
+++ b/mrmustard/math/numba/compactFock_diagonal_grad.py
@@ -254,7 +254,7 @@ def fock_representation_diagonal_grad_NUMBA(
     for sum_params in range(sum(cutoffs)):
         for params in dict_params[sum_params]:
             # diagonal pivots: aa,bb,cc,dd,...
-            if params[0] < cutoffs[0] - 1:
+            if (cutoffs[0] == 1) or (params[0] < cutoffs[0] - 1):
                 arr1_dA, arr1_dB = use_diag_pivot_grad(
                     A, B, M, cutoffs, params, arr0, arr1, arr0_dA, arr1_dA, arr0_dB, arr1_dB
                 )

--- a/tests/test_math/test_compactFock.py
+++ b/tests/test_math/test_compactFock.py
@@ -14,6 +14,13 @@ from tests.random import n_mode_mixed_state
 
 math = Math()  # use methods in math if you want them to be differentiable
 
+def allowed_cutoffs(max_cutoffs):
+    r'''Generate all cutoffs from (1,)*M to max_cutoffs'''
+    res = []
+    for idx in np.ndindex(max_cutoffs):
+        cutoffs = np.array(idx)+1
+        res.append(tuple(cutoffs))
+    return res
 
 @st.composite
 def random_ABC(draw, M):
@@ -29,48 +36,48 @@ def random_ABC(draw, M):
 @given(random_ABC(M=3))
 def test_compactFock_diagonal(A_B_G0):
     """Test getting Fock amplitudes if all modes are detected (math.hermite_renormalized_diagonal)"""
-    cutoffs = [7, 4, 8]
-    A, B, G0 = A_B_G0  # Create random state (M mode Gaussian state with displacement)
+    for cutoffs in allowed_cutoffs((7, 7, 7)):
+        A, B, G0 = A_B_G0  # Create random state (M mode Gaussian state with displacement)
 
-    # Vanilla MM
-    G_ref = math.hermite_renormalized(
-        math.conj(-A), math.conj(B), math.conj(G0), shape=list(cutoffs) * 2
-    ).numpy()  # note: shape=[C1,C2,C3,...,C1,C2,C3,...]
+        # Vanilla MM
+        G_ref = math.hermite_renormalized(
+            math.conj(-A), math.conj(B), math.conj(G0), shape=list(cutoffs) * 2
+        ).numpy()  # note: shape=[C1,C2,C3,...,C1,C2,C3,...]
 
-    # Extract diagonal amplitudes from vanilla MM
-    ref_diag = np.zeros(cutoffs, dtype=np.complex128)
-    for inds in np.ndindex(*cutoffs):
-        inds_expanded = list(inds) + list(inds)  # a,b,c,a,b,c
-        ref_diag[inds] = G_ref[tuple(inds_expanded)]
+        # Extract diagonal amplitudes from vanilla MM
+        ref_diag = np.zeros(cutoffs, dtype=np.complex128)
+        for inds in np.ndindex(*cutoffs):
+            inds_expanded = list(inds) + list(inds)  # a,b,c,a,b,c
+            ref_diag[inds] = G_ref[tuple(inds_expanded)]
 
-    # New MM
-    G_diag = math.hermite_renormalized_diagonal(math.conj(-A), math.conj(B), math.conj(G0), cutoffs)
-    assert np.allclose(ref_diag, G_diag)
+        # New MM
+        G_diag = math.hermite_renormalized_diagonal(math.conj(-A), math.conj(B), math.conj(G0), cutoffs)
+        assert np.allclose(ref_diag, G_diag)
 
 
 @given(random_ABC(M=3))
 def test_compactFock_1leftover(A_B_G0):
     """Test getting Fock amplitudes if all but the first mode are detected (math.hermite_renormalized_1leftoverMode)"""
-    cutoffs = [7, 4, 8]
-    A, B, G0 = A_B_G0  # Create random state (M mode Gaussian state with displacement)
+    for cutoffs in allowed_cutoffs((7,7,7)):
+        A, B, G0 = A_B_G0  # Create random state (M mode Gaussian state with displacement)
 
-    # New algorithm
-    G_leftover = math.hermite_renormalized_1leftoverMode(
-        math.conj(-A), math.conj(B), math.conj(G0), cutoffs
-    )
+        # New algorithm
+        G_leftover = math.hermite_renormalized_1leftoverMode(
+            math.conj(-A), math.conj(B), math.conj(G0), cutoffs
+        )
 
-    # Vanilla MM
-    G_ref = math.hermite_renormalized(
-        math.conj(-A), math.conj(B), math.conj(G0), shape=list(cutoffs) * 2
-    ).numpy()  # note: shape=[C1,C2,C3,...,C1,C2,C3,...]
+        # Vanilla MM
+        G_ref = math.hermite_renormalized(
+            math.conj(-A), math.conj(B), math.conj(G0), shape=list(cutoffs) * 2
+        ).numpy()  # note: shape=[C1,C2,C3,...,C1,C2,C3,...]
 
-    # Extract amplitudes of leftover mode from vanilla MM
-    ref_leftover = np.zeros([cutoffs[0]] * 2 + list(cutoffs)[1:], dtype=np.complex128)
-    for inds in np.ndindex(*cutoffs[1:]):
-        ref_leftover[tuple([slice(cutoffs[0]), slice(cutoffs[0])] + list(inds))] = G_ref[
-            tuple([slice(cutoffs[0])] + list(inds) + [slice(cutoffs[0])] + list(inds))
-        ]
-    assert np.allclose(ref_leftover, G_leftover)
+        # Extract amplitudes of leftover mode from vanilla MM
+        ref_leftover = np.zeros([cutoffs[0]] * 2 + list(cutoffs)[1:], dtype=np.complex128)
+        for inds in np.ndindex(*cutoffs[1:]):
+            ref_leftover[tuple([slice(cutoffs[0]), slice(cutoffs[0])] + list(inds))] = G_ref[
+                tuple([slice(cutoffs[0])] + list(inds) + [slice(cutoffs[0])] + list(inds))
+            ]
+        assert np.allclose(ref_leftover, G_leftover)
 
 
 def test_compactFock_diagonal_gradients():

--- a/tests/test_math/test_compactFock.py
+++ b/tests/test_math/test_compactFock.py
@@ -14,13 +14,15 @@ from tests.random import n_mode_mixed_state
 
 math = Math()  # use methods in math if you want them to be differentiable
 
+
 def allowed_cutoffs(max_cutoffs):
-    r'''Generate all cutoffs from (1,)*M to max_cutoffs'''
+    r"""Generate all cutoffs from (1,)*M to max_cutoffs"""
     res = []
     for idx in np.ndindex(max_cutoffs):
-        cutoffs = np.array(idx)+1
+        cutoffs = np.array(idx) + 1
         res.append(tuple(cutoffs))
     return res
+
 
 @st.composite
 def random_ABC(draw, M):
@@ -51,14 +53,16 @@ def test_compactFock_diagonal(A_B_G0):
             ref_diag[inds] = G_ref[tuple(inds_expanded)]
 
         # New MM
-        G_diag = math.hermite_renormalized_diagonal(math.conj(-A), math.conj(B), math.conj(G0), cutoffs)
+        G_diag = math.hermite_renormalized_diagonal(
+            math.conj(-A), math.conj(B), math.conj(G0), cutoffs
+        )
         assert np.allclose(ref_diag, G_diag)
 
 
 @given(random_ABC(M=3))
 def test_compactFock_1leftover(A_B_G0):
     """Test getting Fock amplitudes if all but the first mode are detected (math.hermite_renormalized_1leftoverMode)"""
-    for cutoffs in allowed_cutoffs((7,7,7)):
+    for cutoffs in allowed_cutoffs((7, 7, 7)):
         A, B, G0 = A_B_G0  # Create random state (M mode Gaussian state with displacement)
 
         # New algorithm


### PR DESCRIPTION
**Context:** There was a bug in the algorithms for faster PNR sampling from Gaussian circuits using density matrices. In the case where the cutoff of the first detector was equal to 1, the resulting density matrix was incorrect.

**Description of the Change:** The problem was solved by allowing for diagonal pivots to be used when the cutoffs[0]=1, effectively changing line 4 of Algorithm 1 in https://arxiv.org/pdf/2303.08879.pdf from `if diag_1 < C_1 − 1 then` to `if (diag_1 < C_1 − 1) or (C_1==1) then`.
