### PR TITLE
Utils for the Representations stage1 MVP

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,3 +1,16 @@
+# Release 0.6.0 (future)
+
+### New features
+* A general factory method and a duck style type-checker.
+
+### Breaking changes
+### Improvements
+### Bug fixes
+### Documentation
+### Contributors
+[Richard A. Wolf](https://github.com/ryk-wolf)
+
+
 # Release 0.5.0 (development release)
 
 ### New features
@@ -83,6 +96,7 @@
 
 * More robust implementation of cutoffs for States.
 [(#239)](https://github.com/XanaduAI/MrMustard/pull/239)
+
 
 ### Bug fixes
 

--- a/mrmustard/utils/misc_tools.py
+++ b/mrmustard/utils/misc_tools.py
@@ -42,9 +42,9 @@ def duck_type_checker(obj_a: object, obj_b: object) -> bool:
         True if both objects have exactly the same attributes, False otherwise.
 
     Raises:
-        TypeError:  If at least one of the objects given can't be compared via duck-typing, i.e.
-        lack attributes. A typical example would be python basic types such as ``int``, ``float``,
-        ``bool``, etc.
+        TypeError: If at least one of the objects given can't be compared via duck-typing, i.e.
+            lack attributes. A typical example would be python basic types such as ``int``, ``float``,
+            ``bool``, etc.
     """
     try:
         set_a = set(obj_a.__dict__.keys())

--- a/mrmustard/utils/misc_tools.py
+++ b/mrmustard/utils/misc_tools.py
@@ -1,0 +1,70 @@
+# Copyright 2023 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+This module contains miscellaneous functions which are used accross the code base of MM. 
+They can be used as is in any of the classes.
+"""
+
+all = ["duck_type_checker", "general_factory"]
+
+
+def duck_type_checker(obj_a: object, obj_b: object) -> bool:
+    r"""*If it walks like a duck and it quacks like a duck, then it must be a duck.*
+
+    This function performs type-checking from a duck-type perspective, testing whether both given
+    objects share the same set of attributes. If they do, no matter their *type* -as obtained by
+    a call to ``isinstance``-, they will be considered to be of the same duck-type.
+
+    Note that we here look at the symmetric difference, hence the exact question we ask is better
+    phrased as "*Are both objects of the same type?*" than as "*Is object a of the same type as
+    object b?*".
+
+    Note also that this checks for the exact match between types -via attributes-, this system is
+    **not** meant to work with subclasses since there is a high probability that they might have
+    different attributes.
+
+    Args:
+        obj_a:  one of the objects to be checked
+        obj_b:  the other object to be checked
+
+    Returns:
+        True if both objects have exactly the same attributes, False otherwise.
+
+    Raises:
+        TypeError:  If at least one of the objects given can't be compared via duck-typing, i.e.
+        lack attributes. A typical example would be python basic types such as ``int``, ``float``,
+        ``bool``, etc.
+    """
+    try:
+        set_a = set(obj_a.__dict__.keys())
+        set_b = set(obj_b.__dict__.keys())
+        return set_a.symmetric_difference(set_b) == set()
+
+    except AttributeError as e:
+        raise TypeError(
+            f"Objects of types {type(obj_a), type(obj_b)} can't be compared via duck-type"
+        ) from e
+
+
+def general_factory(cls, *args, **kwargs) -> object:
+    r"""Factory method which generates an instance of cls parameterized by the given arguments.
+
+    Args:
+        args:   non-keyword ordered arguments used to parameterize the class instance
+        kwargs: keyword arguments used to parameterize the class instance
+
+    Returns:
+        An instance of the class cls parametrized by args and kwargs
+    """
+    return cls(*args, **kwargs)

--- a/tests/mock_classes/general_mocks.py
+++ b/tests/mock_classes/general_mocks.py
@@ -1,0 +1,38 @@
+# Copyright 2023 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+This module provides general mock classes.
+"""
+
+all = ["MockAnimal", "MockFruit", "MockNoDefaultParams"]
+
+
+class MockAnimal:
+    def __init__(self, age: int = 42, alive: bool = True, colour: str = "blue") -> None:
+        self.age = age
+        self.alive = alive
+        self.colour = colour
+
+
+class MockFruit:
+    def __init__(self) -> None:
+        self.creation_date = 1954
+        self.at_war = False
+        self.flag_colour = "blue"
+
+
+class MockNoDefaultParams:
+    def __init__(self, a, b) -> None:
+        self.a = a
+        self.b = b

--- a/tests/mock_classes/general_mocks.py
+++ b/tests/mock_classes/general_mocks.py
@@ -15,7 +15,7 @@
 This module provides general mock classes.
 """
 
-all = ["MockAnimal", "MockFruit", "MockNoDefaultParams"]
+__all__ = ["MockAnimal", "MockFruit", "MockNoDefaultParams"]
 
 
 class MockAnimal:

--- a/tests/test_utils/test_misc_tools.py
+++ b/tests/test_utils/test_misc_tools.py
@@ -1,0 +1,95 @@
+# Copyright 2023 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from copy import deepcopy
+from tests.mock_classes.general_mocks import *
+from mrmustard.utils.misc_tools import *
+
+
+###############################################################################
+##########################   duck_type_checker   ##############################
+@pytest.mark.parametrize("cls_instance", [MockAnimal(), MockFruit()])
+def test_dtc_returns_true_when_given_same_object(cls_instance):
+    other_instance = deepcopy(cls_instance)
+    assert duck_type_checker(cls_instance, other_instance) == True
+
+
+@pytest.mark.parametrize(
+    "obj_a, obj_b", [(MockAnimal(), MockAnimal()), (MockFruit(), MockFruit())]
+)
+def test_dtc_returns_true_when_given_different_object_of_same_type(obj_a, obj_b):
+    assert duck_type_checker(obj_a, obj_b)
+
+
+@pytest.mark.parametrize(
+    "obj_type_a, obj_type_b", [(MockAnimal(), MockFruit()), (MockFruit(), MockAnimal())]
+)
+def test_dtc_returns_same_bool_irrelevant_of_object_order(obj_type_a, obj_type_b):
+    assert duck_type_checker(obj_type_a, obj_type_b) == duck_type_checker(
+        obj_type_b, obj_type_a
+    )
+
+
+@pytest.mark.parametrize(
+    "obj_type_a, obj_type_b, truth_val",
+    [
+        (MockAnimal(), MockFruit(), False),
+        (MockAnimal(), MockAnimal(), True),
+        (MockFruit(), MockFruit(), True),
+        (MockFruit(), MockAnimal(), False),
+    ],
+)
+def test_dtc_returns_correct_bool_with_objects_of_different_or_same_type(
+    obj_type_a, obj_type_b, truth_val
+):
+    assert duck_type_checker(obj_type_a, obj_type_b) == truth_val
+
+
+@pytest.mark.parametrize(
+    "x, y", [(1, 1.0), (1.0, "s"), ("s", 2.0), (True, 1.0), (MockAnimal(), 1)]
+)
+def test_dtc_raises_TypeError_when_given_objects_without_dicts(x, y):
+    with pytest.raises(TypeError):
+        duck_type_checker(x, y)
+
+
+##########################   general_factory   ##############################
+@pytest.mark.parametrize(
+    "cls, args, kwargs",
+    [
+        (MockAnimal, (1954, False), {"colour": "red"}),
+        (MockFruit, (), {}),
+        (MockNoDefaultParams, (), {"a": 1954, "b": "no"}),
+        (MockNoDefaultParams, (1954, "yes"), {}),
+    ],
+)
+def test_gfactory_returns_instance_of_correct_class(cls, args, kwargs):
+    assert isinstance(general_factory(cls, *args, **kwargs), cls) == True
+
+
+@pytest.mark.parametrize(
+    "cls, args, kwargs",
+    [
+        (MockAnimal, (1954, False, "red", "extra_arg"), {}),
+        (MockNoDefaultParams, (), {"a": 1954, "b": "no", "c": False}),
+        (MockNoDefaultParams, (1954, "yes", True), {}),
+        (MockNoDefaultParams, (), {}),
+    ],
+)
+def test_gfactory_raises_TypeError_when_unexpected_number_or_wrong_args_given(
+    cls, args, kwargs
+):
+    with pytest.raises(TypeError):
+        general_factory(cls, *args, **kwargs)

--- a/tests/test_utils/test_misc_tools.py
+++ b/tests/test_utils/test_misc_tools.py
@@ -26,9 +26,7 @@ def test_dtc_returns_true_when_given_same_object(cls_instance):
     assert duck_type_checker(cls_instance, other_instance) == True
 
 
-@pytest.mark.parametrize(
-    "obj_a, obj_b", [(MockAnimal(), MockAnimal()), (MockFruit(), MockFruit())]
-)
+@pytest.mark.parametrize("obj_a, obj_b", [(MockAnimal(), MockAnimal()), (MockFruit(), MockFruit())])
 def test_dtc_returns_true_when_given_different_object_of_same_type(obj_a, obj_b):
     assert duck_type_checker(obj_a, obj_b)
 
@@ -37,9 +35,7 @@ def test_dtc_returns_true_when_given_different_object_of_same_type(obj_a, obj_b)
     "obj_type_a, obj_type_b", [(MockAnimal(), MockFruit()), (MockFruit(), MockAnimal())]
 )
 def test_dtc_returns_same_bool_irrelevant_of_object_order(obj_type_a, obj_type_b):
-    assert duck_type_checker(obj_type_a, obj_type_b) == duck_type_checker(
-        obj_type_b, obj_type_a
-    )
+    assert duck_type_checker(obj_type_a, obj_type_b) == duck_type_checker(obj_type_b, obj_type_a)
 
 
 @pytest.mark.parametrize(
@@ -57,9 +53,7 @@ def test_dtc_returns_correct_bool_with_objects_of_different_or_same_type(
     assert duck_type_checker(obj_type_a, obj_type_b) == truth_val
 
 
-@pytest.mark.parametrize(
-    "x, y", [(1, 1.0), (1.0, "s"), ("s", 2.0), (True, 1.0), (MockAnimal(), 1)]
-)
+@pytest.mark.parametrize("x, y", [(1, 1.0), (1.0, "s"), ("s", 2.0), (True, 1.0), (MockAnimal(), 1)])
 def test_dtc_raises_TypeError_when_given_objects_without_dicts(x, y):
     with pytest.raises(TypeError):
         duck_type_checker(x, y)
@@ -88,8 +82,6 @@ def test_gfactory_returns_instance_of_correct_class(cls, args, kwargs):
         (MockNoDefaultParams, (), {}),
     ],
 )
-def test_gfactory_raises_TypeError_when_unexpected_number_or_wrong_args_given(
-    cls, args, kwargs
-):
+def test_gfactory_raises_TypeError_when_unexpected_number_or_wrong_args_given(cls, args, kwargs):
     with pytest.raises(TypeError):
         general_factory(cls, *args, **kwargs)


### PR DESCRIPTION
**Context:**
Within the representations project, some tools were needed.

**Description of the Change:**
Implement a duck-style type-checker and a very generic factory method.

**Benefits:**
Allowing to check whether an object is of a certain class in a more pythonic way than `isinstance`. Allowing the creation of objects in tests (and beyond) through a dedicated factory.

**Possible Drawbacks:**
The current implementation of the duck type checker doesn't support checking python native types like booleans or ints, floats.

**Related GitHub Issues:**
