### PR TITLE
Bugfix gradients

### DIFF
--- a/mrmustard/lab/abstract/state.py
+++ b/mrmustard/lab/abstract/state.py
@@ -526,8 +526,10 @@ class State:  # pylint: disable=too-many-public-methods
         self._modes = item
         return self
 
-    def bargmann(self) -> Optional[tuple[ComplexMatrix, ComplexVector, complex]]:
-        r"""Returns the Bargmann representation of the state."""
+    def bargmann(self, numpy=False) -> Optional[tuple[ComplexMatrix, ComplexVector, complex]]:
+        r"""Returns the Bargmann representation of the state.
+        If numpy=True, returns the numpy arrays instead of the backend arrays.
+        """
         if self.is_gaussian:
             if self.is_pure:
                 A, B, C = bargmann.wigner_to_bargmann_psi(self.cov, self.means)
@@ -535,6 +537,8 @@ class State:  # pylint: disable=too-many-public-methods
                 A, B, C = bargmann.wigner_to_bargmann_rho(self.cov, self.means)
         else:
             return None
+        if numpy:
+            return math.asnumpy(A), math.asnumpy(B), math.asnumpy(C)
         return A, B, C
 
     def get_modes(self, item) -> State:

--- a/mrmustard/lab/abstract/transformation.py
+++ b/mrmustard/lab/abstract/transformation.py
@@ -38,19 +38,22 @@ class Transformation:
     r"""Base class for all Transformations."""
     is_unitary = True  # whether the transformation is unitary (True by default)
 
-    def bargmann(self):
+    def bargmann(self, numpy=False):
         X, Y, d = self.XYd(allow_none=False)
         if self.is_unitary:
-            return bargmann.wigner_to_bargmann_U(
+            A, B, C = bargmann.wigner_to_bargmann_U(
                 X if X is not None else math.identity(d.shape[-1], dtype=d.dtype),
                 d if d is not None else math.zeros(X.shape[-1], dtype=X.dtype),
             )
         else:
-            return bargmann.wigner_to_bargmann_Choi(
+            A, B, C = bargmann.wigner_to_bargmann_Choi(
                 X if X is not None else math.identity(d.shape[-1], dtype=d.dtype),
                 Y if Y is not None else math.zeros((d.shape[-1], d.shape[-1]), dtype=d.dtype),
                 d if d is not None else math.zeros(X.shape[-1], dtype=X.dtype),
             )
+        if numpy:
+            return math.asnumpy(A), math.asnumpy(B), math.asnumpy(C)
+        return A, B, C
 
     def primal(self, state: State) -> State:
         r"""Applies ``self`` (a ``Transformation``) to other (a ``State``) and returns the transformed state.

--- a/mrmustard/lab/gates.py
+++ b/mrmustard/lab/gates.py
@@ -123,9 +123,9 @@ class Dgate(Parametrized, Transformation):
             Ud = None
             for idx, out_in in enumerate(zip(shape[:N], shape[N:])):
                 if Ud is None:
-                    Ud = fock.displacement(x[idx], y[idx], out_in)
+                    Ud = fock.displacement(x[idx], y[idx], shape=out_in)
                 else:
-                    U_next = fock.displacement(x[idx], y[idx], out_in)
+                    U_next = fock.displacement(x[idx], y[idx], shape=out_in)
                     Ud = math.outer(Ud, U_next)
 
             return math.transpose(
@@ -133,7 +133,7 @@ class Dgate(Parametrized, Transformation):
                 list(range(0, 2 * N, 2)) + list(range(1, 2 * N, 2)),
             )
         else:
-            return fock.displacement(x[0], y[0], shape)
+            return fock.displacement(x[0], y[0], shape=shape)
 
 
 class Sgate(Parametrized, Transformation):
@@ -204,16 +204,16 @@ class Sgate(Parametrized, Transformation):
             Us = None
             for idx, single_shape in enumerate(zip(shape[:N], shape[N:])):
                 if Us is None:
-                    Us = fock.squeezer(r=r[idx], phi=phi[idx], shape=single_shape)
+                    Us = fock.squeezer(r[idx], phi[idx], shape=single_shape)
                 else:
-                    U_next = fock.squeezer(r=r[idx], phi=phi[idx], shape=single_shape)
+                    U_next = fock.squeezer(r[idx], phi[idx], shape=single_shape)
                     Us = math.outer(Us, U_next)
             return math.transpose(
                 Us,
                 list(range(0, 2 * N, 2)) + list(range(1, 2 * N, 2)),
             )
         else:
-            return fock.squeezer(r=r[0], phi=phi[0], shape=shape)
+            return fock.squeezer(r[0], phi[0], shape=shape)
 
     @property
     def X_matrix(self):
@@ -464,7 +464,7 @@ class BSgate(Parametrized, Transformation):
         return fock.beamsplitter(
             self.theta.value,
             self.phi.value,
-            shape,
+            shape=shape,
             method=method or settings.DEFAULT_BS_METHOD,
         )
 

--- a/mrmustard/math/tensorflow.py
+++ b/mrmustard/math/tensorflow.py
@@ -382,7 +382,7 @@ class TFMath(MathInterface):
 
         def grad(dLdGconj):
             dLdA, dLdB, dLdC = strategies.vanilla_vjp(G, _C, np.conj(dLdGconj))
-            return np.conj(dLdA), np.conj(dLdB), np.conj(dLdC)
+            return self.conj(dLdA), self.conj(dLdB), self.conj(dLdC)
 
         return G, grad
 
@@ -425,7 +425,7 @@ class TFMath(MathInterface):
 
         def grad(dLdGconj):
             dLdA, dLdB, dLdC = strategies.vanilla_vjp(G, _C, np.conj(dLdGconj))
-            return np.conj(dLdA), np.conj(dLdB), np.conj(dLdC)
+            return self.conj(dLdA), self.conj(dLdB), self.conj(dLdC)
 
         return G, grad
 
@@ -573,9 +573,9 @@ class TFMath(MathInterface):
         return tf.boolean_mask(tensor, mask)
 
     @staticmethod
-    def custom_gradient(func):
+    def custom_gradient(func, *args, **kwargs):
         """Decorator to define a function with a custom gradient."""
-        return tf.custom_gradient(func)
+        return tf.custom_gradient(func, *args, **kwargs)
 
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     # Extras (not in the Interface)

--- a/mrmustard/physics/fock.py
+++ b/mrmustard/physics/fock.py
@@ -873,9 +873,9 @@ def displacement(x, y, shape, tol=1e-15):
         dL_dac = np.conj(dL_dDc) * dD_dac + dL_dDc * np.conj(dD_da)
         dLdx = 2 * np.real(dL_dac)
         dLdy = 2 * np.imag(dL_dac)
-        return dLdx, dLdy
+        return math.astensor(dLdx, dtype=x.dtype), math.astensor(dLdy, dtype=y.dtype)
 
-    return gate, grad
+    return math.astensor(gate, dtype=gate.dtype.name), grad
 
 
 @math.custom_gradient
@@ -899,14 +899,15 @@ def beamsplitter(theta: float, phi: float, shape: Sequence[int], method: str):
         )
 
     def vjp(dLdGc):
-        return strategies.beamsplitter_vjp(
+        dtheta, dphi = strategies.beamsplitter_vjp(
             math.asnumpy(bs_unitary),
             math.asnumpy(math.conj(dLdGc)),
             math.asnumpy(theta),
             math.asnumpy(phi),
         )
+        return math.astensor(dtheta, dtype=theta.dtype), math.astensor(dphi, dtype=phi.dtype)
 
-    return bs_unitary, vjp
+    return math.astensor(bs_unitary, dtype=bs_unitary.dtype.name), vjp
 
 
 @math.custom_gradient
@@ -921,9 +922,9 @@ def squeezer(r, phi, shape):
             math.asnumpy(r),
             math.asnumpy(phi),
         )
-        return dr, dphi
+        return math.astensor(dr, dtype=r.dtype), math.astensor(dphi, phi.dtype)
 
-    return sq_unitary, vjp
+    return math.astensor(sq_unitary, dtype=sq_unitary.dtype.name), vjp
 
 
 @math.custom_gradient
@@ -932,11 +933,12 @@ def squeezed(r, phi, shape):
     sq_ket = strategies.squeezed(shape, math.asnumpy(r), math.asnumpy(phi))
 
     def vjp(dLdGc):
-        return strategies.squeezed_vjp(
+        dr, dphi = strategies.squeezed_vjp(
             math.asnumpy(sq_ket),
             math.asnumpy(math.conj(dLdGc)),
             math.asnumpy(r),
             math.asnumpy(phi),
         )
+        return math.astensor(dr, dtype=r.dtype), math.astensor(dphi, phi.dtype)
 
-    return sq_ket, vjp
+    return math.astensor(sq_ket, dtype=sq_ket.dtype.name), vjp

--- a/mrmustard/physics/fock.py
+++ b/mrmustard/physics/fock.py
@@ -870,7 +870,7 @@ def displacement(x, y, shape, tol=1e-15):
 
     def grad(dL_dDc):
         dD_da, dD_dac = strategies.jacobian_displacement(math.asnumpy(gate), alpha)
-        dL_dac = np.conj(dL_dDc) * dD_dac + dL_dDc * np.conj(dD_da)
+        dL_dac = np.sum(np.conj(dL_dDc) * dD_dac + dL_dDc * np.conj(dD_da))
         dLdx = 2 * np.real(dL_dac)
         dLdy = 2 * np.imag(dL_dac)
         return math.astensor(dLdx, dtype=x.dtype), math.astensor(dLdy, dtype=y.dtype)

--- a/tests/test_physics/test_bargmann.py
+++ b/tests/test_physics/test_bargmann.py
@@ -39,3 +39,15 @@ def test_wigner_to_bargmann_choi():
     X, Y, d = G.XYd(allow_none=False)
     for x, y in zip(G.bargmann(), wigner_to_bargmann_Choi(X, Y, d)):
         assert np.allclose(x, y)
+
+
+def test_bargmann_numpy_state():
+    """Tests that the numpy option of the bargmann method of State works correctly"""
+    state = Gaussian(1)
+    assert all(isinstance(thing, np.ndarray) for thing in state.bargmann(numpy=True))
+
+
+def test_bargmann_numpy_transformation():
+    """Tests that the numpy option of the bargmann method of State works correctly"""
+    transformation = Ggate(1)
+    assert all(isinstance(thing, np.ndarray) for thing in transformation.bargmann(numpy=True))

--- a/tests/test_training/test_opt.py
+++ b/tests/test_training/test_opt.py
@@ -31,7 +31,7 @@ from mrmustard.lab.gates import (
     S2gate,
     Sgate,
 )
-from mrmustard.lab.states import DisplacedSqueezed, Gaussian, SqueezedVacuum, Vacuum
+from mrmustard.lab.states import DisplacedSqueezed, Fock, Gaussian, SqueezedVacuum, Vacuum
 from mrmustard.math import Math
 from mrmustard.physics import fidelity
 from mrmustard.physics.gaussian import trace, von_neumann_entropy
@@ -457,3 +457,14 @@ def test_bsgate_optimization():
 
     assert np.allclose(bsgate.theta.value, 0.1, atol=0.01)
     assert np.allclose(bsgate.phi.value, 0.2, atol=0.01)
+
+
+def test_squeezing_grad_from_fock():
+    """Test that the gradient of a squeezing gate is computed from the fock representation."""
+    squeezing = Sgate(r=1, r_trainable=True)
+
+    def cost_fn():
+        return -(Fock(2) >> squeezing << Vacuum(1))
+
+    opt = Optimizer(euclidean_lr=0.05)
+    opt.minimize(cost_fn, by_optimizing=[squeezing], max_steps=100)

--- a/tests/test_training/test_opt.py
+++ b/tests/test_training/test_opt.py
@@ -468,3 +468,25 @@ def test_squeezing_grad_from_fock():
 
     opt = Optimizer(euclidean_lr=0.05)
     opt.minimize(cost_fn, by_optimizing=[squeezing], max_steps=100)
+
+
+def test_displacement_grad_from_fock():
+    """Test that the gradient of a displacement gate is computed from the fock representation."""
+    disp = Dgate(x=1.0, y=1.0, x_trainable=True, y_trainable=True)
+
+    def cost_fn():
+        return -(Fock(2) >> disp << Vacuum(1))
+
+    opt = Optimizer(euclidean_lr=0.05)
+    opt.minimize(cost_fn, by_optimizing=[disp], max_steps=100)
+
+
+def test_bsgate_grad_from_fock():
+    """Test that the gradient of a beamsplitter gate is computed from the fock representation."""
+    sq = SqueezedVacuum(r=1.0, r_trainable=True)
+
+    def cost_fn():
+        return -((sq & Fock(1)) >> BSgate(0.5) << (Vacuum(1) & Fock(1)))
+
+    opt = Optimizer(euclidean_lr=0.05)
+    opt.minimize(cost_fn, by_optimizing=[sq], max_steps=100)


### PR DESCRIPTION
**Context:**
The `more_strategies` PR introduced several custom gradients, but we never noticed they were broken under some conditions.

**Description of the Change:**
- Gradients are now cast to the backend array type
- This PR also adds the numpy option to the bargmann methods

**Benefits:**
Gradients work

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None