### PR TITLE
Fix of math.lattice.strategies.vanilla

### DIFF
--- a/mrmustard/math/lattice/neighbors.py
+++ b/mrmustard/math/lattice/neighbors.py
@@ -29,7 +29,8 @@ from numba.cpython.unsafe.tuple import tuple_setitem
 def all_neighbors(pivot: tuple[int, ...]) -> Iterator[tuple[int, tuple[int, ...]]]:
     r"""yields the indices of all the neighbours of the given index."""
     for j in range(len(pivot)):  # pylint: disable=consider-using-enumerate
-        yield j, tuple_setitem(pivot, j, pivot[j] - 1)
+        if pivot[j] - 1 >= 0:
+            yield j, tuple_setitem(pivot, j, pivot[j] - 1)
         yield j, tuple_setitem(pivot, j, pivot[j] + 1)
 
 
@@ -42,7 +43,8 @@ def all_neighbors(pivot: tuple[int, ...]) -> Iterator[tuple[int, tuple[int, ...]
 def lower_neighbors(pivot: tuple[int, ...]) -> Iterator[tuple[int, tuple[int, ...]]]:
     r"""yields the indices of the lower neighbours of the given index."""
     for j in range(len(pivot)):  # pylint: disable=consider-using-enumerate
-        yield j, tuple_setitem(pivot, j, pivot[j] - 1)
+        if pivot[j] - 1 >=0:
+            yield j, tuple_setitem(pivot, j, pivot[j] - 1)
 
 
 ####################################################################################
@@ -69,6 +71,7 @@ def bitstring_neighbors(
     r"yields the indices of the bitstring neighbours of the given index"
     for i, b in enumerate(bitstring):
         if b:  # b == 1 -> lower
-            yield i, tuple_setitem(pivot, i, pivot[i] - 1)
+            if pivot[i] - 1 >= 0:
+                yield i, tuple_setitem(pivot, i, pivot[i] - 1)
         else:  # b == 0 -> upper
             yield i, tuple_setitem(pivot, i, pivot[i] + 1)

--- a/mrmustard/math/lattice/strategies/vanilla.py
+++ b/mrmustard/math/lattice/strategies/vanilla.py
@@ -68,7 +68,7 @@ def vanilla_jacobian(
     dGdc = G / c
 
     # initialize path iterator
-    path = paths.ndindex_path(G.shape)
+    path = np.ndindex(G.shape)
 
     # skip first index
     next(path)


### PR DESCRIPTION


### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Ensure that code and tests are properly formatted, by running `make format` or `black -l 100
      <filename>` on any relevant files. You will need to have the Black code format installed:
      `pip install black`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] The Mr Mustard source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/) except line length.
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint mrmustard/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:** The lower neighbours of pivot incorrect at border of Fock representation. math.lattice.neighbours didn't check whether a certain entry of a pivot index is zero before subtracting 1 from it. Because of that, amplitudes at the opposite border of the Fock representation were read, while the neighbour should actually be disregarded.

**Description of the Change:** We now check the value of pivot indices before lowering them. 
A typo was also fixed in math.lattice.strategies.vanilla_jacobian. I still referred to paths.ndindex_path, which doesn't exist anymore. IIt was replaced by np.ndindex.
