### PR TITLE
Ensuring that hbar can only be specified in `Settings`

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -394,7 +394,7 @@ cutoff of the first detector is equal to 1, the resulting density matrix is now 
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
-[Robbe De Prins](https://github.com/rdprins), [Sebastian Duque Mesa](https://github.com/sduquemesa),
+[Robbe De Prins](https://github.com/rdprins), [Sebastian Duque Mesa](https://github.com/sduquemesa), [Samuele Ferracin] (https://github.com/SamFerracin),
 [Filippo Miatto](https://github.com/ziofil), [Zeyue Niu](https://github.com/zeyueN),
 [Yuan Yao](https://github.com/sylviemonet)
 
@@ -501,6 +501,9 @@ This release contains contributions from (in alphabetical order):
   [(#133)](https://github.com/XanaduAI/MrMustard/pull/133),
   patch [(#144)](https://github.com/XanaduAI/MrMustard/pull/144)
   and [(#158)](https://github.com/XanaduAI/MrMustard/pull/158).
+
+* The value of `hbar` can no longer be specified outside of `Settings`. All the classes and 
+  methods that allowed specifying values for `hbar` now retrieve it directly from `Settings`.
 
 ### Improvements
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Breaking changes
 
+* The value of `hbar` can no longer be specified outside of `Settings`. All the classes and 
+  methods that allowed specifying its value as an input now retrieve it directly from `Settings`.
+
 ### Improvements
 
 ### Bug fixes
@@ -13,7 +16,7 @@
 ### Documentation
 
 ### Contributors
-[Yuan Yao](https://github.com/sylviemonet)
+[Samuele Ferracin](https://github.com/SamFerracin), [Yuan Yao](https://github.com/sylviemonet)
 
 
 # Release 0.5.0 (current release)
@@ -394,7 +397,7 @@ cutoff of the first detector is equal to 1, the resulting density matrix is now 
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
-[Robbe De Prins](https://github.com/rdprins), [Sebastian Duque Mesa](https://github.com/sduquemesa), [Samuele Ferracin] (https://github.com/SamFerracin),
+[Robbe De Prins](https://github.com/rdprins), [Sebastian Duque Mesa](https://github.com/sduquemesa),
 [Filippo Miatto](https://github.com/ziofil), [Zeyue Niu](https://github.com/zeyueN),
 [Yuan Yao](https://github.com/sylviemonet)
 
@@ -501,9 +504,6 @@ This release contains contributions from (in alphabetical order):
   [(#133)](https://github.com/XanaduAI/MrMustard/pull/133),
   patch [(#144)](https://github.com/XanaduAI/MrMustard/pull/144)
   and [(#158)](https://github.com/XanaduAI/MrMustard/pull/158).
-
-* The value of `hbar` can no longer be specified outside of `Settings`. All the classes and 
-  methods that allowed specifying its value as an input now retrieve it directly from `Settings`.
 
 ### Improvements
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -503,7 +503,7 @@ This release contains contributions from (in alphabetical order):
   and [(#158)](https://github.com/XanaduAI/MrMustard/pull/158).
 
 * The value of `hbar` can no longer be specified outside of `Settings`. All the classes and 
-  methods that allowed specifying values for `hbar` now retrieve it directly from `Settings`.
+  methods that allowed specifying its value as an input now retrieve it directly from `Settings`.
 
 ### Improvements
 

--- a/mrmustard/lab/abstract/state.py
+++ b/mrmustard/lab/abstract/state.py
@@ -172,9 +172,7 @@ class State:  # pylint: disable=too-many-public-methods
             return math.sqrt(math.diag_part(self.number_cov))
 
         return math.sqrt(
-            fock.number_variances(
-                self.fock, is_dm=len(self.fock.shape) == self.num_modes * 2
-            )
+            fock.number_variances(self.fock, is_dm=len(self.fock.shape) == self.num_modes * 2)
         )
 
     @property
@@ -236,9 +234,7 @@ class State:  # pylint: disable=too-many-public-methods
     def number_cov(self) -> RealMatrix:
         r"""Returns the complete photon number covariance matrix."""
         if not self.is_gaussian:
-            raise NotImplementedError(
-                "number_cov not yet implemented for non-gaussian states"
-            )
+            raise NotImplementedError("number_cov not yet implemented for non-gaussian states")
 
         return gaussian.number_cov(self.cov, self.means)
 
@@ -282,9 +278,7 @@ class State:  # pylint: disable=too-many-public-methods
         if cutoffs is None:
             cutoffs = self.cutoffs
         else:
-            cutoffs = [
-                c if c is not None else self.cutoffs[i] for i, c in enumerate(cutoffs)
-            ]
+            cutoffs = [c if c is not None else self.cutoffs[i] for i, c in enumerate(cutoffs)]
 
         # TODO: shouldn't we check if trainable instead? that's when we want to recompute fock
         if self.is_gaussian:
@@ -303,9 +297,7 @@ class State:  # pylint: disable=too-many-public-methods
                     self._ket = fock.dm_to_ket(self._dm)
             current_cutoffs = [int(s) for s in self._ket.shape]
             if cutoffs != current_cutoffs:
-                paddings = [
-                    (0, max(0, new - old)) for new, old in zip(cutoffs, current_cutoffs)
-                ]
+                paddings = [(0, max(0, new - old)) for new, old in zip(cutoffs, current_cutoffs)]
                 if any(p != (0, 0) for p in paddings):
                     padded = fock.math.pad(self._ket, paddings, mode="constant")
                 else:
@@ -326,9 +318,7 @@ class State:  # pylint: disable=too-many-public-methods
         if cutoffs is None:
             cutoffs = self.cutoffs
         else:
-            cutoffs = [
-                c if c is not None else self.cutoffs[i] for i, c in enumerate(cutoffs)
-            ]
+            cutoffs = [c if c is not None else self.cutoffs[i] for i, c in enumerate(cutoffs)]
         if self.is_pure:
             ket = self.ket(cutoffs=cutoffs)
             if ket is not None:
@@ -339,13 +329,9 @@ class State:  # pylint: disable=too-many-public-methods
                     self.cov, self.means, shape=cutoffs + cutoffs, return_dm=True
                 )
             elif cutoffs != (current_cutoffs := list(self._dm.shape[: self.num_modes])):
-                paddings = [
-                    (0, max(0, new - old)) for new, old in zip(cutoffs, current_cutoffs)
-                ]
+                paddings = [(0, max(0, new - old)) for new, old in zip(cutoffs, current_cutoffs)]
                 if any(p != (0, 0) for p in paddings):
-                    padded = fock.math.pad(
-                        self._dm, paddings + paddings, mode="constant"
-                    )
+                    padded = fock.math.pad(self._dm, paddings + paddings, mode="constant")
                 else:
                     padded = self._dm
                 return padded[tuple(slice(s) for s in cutoffs + cutoffs)]
@@ -437,8 +423,7 @@ class State:  # pylint: disable=too-many-public-methods
 
     def _contract_with_other(self, other):
         other_cutoffs = [
-            None if m not in self.modes else other.cutoffs[other.indices(m)]
-            for m in other.modes
+            None if m not in self.modes else other.cutoffs[other.indices(m)] for m in other.modes
         ]
         if hasattr(self, "_preferred_projection"):
             out_fock = self._preferred_projection(other, other.indices(self.modes))
@@ -446,12 +431,8 @@ class State:  # pylint: disable=too-many-public-methods
             # matching other's cutoffs
             self_cutoffs = [other.cutoffs[other.indices(m)] for m in self.modes]
             out_fock = fock.contract_states(
-                stateA=other.ket(other_cutoffs)
-                if other.is_pure
-                else other.dm(other_cutoffs),
-                stateB=self.ket(self_cutoffs)
-                if self.is_pure
-                else self.dm(self_cutoffs),
+                stateA=other.ket(other_cutoffs) if other.is_pure else other.dm(other_cutoffs),
+                stateB=self.ket(self_cutoffs) if self.is_pure else self.dm(self_cutoffs),
                 a_is_dm=other.is_mixed,
                 b_is_dm=self.is_mixed,
                 modes=other.indices(self.modes),
@@ -509,9 +490,7 @@ class State:  # pylint: disable=too-many-public-methods
                 # we want self & other to have shape [1,3,2,1,3,2]
                 # before transposing shape is [1,3,1,3]+[2,2]
                 self_idx = list(range(len(self_fock.shape)))
-                other_idx = list(
-                    range(len(self_idx), len(self_idx) + len(other_fock.shape))
-                )
+                other_idx = list(range(len(self_idx), len(self_idx) + len(other_fock.shape)))
                 return State(
                     dm=math.transpose(
                         dm,
@@ -552,9 +531,7 @@ class State:  # pylint: disable=too-many-public-methods
         self._modes = item
         return self
 
-    def bargmann(
-        self, numpy=False
-    ) -> Optional[tuple[ComplexMatrix, ComplexVector, complex]]:
+    def bargmann(self, numpy=False) -> Optional[tuple[ComplexMatrix, ComplexVector, complex]]:
         r"""Returns the Bargmann representation of the state.
         If numpy=True, returns the numpy arrays instead of the backend arrays.
         """
@@ -639,9 +616,7 @@ class State:  # pylint: disable=too-many-public-methods
         r"""Implements a mixture of states (only available in fock representation for the moment)."""
         if not isinstance(other, State):
             raise TypeError(f"Cannot add {other.__class__.__qualname__} to a state")
-        warnings.warn(
-            "mixing states forces conversion to fock representation", UserWarning
-        )
+        warnings.warn("mixing states forces conversion to fock representation", UserWarning)
         return State(dm=self.dm(self.cutoffs) + other.dm(self.cutoffs))
 
     def __rmul__(self, other):
@@ -669,9 +644,7 @@ class State:  # pylint: disable=too-many-public-methods
         E.g. ``psi / 0.5``
         """
         if self.is_gaussian:
-            warnings.warn(
-                "scalar division forces conversion to fock representation", UserWarning
-            )
+            warnings.warn("scalar division forces conversion to fock representation", UserWarning)
             if self.is_pure:
                 return State(ket=self.ket() / other)
             return State(dm=self.dm() / other)

--- a/mrmustard/lab/gates.py
+++ b/mrmustard/lab/gates.py
@@ -279,9 +279,7 @@ class Rgate(Parametrized, Transformation):
             raise ValueError(
                 "len(cutoffs) should be either equal to the number of modes or twice the number of modes (for output-input)."
             )
-        angles = self.angle.value * math.ones(
-            self.num_modes, dtype=self.angle.value.dtype
-        )
+        angles = self.angle.value * math.ones(self.num_modes, dtype=self.angle.value.dtype)
 
         # calculate rotation unitary for each mode and concatenate with outer product
         Ur = None
@@ -296,8 +294,7 @@ class Rgate(Parametrized, Transformation):
         # return total unitary with indexes reordered according to MM convention
         return math.transpose(
             Ur,
-            list(range(0, 2 * self.num_modes, 2))
-            + list(range(1, 2 * self.num_modes, 2)),
+            list(range(0, 2 * self.num_modes, 2)) + list(range(1, 2 * self.num_modes, 2)),
         )
 
 
@@ -463,9 +460,7 @@ class BSgate(Parametrized, Transformation):
         elif len(cutoffs) == 2:
             shape = tuple(cutoffs) + tuple(cutoffs)
         else:
-            raise ValueError(
-                f"Invalid len(cutoffs): {len(cutoffs)} (should be 2 or 4)."
-            )
+            raise ValueError(f"Invalid len(cutoffs): {len(cutoffs)} (should be 2 or 4).")
         return fock.beamsplitter(
             self.theta.value,
             self.phi.value,
@@ -530,9 +525,7 @@ class MZgate(Parametrized, Transformation):
 
     @property
     def X_matrix(self):
-        return gaussian.mz_symplectic(
-            self.phi_a.value, self.phi_b.value, internal=self._internal
-        )
+        return gaussian.mz_symplectic(self.phi_a.value, self.phi_b.value, internal=self._internal)
 
     def _validate_modes(self, modes):
         if len(modes) != 2:
@@ -607,9 +600,7 @@ class Interferometer(Parametrized, Transformation):
         modes: Optional[List[int]] = None,
     ):
         if modes is not None and num_modes != len(modes):
-            raise ValueError(
-                f"Invalid number of modes: got {len(modes)}, should be {num_modes}"
-            )
+            raise ValueError(f"Invalid number of modes: got {len(modes)}, should be {num_modes}")
         if unitary is None:
             unitary = math.random_unitary(num_modes)
         super().__init__(
@@ -659,14 +650,10 @@ class RealInterferometer(Parametrized, Transformation):
         modes: Optional[List[int]] = None,
     ):
         if modes is not None and (num_modes != len(modes)):
-            raise ValueError(
-                f"Invalid number of modes: got {len(modes)}, should be {num_modes}"
-            )
+            raise ValueError(f"Invalid number of modes: got {len(modes)}, should be {num_modes}")
         if orthogonal is None:
             orthogonal = math.random_orthogonal(num_modes)
-        super().__init__(
-            orthogonal=orthogonal, orthogonal_trainable=orthogonal_trainable
-        )
+        super().__init__(orthogonal=orthogonal, orthogonal_trainable=orthogonal_trainable)
         self._modes = modes or list(range(num_modes))
         self._is_gaussian = True
         self.short_name = "RI"
@@ -712,9 +699,7 @@ class Ggate(Parametrized, Transformation):
         modes: Optional[List[int]] = None,
     ):
         if modes is not None and (num_modes != len(modes)):
-            raise ValueError(
-                f"Invalid number of modes: got {len(modes)}, should be {num_modes}"
-            )
+            raise ValueError(f"Invalid number of modes: got {len(modes)}, should be {num_modes}")
         if symplectic is None:
             symplectic = math.random_symplectic(num_modes)
         super().__init__(

--- a/mrmustard/lab/gates.py
+++ b/mrmustard/lab/gates.py
@@ -92,7 +92,7 @@ class Dgate(Parametrized, Transformation):
 
     @property
     def d_vector(self):
-        return gaussian.displacement(self.x.value, self.y.value, settings.HBAR)
+        return gaussian.displacement(self.x.value, self.y.value)
 
     def U(self, cutoffs: Sequence[int]):
         r"""Returns the unitary representation of the Displacement gate using
@@ -279,7 +279,9 @@ class Rgate(Parametrized, Transformation):
             raise ValueError(
                 "len(cutoffs) should be either equal to the number of modes or twice the number of modes (for output-input)."
             )
-        angles = self.angle.value * math.ones(self.num_modes, dtype=self.angle.value.dtype)
+        angles = self.angle.value * math.ones(
+            self.num_modes, dtype=self.angle.value.dtype
+        )
 
         # calculate rotation unitary for each mode and concatenate with outer product
         Ur = None
@@ -294,7 +296,8 @@ class Rgate(Parametrized, Transformation):
         # return total unitary with indexes reordered according to MM convention
         return math.transpose(
             Ur,
-            list(range(0, 2 * self.num_modes, 2)) + list(range(1, 2 * self.num_modes, 2)),
+            list(range(0, 2 * self.num_modes, 2))
+            + list(range(1, 2 * self.num_modes, 2)),
         )
 
 
@@ -460,7 +463,9 @@ class BSgate(Parametrized, Transformation):
         elif len(cutoffs) == 2:
             shape = tuple(cutoffs) + tuple(cutoffs)
         else:
-            raise ValueError(f"Invalid len(cutoffs): {len(cutoffs)} (should be 2 or 4).")
+            raise ValueError(
+                f"Invalid len(cutoffs): {len(cutoffs)} (should be 2 or 4)."
+            )
         return fock.beamsplitter(
             self.theta.value,
             self.phi.value,
@@ -525,7 +530,9 @@ class MZgate(Parametrized, Transformation):
 
     @property
     def X_matrix(self):
-        return gaussian.mz_symplectic(self.phi_a.value, self.phi_b.value, internal=self._internal)
+        return gaussian.mz_symplectic(
+            self.phi_a.value, self.phi_b.value, internal=self._internal
+        )
 
     def _validate_modes(self, modes):
         if len(modes) != 2:
@@ -600,7 +607,9 @@ class Interferometer(Parametrized, Transformation):
         modes: Optional[List[int]] = None,
     ):
         if modes is not None and num_modes != len(modes):
-            raise ValueError(f"Invalid number of modes: got {len(modes)}, should be {num_modes}")
+            raise ValueError(
+                f"Invalid number of modes: got {len(modes)}, should be {num_modes}"
+            )
         if unitary is None:
             unitary = math.random_unitary(num_modes)
         super().__init__(
@@ -650,10 +659,14 @@ class RealInterferometer(Parametrized, Transformation):
         modes: Optional[List[int]] = None,
     ):
         if modes is not None and (num_modes != len(modes)):
-            raise ValueError(f"Invalid number of modes: got {len(modes)}, should be {num_modes}")
+            raise ValueError(
+                f"Invalid number of modes: got {len(modes)}, should be {num_modes}"
+            )
         if orthogonal is None:
             orthogonal = math.random_orthogonal(num_modes)
-        super().__init__(orthogonal=orthogonal, orthogonal_trainable=orthogonal_trainable)
+        super().__init__(
+            orthogonal=orthogonal, orthogonal_trainable=orthogonal_trainable
+        )
         self._modes = modes or list(range(num_modes))
         self._is_gaussian = True
         self.short_name = "RI"
@@ -699,7 +712,9 @@ class Ggate(Parametrized, Transformation):
         modes: Optional[List[int]] = None,
     ):
         if modes is not None and (num_modes != len(modes)):
-            raise ValueError(f"Invalid number of modes: got {len(modes)}, should be {num_modes}")
+            raise ValueError(
+                f"Invalid number of modes: got {len(modes)}, should be {num_modes}"
+            )
         if symplectic is None:
             symplectic = math.random_symplectic(num_modes)
         super().__init__(
@@ -787,11 +802,11 @@ class Attenuator(Parametrized, Transformation):
 
     @property
     def X_matrix(self):
-        return gaussian.loss_XYd(self.transmissivity.value, self.nbar.value, settings.HBAR)[0]
+        return gaussian.loss_XYd(self.transmissivity.value, self.nbar.value)[0]
 
     @property
     def Y_matrix(self):
-        return gaussian.loss_XYd(self.transmissivity.value, self.nbar.value, settings.HBAR)[1]
+        return gaussian.loss_XYd(self.transmissivity.value, self.nbar.value)[1]
 
 
 class Amplifier(Parametrized, Transformation):
@@ -844,11 +859,11 @@ class Amplifier(Parametrized, Transformation):
 
     @property
     def X_matrix(self):
-        return gaussian.amp_XYd(self.gain.value, self.nbar.value, settings.HBAR)[0]
+        return gaussian.amp_XYd(self.gain.value, self.nbar.value)[0]
 
     @property
     def Y_matrix(self):
-        return gaussian.amp_XYd(self.gain.value, self.nbar.value, settings.HBAR)[1]
+        return gaussian.amp_XYd(self.gain.value, self.nbar.value)[1]
 
 
 # pylint: disable=no-member
@@ -897,4 +912,4 @@ class AdditiveNoise(Parametrized, Transformation):
 
     @property
     def Y_matrix(self):
-        return gaussian.noise_Y(self.noise.value, settings.HBAR)
+        return gaussian.noise_Y(self.noise.value)

--- a/mrmustard/lab/states.py
+++ b/mrmustard/lab/states.py
@@ -45,8 +45,8 @@ class Vacuum(State):
     r"""The N-mode vacuum state."""
 
     def __init__(self, num_modes: int):
-        cov = gaussian.vacuum_cov(num_modes, settings.HBAR)
-        means = gaussian.vacuum_means(num_modes, settings.HBAR)
+        cov = gaussian.vacuum_cov(num_modes)
+        means = gaussian.vacuum_means(num_modes)
         State.__init__(self, cov=cov, means=means)
 
 
@@ -109,13 +109,13 @@ class Coherent(Parametrized, State):
         self._modes = modes
         self._normalize = normalize
 
-        means = gaussian.displacement(self.x.value, self.y.value, settings.HBAR)
-        cov = gaussian.vacuum_cov(means.shape[-1] // 2, settings.HBAR)
+        means = gaussian.displacement(self.x.value, self.y.value)
+        cov = gaussian.vacuum_cov(means.shape[-1] // 2)
         State.__init__(self, cov=cov, means=means, cutoffs=cutoffs, modes=modes)
 
     @property
     def means(self):
-        return gaussian.displacement(self.x.value, self.y.value, settings.HBAR)
+        return gaussian.displacement(self.x.value, self.y.value)
 
 
 class SqueezedVacuum(Parametrized, State):
@@ -176,13 +176,15 @@ class SqueezedVacuum(Parametrized, State):
         self._modes = modes
         self._normalize = normalize
 
-        cov = gaussian.squeezed_vacuum_cov(self.r.value, self.phi.value, settings.HBAR)
-        means = gaussian.vacuum_means(cov.shape[-1] // 2, settings.HBAR)
+        cov = gaussian.squeezed_vacuum_cov(self.r.value, self.phi.value)
+        means = gaussian.vacuum_means(
+            cov.shape[-1] // 2,
+        )
         State.__init__(self, cov=cov, means=means, cutoffs=cutoffs)
 
     @property
     def cov(self):
-        return gaussian.squeezed_vacuum_cov(self.r.value, self.phi.value, settings.HBAR)
+        return gaussian.squeezed_vacuum_cov(self.r.value, self.phi.value)
 
 
 class TMSV(Parametrized, State):
@@ -231,13 +233,16 @@ class TMSV(Parametrized, State):
         self._modes = modes
         self._normalize = normalize
 
-        cov = gaussian.two_mode_squeezed_vacuum_cov(self.r.value, self.phi.value, settings.HBAR)
-        means = gaussian.vacuum_means(2, settings.HBAR)
+        cov = gaussian.two_mode_squeezed_vacuum_cov(
+            self.r.value,
+            self.phi.value,
+        )
+        means = gaussian.vacuum_means(2)
         State.__init__(self, cov=cov, means=means, cutoffs=cutoffs)
 
     @property
     def cov(self):
-        return gaussian.two_mode_squeezed_vacuum_cov(self.r.value, self.phi.value, settings.HBAR)
+        return gaussian.two_mode_squeezed_vacuum_cov(self.r.value, self.phi.value)
 
 
 class Thermal(Parametrized, State):
@@ -284,13 +289,13 @@ class Thermal(Parametrized, State):
         self._modes = modes
         self._normalize = normalize
 
-        cov = gaussian.thermal_cov(self.nbar.value, settings.HBAR)
-        means = gaussian.vacuum_means(cov.shape[-1] // 2, settings.HBAR)
+        cov = gaussian.thermal_cov(self.nbar.value)
+        means = gaussian.vacuum_means(cov.shape[-1] // 2)
         State.__init__(self, cov=cov, means=means, cutoffs=cutoffs)
 
     @property
     def cov(self):
-        return gaussian.thermal_cov(self.nbar.value, settings.HBAR)
+        return gaussian.thermal_cov(self.nbar.value)
 
 
 class DisplacedSqueezed(Parametrized, State):
@@ -371,17 +376,17 @@ class DisplacedSqueezed(Parametrized, State):
         self._modes = modes
         self._normalize = normalize
 
-        cov = gaussian.squeezed_vacuum_cov(self.r.value, self.phi.value, settings.HBAR)
-        means = gaussian.displacement(self.x.value, self.y.value, settings.HBAR)
+        cov = gaussian.squeezed_vacuum_cov(self.r.value, self.phi.value)
+        means = gaussian.displacement(self.x.value, self.y.value)
         State.__init__(self, cov=cov, means=means, cutoffs=cutoffs, modes=modes)
 
     @property
     def cov(self):
-        return gaussian.squeezed_vacuum_cov(self.r.value, self.phi.value, settings.HBAR)
+        return gaussian.squeezed_vacuum_cov(self.r.value, self.phi.value)
 
     @property
     def means(self):
-        return gaussian.displacement(self.x.value, self.y.value, settings.HBAR)
+        return gaussian.displacement(self.x.value, self.y.value)
 
 
 class Gaussian(Parametrized, State):
@@ -421,7 +426,10 @@ class Gaussian(Parametrized, State):
         eigenvalues: Vector = None,
         symplectic_trainable: bool = False,
         eigenvalues_trainable: bool = False,
-        eigenvalues_bounds: Tuple[Optional[float], Optional[float]] = (settings.HBAR / 2, None),
+        eigenvalues_bounds: Tuple[Optional[float], Optional[float]] = (
+            settings.HBAR / 2,
+            None,
+        ),
         modes: List[int] = None,
         cutoffs: Optional[Sequence[int]] = None,
         normalize: bool = False,
@@ -447,7 +455,7 @@ class Gaussian(Parametrized, State):
         self._normalize = normalize
 
         cov = gaussian.gaussian_cov(self.symplectic.value, self.eigenvalues.value)
-        means = gaussian.vacuum_means(cov.shape[-1] // 2, settings.HBAR)
+        means = gaussian.vacuum_means(cov.shape[-1] // 2)
         State.__init__(self, cov=cov, means=means, cutoffs=cutoffs)
 
     @property

--- a/mrmustard/lab/states.py
+++ b/mrmustard/lab/states.py
@@ -426,10 +426,7 @@ class Gaussian(Parametrized, State):
         eigenvalues: Vector = None,
         symplectic_trainable: bool = False,
         eigenvalues_trainable: bool = False,
-        eigenvalues_bounds: Tuple[Optional[float], Optional[float]] = (
-            settings.HBAR / 2,
-            None,
-        ),
+        eigenvalues_bounds: Tuple[Optional[float], Optional[float]] = (None, None),
         modes: List[int] = None,
         cutoffs: Optional[Sequence[int]] = None,
         normalize: bool = False,
@@ -448,7 +445,9 @@ class Gaussian(Parametrized, State):
             eigenvalues=eigenvalues,
             eigenvalues_trainable=eigenvalues_trainable,
             symplectic_trainable=symplectic_trainable,
-            eigenvalues_bounds=eigenvalues_bounds,
+            eigenvalues_bounds=(settings.HBAR / 2, None)
+            if eigenvalues_bounds == (None, None)
+            else eigenvalues_bounds,
             symplectic_bounds=(None, None),
         )
         self._modes = modes

--- a/mrmustard/physics/__init__.py
+++ b/mrmustard/physics/__init__.py
@@ -37,9 +37,7 @@ def fidelity(A, B) -> float:
     """
     if A.is_gaussian and B.is_gaussian:
         return gaussian.fidelity(A.means, A.cov, B.means, B.cov)
-    return fock.fidelity(
-        A.fock, B.fock, a_ket=A._ket is not None, b_ket=B._ket is not None
-    )
+    return fock.fidelity(A.fock, B.fock, a_ket=A._ket is not None, b_ket=B._ket is not None)
 
 
 def normalize(A):

--- a/mrmustard/physics/__init__.py
+++ b/mrmustard/physics/__init__.py
@@ -36,8 +36,10 @@ def fidelity(A, B) -> float:
         float: The fidelity between the two states.
     """
     if A.is_gaussian and B.is_gaussian:
-        return gaussian.fidelity(A.means, A.cov, B.means, B.cov, settings.HBAR)
-    return fock.fidelity(A.fock, B.fock, a_ket=A._ket is not None, b_ket=B._ket is not None)
+        return gaussian.fidelity(A.means, A.cov, B.means, B.cov)
+    return fock.fidelity(
+        A.fock, B.fock, a_ket=A._ket is not None, b_ket=B._ket is not None
+    )
 
 
 def normalize(A):

--- a/mrmustard/physics/__init__.py
+++ b/mrmustard/physics/__init__.py
@@ -92,9 +92,6 @@ def overlap(A, B) -> float:
         float: the overlap between the two states
     """
     raise NotImplementedError
-    if A.is_gaussian and B.is_gaussian:
-        return gaussian.overlap(A.means, A.cov, B.means, B.cov, settings.HBAR)
-    return fock.overlap(A.fock, B.fock, a_dm=A.is_mixed, b_dm=B.is_mixed)
 
 
 def von_neumann_entropy(A) -> float:
@@ -107,7 +104,7 @@ def von_neumann_entropy(A) -> float:
         float: the Von Neumann entropy of the state
     """
     if A.is_gaussian:
-        return gaussian.von_neumann_entropy(A.cov, settings.HBAR)
+        return gaussian.von_neumann_entropy(A.cov)
     return fock.von_neumann_entropy(A.fock, a_dm=A.is_mixed)
 
 
@@ -122,9 +119,6 @@ def relative_entropy(A, B) -> float:
         float: the relative entropy between the two states
     """
     raise NotImplementedError
-    if A.is_gaussian and B.is_gaussian:
-        return gaussian.relative_entropy(A.means, A.cov, B.means, B.cov, settings.HBAR)
-    return fock.relative_entropy(A.fock, B.fock, a_dm=A.is_mixed, b_dm=B.is_mixed)
 
 
 def trace_distance(A, B) -> float:
@@ -138,5 +132,5 @@ def trace_distance(A, B) -> float:
         float: the trace distance between the two states
     """
     if A.is_gaussian and B.is_gaussian:
-        return gaussian.trace_distance(A.means, A.cov, B.means, B.cov, settings.HBAR)
+        return gaussian.trace_distance(A.means, A.cov, B.means, B.cov)
     return fock.trace_distance(A.fock, B.fock, a_dm=A.is_mixed, b_dm=B.is_mixed)

--- a/mrmustard/physics/fock.py
+++ b/mrmustard/physics/fock.py
@@ -28,7 +28,9 @@ from mrmustard.math import Math
 from mrmustard.math.caching import tensor_int_cache
 from mrmustard.math.lattice import strategies
 from mrmustard.math.mmtensor import MMTensor
-from mrmustard.math.numba.compactFock_diagonal_amps import fock_representation_diagonal_amps
+from mrmustard.math.numba.compactFock_diagonal_amps import (
+    fock_representation_diagonal_amps,
+)
 from mrmustard.physics.bargmann import (
     wigner_to_bargmann_Choi,
     wigner_to_bargmann_psi,
@@ -74,7 +76,9 @@ def autocutoffs(cov: Matrix, means: Vector, probability: float):
     M = len(means) // 2
     cutoffs = []
     for i in range(M):
-        cov_i = np.array([[cov[i, i], cov[i, i + M]], [cov[i + M, i], cov[i + M, i + M]]])
+        cov_i = np.array(
+            [[cov[i, i], cov[i, i + M]], [cov[i + M, i], cov[i + M, i + M]]]
+        )
         means_i = np.array([means[i], means[i + M]])
         # apply 1-d recursion until probability is less than 0.99
         A, B, C = [math.asnumpy(x) for x in wigner_to_bargmann_rho(cov_i, means_i)]
@@ -268,7 +272,9 @@ def fidelity(state_a, state_b, a_ket: bool, b_ket: bool) -> Scalar:
         state_b = state_b[tuple(min_cutoffs * 2)]
         a = math.reshape(state_a, -1)
         return math.real(
-            math.sum(math.conj(a) * math.matvec(math.reshape(state_b, (len(a), len(a))), a))
+            math.sum(
+                math.conj(a) * math.matvec(math.reshape(state_b, (len(a), len(a))), a)
+            )
         )
 
     if b_ket:
@@ -280,7 +286,9 @@ def fidelity(state_a, state_b, a_ket: bool, b_ket: bool) -> Scalar:
         state_b = state_b[tuple(min_cutoffs)]
         b = math.reshape(state_b, -1)
         return math.real(
-            math.sum(math.conj(b) * math.matvec(math.reshape(state_a, (len(b), len(b))), b))
+            math.sum(
+                math.conj(b) * math.matvec(math.reshape(state_a, (len(b), len(b))), b)
+            )
         )
 
     # mixed state
@@ -290,7 +298,8 @@ def fidelity(state_a, state_b, a_ket: bool, b_ket: bool) -> Scalar:
     min_cutoffs = [
         slice(min(a, b))
         for a, b in zip(
-            state_a.shape[: len(state_a.shape) // 2], state_b.shape[: len(state_b.shape) // 2]
+            state_a.shape[: len(state_a.shape) // 2],
+            state_b.shape[: len(state_b.shape) // 2],
         )
     ]
     state_a = state_a[tuple(min_cutoffs * 2)]
@@ -299,7 +308,9 @@ def fidelity(state_a, state_b, a_ket: bool, b_ket: bool) -> Scalar:
         (
             math.trace(
                 math.sqrtm(
-                    math.matmul(math.matmul(math.sqrtm(state_a), state_b), math.sqrtm(state_a))
+                    math.matmul(
+                        math.matmul(math.sqrtm(state_a), state_b), math.sqrtm(state_a)
+                    )
                 )
             )
             ** 2
@@ -311,7 +322,9 @@ def number_means(tensor, is_dm: bool):
     r"""Returns the mean of the number operator in each mode."""
     probs = math.all_diagonals(tensor, real=True) if is_dm else math.abs(tensor) ** 2
     modes = list(range(len(probs.shape)))
-    marginals = [math.sum(probs, axes=modes[:k] + modes[k + 1 :]) for k in range(len(modes))]
+    marginals = [
+        math.sum(probs, axes=modes[:k] + modes[k + 1 :]) for k in range(len(modes))
+    ]
     return math.astensor(
         [
             math.sum(marginal * math.arange(len(marginal), dtype=marginal.dtype))
@@ -324,12 +337,19 @@ def number_variances(tensor, is_dm: bool):
     r"""Returns the variance of the number operator in each mode."""
     probs = math.all_diagonals(tensor, real=True) if is_dm else math.abs(tensor) ** 2
     modes = list(range(len(probs.shape)))
-    marginals = [math.sum(probs, axes=modes[:k] + modes[k + 1 :]) for k in range(len(modes))]
+    marginals = [
+        math.sum(probs, axes=modes[:k] + modes[k + 1 :]) for k in range(len(modes))
+    ]
     return math.astensor(
         [
             (
-                math.sum(marginal * math.arange(marginal.shape[0], dtype=marginal.dtype) ** 2)
-                - math.sum(marginal * math.arange(marginal.shape[0], dtype=marginal.dtype)) ** 2
+                math.sum(
+                    marginal * math.arange(marginal.shape[0], dtype=marginal.dtype) ** 2
+                )
+                - math.sum(
+                    marginal * math.arange(marginal.shape[0], dtype=marginal.dtype)
+                )
+                ** 2
             )
             for marginal in marginals
         ]
@@ -341,7 +361,9 @@ def purity(dm: Tensor) -> Scalar:
     cutoffs = dm.shape[: len(dm.shape) // 2]
     d = int(np.prod(cutoffs))  # combined cutoffs in all modes
     dm = math.reshape(dm, (d, d))
-    dm = dm / math.trace(dm)  # assumes all nonzero values are included in the density matrix
+    dm = dm / math.trace(
+        dm
+    )  # assumes all nonzero values are included in the density matrix
     return math.abs(math.sum(math.transpose(dm) * dm))  # tr(rho^2)
 
 
@@ -421,7 +443,9 @@ def apply_kraus_to_dm(kraus, dm, kraus_in_modes, kraus_out_modes=None):
         kraus_out_modes = kraus_in_modes
 
     if not set(kraus_in_modes).issubset(range(dm.ndim // 2)):
-        raise ValueError("kraus_in_modes should be a subset of the density matrix indices.")
+        raise ValueError(
+            "kraus_in_modes should be a subset of the density matrix indices."
+        )
 
     # check that there are no repeated indices in kraus_in_modes and kraus_out_modes (separately)
     validate_contraction_indices(kraus_in_modes, kraus_out_modes, dm.ndim // 2, "kraus")
@@ -479,7 +503,9 @@ def apply_choi_to_dm(
     if choi_out_modes is None:
         choi_out_modes = choi_in_modes
     if not set(choi_in_modes).issubset(range(dm.ndim // 2)):
-        raise ValueError("choi_in_modes should be a subset of the density matrix indices.")
+        raise ValueError(
+            "choi_in_modes should be a subset of the density matrix indices."
+        )
 
     # check that there are no repeated indices in kraus_in_modes and kraus_out_modes (separately)
     validate_contraction_indices(choi_in_modes, choi_out_modes, dm.ndim // 2, "choi")
@@ -536,7 +562,9 @@ def apply_choi_to_ket(choi, ket, choi_in_modes, choi_out_modes=None):
     validate_contraction_indices(choi_in_modes, choi_out_modes, ket.ndim, "choi")
 
     ket = MMTensor(ket, axis_labels=[f"left_{i}" for i in range(ket.ndim)])
-    ket_dual = MMTensor(math.conj(ket.tensor), axis_labels=[f"right_{i}" for i in range(ket.ndim)])
+    ket_dual = MMTensor(
+        math.conj(ket.tensor), axis_labels=[f"right_{i}" for i in range(ket.ndim)]
+    )
     choi = MMTensor(
         choi,
         axis_labels=[f"out_left_{i}" for i in choi_out_modes]
@@ -578,19 +606,30 @@ def contract_states(
 
     if a_is_dm:
         if b_is_dm:  # a DM, b DM
-            dm = apply_choi_to_dm(choi=stateB, dm=stateA, choi_in_modes=modes, choi_out_modes=[])
+            dm = apply_choi_to_dm(
+                choi=stateB, dm=stateA, choi_in_modes=modes, choi_out_modes=[]
+            )
         else:  # a DM, b ket
             dm = apply_kraus_to_dm(
-                kraus=math.conj(stateB), dm=stateA, kraus_in_modes=modes, kraus_out_modes=[]
+                kraus=math.conj(stateB),
+                dm=stateA,
+                kraus_in_modes=modes,
+                kraus_out_modes=[],
             )
     else:
         if b_is_dm:  # a ket, b DM
             dm = apply_kraus_to_dm(
-                kraus=math.conj(stateA), dm=stateB, kraus_in_modes=modes, kraus_out_modes=[]
+                kraus=math.conj(stateA),
+                dm=stateB,
+                kraus_in_modes=modes,
+                kraus_out_modes=[],
             )
         else:  # a ket, b ket
             ket = apply_kraus_to_ket(
-                kraus=math.conj(stateB), ket=stateA, kraus_in_modes=modes, kraus_out_modes=[]
+                kraus=math.conj(stateB),
+                ket=stateA,
+                kraus_in_modes=modes,
+                kraus_out_modes=[],
             )
 
     try:
@@ -648,9 +687,13 @@ def trace(dm, keep: List[int]):
     dm = MMTensor(
         dm,
         axis_labels=[
-            f"out_{i}" if i in keep else f"contract_{i}" for i in range(len(dm.shape) // 2)
+            f"out_{i}" if i in keep else f"contract_{i}"
+            for i in range(len(dm.shape) // 2)
         ]
-        + [f"in_{i}" if i in keep else f"contract_{i}" for i in range(len(dm.shape) // 2)],
+        + [
+            f"in_{i}" if i in keep else f"contract_{i}"
+            for i in range(len(dm.shape) // 2)
+        ],
     )
     return dm.contract().tensor
 
@@ -662,7 +705,6 @@ def oscillator_eigenstate(q: Vector, cutoff: int) -> Tensor:
     Args:
         q (Vector): a vector containing the q points at which the function is evaluated (units of \sqrt{\hbar})
         cutoff (int): maximum number of photons
-        hbar (optional): value of `\hbar`, defaults to Mr Mustard's internal value
 
     Returns:
         Tensor: a tensor of size ``len(q)*cutoff``. Each entry with index ``[i, j]`` represents the eigenstate evaluated
@@ -686,7 +728,9 @@ def oscillator_eigenstate(q: Vector, cutoff: int) -> Tensor:
     x_tensor = math.sqrt(omega_over_hbar) * math.cast(q, "float64")  # unit-less vector
 
     # prefactor term (\Omega/\hbar \pi)**(1/4) * 1 / sqrt(2**n)
-    prefactor = (omega_over_hbar / np.pi) ** (1 / 4) * math.sqrt(2 ** (-math.arange(0, cutoff)))
+    prefactor = (omega_over_hbar / np.pi) ** (1 / 4) * math.sqrt(
+        2 ** (-math.arange(0, cutoff))
+    )
 
     # Renormalized physicist hermite polys: Hn / sqrt(n!)
     R = -np.array([[2 + 0j]])  # to get the physicist polys
@@ -780,7 +824,9 @@ def estimate_quadrature_axis(cutoff, minimum=5, period_resolution=20):
 
 
 def quadrature_distribution(
-    state: Tensor, quadrature_angle: float = 0.0, x: Vector = None, hbar: Optional[float] = None
+    state: Tensor,
+    quadrature_angle: float = 0.0,
+    x: Vector = None,
 ):
     r"""Given the ket or density matrix of a single-mode state, it generates the probability
     density distribution :math:`\tr [ \rho |x_\phi><x_\phi| ]`  where `\rho` is the
@@ -815,8 +861,9 @@ def quadrature_distribution(
         )
 
     if x is None:
-        hbar = hbar or settings.HBAR
-        x = np.sqrt(hbar) * math.new_constant(estimate_quadrature_axis(cutoff), "q_tensor")
+        x = np.sqrt(settings.HBAR) * math.new_constant(
+            estimate_quadrature_axis(cutoff), "q_tensor"
+        )
 
     psi_x = math.cast(oscillator_eigenstate(x, cutoff), "complex128")
     pdf = (
@@ -829,7 +876,7 @@ def quadrature_distribution(
 
 
 def sample_homodyne(
-    state: Tensor, quadrature_angle: float = 0.0, hbar: Optional[float] = None
+    state: Tensor, quadrature_angle: float = 0.0
 ) -> Tuple[float, float]:
     r"""Given a single-mode state, it generates the pdf of :math:`\tr [ \rho |x_\phi><x_\phi| ]`
     where `\rho` is the reduced density matrix of the state.
@@ -847,7 +894,7 @@ def sample_homodyne(
             "Input state has dimension {state.shape}. Make sure is either a single-mode ket or dm."
         )
 
-    x, pdf = quadrature_distribution(state, quadrature_angle, hbar=hbar or settings.HBAR)
+    x, pdf = quadrature_distribution(state, quadrature_angle, settings.HBAR)
     probs = pdf * (x[1] - x[0])
 
     # draw a sample from the distribution
@@ -889,7 +936,9 @@ def beamsplitter(theta: float, phi: float, shape: Sequence[int], method: str):
         cutoffs (int,int): cutoff dimensions of the two modes
     """
     if method == "vanilla":
-        bs_unitary = strategies.beamsplitter(shape, math.asnumpy(theta), math.asnumpy(phi))
+        bs_unitary = strategies.beamsplitter(
+            shape, math.asnumpy(theta), math.asnumpy(phi)
+        )
     elif method == "schwinger":
         bs_unitary = strategies.beamsplitter_schwinger(
             shape, math.asnumpy(theta), math.asnumpy(phi)
@@ -906,7 +955,9 @@ def beamsplitter(theta: float, phi: float, shape: Sequence[int], method: str):
             math.asnumpy(theta),
             math.asnumpy(phi),
         )
-        return math.astensor(dtheta, dtype=theta.dtype), math.astensor(dphi, dtype=phi.dtype)
+        return math.astensor(dtheta, dtype=theta.dtype), math.astensor(
+            dphi, dtype=phi.dtype
+        )
 
     return math.astensor(bs_unitary, dtype=bs_unitary.dtype.name), vjp
 

--- a/mrmustard/physics/fock.py
+++ b/mrmustard/physics/fock.py
@@ -76,7 +76,9 @@ def autocutoffs(cov: Matrix, means: Vector, probability: float):
     M = len(means) // 2
     cutoffs = []
     for i in range(M):
-        cov_i = np.array([[cov[i, i], cov[i, i + M]], [cov[i + M, i], cov[i + M, i + M]]])
+        cov_i = np.array(
+            [[cov[i, i], cov[i, i + M]], [cov[i + M, i], cov[i + M, i + M]]]
+        )
         means_i = np.array([means[i], means[i + M]])
         # apply 1-d recursion until probability is less than 0.99
         A, B, C = [math.asnumpy(x) for x in wigner_to_bargmann_rho(cov_i, means_i)]
@@ -270,7 +272,9 @@ def fidelity(state_a, state_b, a_ket: bool, b_ket: bool) -> Scalar:
         state_b = state_b[tuple(min_cutoffs * 2)]
         a = math.reshape(state_a, -1)
         return math.real(
-            math.sum(math.conj(a) * math.matvec(math.reshape(state_b, (len(a), len(a))), a))
+            math.sum(
+                math.conj(a) * math.matvec(math.reshape(state_b, (len(a), len(a))), a)
+            )
         )
 
     if b_ket:
@@ -282,7 +286,9 @@ def fidelity(state_a, state_b, a_ket: bool, b_ket: bool) -> Scalar:
         state_b = state_b[tuple(min_cutoffs)]
         b = math.reshape(state_b, -1)
         return math.real(
-            math.sum(math.conj(b) * math.matvec(math.reshape(state_a, (len(b), len(b))), b))
+            math.sum(
+                math.conj(b) * math.matvec(math.reshape(state_a, (len(b), len(b))), b)
+            )
         )
 
     # mixed state
@@ -302,7 +308,9 @@ def fidelity(state_a, state_b, a_ket: bool, b_ket: bool) -> Scalar:
         (
             math.trace(
                 math.sqrtm(
-                    math.matmul(math.matmul(math.sqrtm(state_a), state_b), math.sqrtm(state_a))
+                    math.matmul(
+                        math.matmul(math.sqrtm(state_a), state_b), math.sqrtm(state_a)
+                    )
                 )
             )
             ** 2
@@ -314,7 +322,9 @@ def number_means(tensor, is_dm: bool):
     r"""Returns the mean of the number operator in each mode."""
     probs = math.all_diagonals(tensor, real=True) if is_dm else math.abs(tensor) ** 2
     modes = list(range(len(probs.shape)))
-    marginals = [math.sum(probs, axes=modes[:k] + modes[k + 1 :]) for k in range(len(modes))]
+    marginals = [
+        math.sum(probs, axes=modes[:k] + modes[k + 1 :]) for k in range(len(modes))
+    ]
     return math.astensor(
         [
             math.sum(marginal * math.arange(len(marginal), dtype=marginal.dtype))
@@ -327,12 +337,19 @@ def number_variances(tensor, is_dm: bool):
     r"""Returns the variance of the number operator in each mode."""
     probs = math.all_diagonals(tensor, real=True) if is_dm else math.abs(tensor) ** 2
     modes = list(range(len(probs.shape)))
-    marginals = [math.sum(probs, axes=modes[:k] + modes[k + 1 :]) for k in range(len(modes))]
+    marginals = [
+        math.sum(probs, axes=modes[:k] + modes[k + 1 :]) for k in range(len(modes))
+    ]
     return math.astensor(
         [
             (
-                math.sum(marginal * math.arange(marginal.shape[0], dtype=marginal.dtype) ** 2)
-                - math.sum(marginal * math.arange(marginal.shape[0], dtype=marginal.dtype)) ** 2
+                math.sum(
+                    marginal * math.arange(marginal.shape[0], dtype=marginal.dtype) ** 2
+                )
+                - math.sum(
+                    marginal * math.arange(marginal.shape[0], dtype=marginal.dtype)
+                )
+                ** 2
             )
             for marginal in marginals
         ]
@@ -344,7 +361,9 @@ def purity(dm: Tensor) -> Scalar:
     cutoffs = dm.shape[: len(dm.shape) // 2]
     d = int(np.prod(cutoffs))  # combined cutoffs in all modes
     dm = math.reshape(dm, (d, d))
-    dm = dm / math.trace(dm)  # assumes all nonzero values are included in the density matrix
+    dm = dm / math.trace(
+        dm
+    )  # assumes all nonzero values are included in the density matrix
     return math.abs(math.sum(math.transpose(dm) * dm))  # tr(rho^2)
 
 
@@ -424,7 +443,9 @@ def apply_kraus_to_dm(kraus, dm, kraus_in_modes, kraus_out_modes=None):
         kraus_out_modes = kraus_in_modes
 
     if not set(kraus_in_modes).issubset(range(dm.ndim // 2)):
-        raise ValueError("kraus_in_modes should be a subset of the density matrix indices.")
+        raise ValueError(
+            "kraus_in_modes should be a subset of the density matrix indices."
+        )
 
     # check that there are no repeated indices in kraus_in_modes and kraus_out_modes (separately)
     validate_contraction_indices(kraus_in_modes, kraus_out_modes, dm.ndim // 2, "kraus")
@@ -482,7 +503,9 @@ def apply_choi_to_dm(
     if choi_out_modes is None:
         choi_out_modes = choi_in_modes
     if not set(choi_in_modes).issubset(range(dm.ndim // 2)):
-        raise ValueError("choi_in_modes should be a subset of the density matrix indices.")
+        raise ValueError(
+            "choi_in_modes should be a subset of the density matrix indices."
+        )
 
     # check that there are no repeated indices in kraus_in_modes and kraus_out_modes (separately)
     validate_contraction_indices(choi_in_modes, choi_out_modes, dm.ndim // 2, "choi")
@@ -539,7 +562,9 @@ def apply_choi_to_ket(choi, ket, choi_in_modes, choi_out_modes=None):
     validate_contraction_indices(choi_in_modes, choi_out_modes, ket.ndim, "choi")
 
     ket = MMTensor(ket, axis_labels=[f"left_{i}" for i in range(ket.ndim)])
-    ket_dual = MMTensor(math.conj(ket.tensor), axis_labels=[f"right_{i}" for i in range(ket.ndim)])
+    ket_dual = MMTensor(
+        math.conj(ket.tensor), axis_labels=[f"right_{i}" for i in range(ket.ndim)]
+    )
     choi = MMTensor(
         choi,
         axis_labels=[f"out_left_{i}" for i in choi_out_modes]
@@ -581,7 +606,9 @@ def contract_states(
 
     if a_is_dm:
         if b_is_dm:  # a DM, b DM
-            dm = apply_choi_to_dm(choi=stateB, dm=stateA, choi_in_modes=modes, choi_out_modes=[])
+            dm = apply_choi_to_dm(
+                choi=stateB, dm=stateA, choi_in_modes=modes, choi_out_modes=[]
+            )
         else:  # a DM, b ket
             dm = apply_kraus_to_dm(
                 kraus=math.conj(stateB),
@@ -660,9 +687,13 @@ def trace(dm, keep: List[int]):
     dm = MMTensor(
         dm,
         axis_labels=[
-            f"out_{i}" if i in keep else f"contract_{i}" for i in range(len(dm.shape) // 2)
+            f"out_{i}" if i in keep else f"contract_{i}"
+            for i in range(len(dm.shape) // 2)
         ]
-        + [f"in_{i}" if i in keep else f"contract_{i}" for i in range(len(dm.shape) // 2)],
+        + [
+            f"in_{i}" if i in keep else f"contract_{i}"
+            for i in range(len(dm.shape) // 2)
+        ],
     )
     return dm.contract().tensor
 
@@ -697,7 +728,9 @@ def oscillator_eigenstate(q: Vector, cutoff: int) -> Tensor:
     x_tensor = math.sqrt(omega_over_hbar) * math.cast(q, "float64")  # unit-less vector
 
     # prefactor term (\Omega/\hbar \pi)**(1/4) * 1 / sqrt(2**n)
-    prefactor = (omega_over_hbar / np.pi) ** (1 / 4) * math.sqrt(2 ** (-math.arange(0, cutoff)))
+    prefactor = (omega_over_hbar / np.pi) ** (1 / 4) * math.sqrt(
+        2 ** (-math.arange(0, cutoff))
+    )
 
     # Renormalized physicist hermite polys: Hn / sqrt(n!)
     R = -np.array([[2 + 0j]])  # to get the physicist polys
@@ -828,7 +861,9 @@ def quadrature_distribution(
         )
 
     if x is None:
-        x = np.sqrt(settings.HBAR) * math.new_constant(estimate_quadrature_axis(cutoff), "q_tensor")
+        x = np.sqrt(settings.HBAR) * math.new_constant(
+            estimate_quadrature_axis(cutoff), "q_tensor"
+        )
 
     psi_x = math.cast(oscillator_eigenstate(x, cutoff), "complex128")
     pdf = (
@@ -840,7 +875,9 @@ def quadrature_distribution(
     return x, math.cast(pdf, "float64")
 
 
-def sample_homodyne(state: Tensor, quadrature_angle: float = 0.0) -> Tuple[float, float]:
+def sample_homodyne(
+    state: Tensor, quadrature_angle: float = 0.0
+) -> Tuple[float, float]:
     r"""Given a single-mode state, it generates the pdf of :math:`\tr [ \rho |x_\phi><x_\phi| ]`
     where `\rho` is the reduced density matrix of the state.
 
@@ -857,7 +894,7 @@ def sample_homodyne(state: Tensor, quadrature_angle: float = 0.0) -> Tuple[float
             "Input state has dimension {state.shape}. Make sure is either a single-mode ket or dm."
         )
 
-    x, pdf = quadrature_distribution(state, quadrature_angle, settings.HBAR)
+    x, pdf = quadrature_distribution(state, quadrature_angle)
     probs = pdf * (x[1] - x[0])
 
     # draw a sample from the distribution
@@ -899,7 +936,9 @@ def beamsplitter(theta: float, phi: float, shape: Sequence[int], method: str):
         cutoffs (int,int): cutoff dimensions of the two modes
     """
     if method == "vanilla":
-        bs_unitary = strategies.beamsplitter(shape, math.asnumpy(theta), math.asnumpy(phi))
+        bs_unitary = strategies.beamsplitter(
+            shape, math.asnumpy(theta), math.asnumpy(phi)
+        )
     elif method == "schwinger":
         bs_unitary = strategies.beamsplitter_schwinger(
             shape, math.asnumpy(theta), math.asnumpy(phi)
@@ -916,7 +955,9 @@ def beamsplitter(theta: float, phi: float, shape: Sequence[int], method: str):
             math.asnumpy(theta),
             math.asnumpy(phi),
         )
-        return math.astensor(dtheta, dtype=theta.dtype), math.astensor(dphi, dtype=phi.dtype)
+        return math.astensor(dtheta, dtype=theta.dtype), math.astensor(
+            dphi, dtype=phi.dtype
+        )
 
     return math.astensor(bs_unitary, dtype=bs_unitary.dtype.name), vjp
 

--- a/mrmustard/physics/fock.py
+++ b/mrmustard/physics/fock.py
@@ -76,9 +76,7 @@ def autocutoffs(cov: Matrix, means: Vector, probability: float):
     M = len(means) // 2
     cutoffs = []
     for i in range(M):
-        cov_i = np.array(
-            [[cov[i, i], cov[i, i + M]], [cov[i + M, i], cov[i + M, i + M]]]
-        )
+        cov_i = np.array([[cov[i, i], cov[i, i + M]], [cov[i + M, i], cov[i + M, i + M]]])
         means_i = np.array([means[i], means[i + M]])
         # apply 1-d recursion until probability is less than 0.99
         A, B, C = [math.asnumpy(x) for x in wigner_to_bargmann_rho(cov_i, means_i)]
@@ -272,9 +270,7 @@ def fidelity(state_a, state_b, a_ket: bool, b_ket: bool) -> Scalar:
         state_b = state_b[tuple(min_cutoffs * 2)]
         a = math.reshape(state_a, -1)
         return math.real(
-            math.sum(
-                math.conj(a) * math.matvec(math.reshape(state_b, (len(a), len(a))), a)
-            )
+            math.sum(math.conj(a) * math.matvec(math.reshape(state_b, (len(a), len(a))), a))
         )
 
     if b_ket:
@@ -286,9 +282,7 @@ def fidelity(state_a, state_b, a_ket: bool, b_ket: bool) -> Scalar:
         state_b = state_b[tuple(min_cutoffs)]
         b = math.reshape(state_b, -1)
         return math.real(
-            math.sum(
-                math.conj(b) * math.matvec(math.reshape(state_a, (len(b), len(b))), b)
-            )
+            math.sum(math.conj(b) * math.matvec(math.reshape(state_a, (len(b), len(b))), b))
         )
 
     # mixed state
@@ -308,9 +302,7 @@ def fidelity(state_a, state_b, a_ket: bool, b_ket: bool) -> Scalar:
         (
             math.trace(
                 math.sqrtm(
-                    math.matmul(
-                        math.matmul(math.sqrtm(state_a), state_b), math.sqrtm(state_a)
-                    )
+                    math.matmul(math.matmul(math.sqrtm(state_a), state_b), math.sqrtm(state_a))
                 )
             )
             ** 2
@@ -322,9 +314,7 @@ def number_means(tensor, is_dm: bool):
     r"""Returns the mean of the number operator in each mode."""
     probs = math.all_diagonals(tensor, real=True) if is_dm else math.abs(tensor) ** 2
     modes = list(range(len(probs.shape)))
-    marginals = [
-        math.sum(probs, axes=modes[:k] + modes[k + 1 :]) for k in range(len(modes))
-    ]
+    marginals = [math.sum(probs, axes=modes[:k] + modes[k + 1 :]) for k in range(len(modes))]
     return math.astensor(
         [
             math.sum(marginal * math.arange(len(marginal), dtype=marginal.dtype))
@@ -337,19 +327,12 @@ def number_variances(tensor, is_dm: bool):
     r"""Returns the variance of the number operator in each mode."""
     probs = math.all_diagonals(tensor, real=True) if is_dm else math.abs(tensor) ** 2
     modes = list(range(len(probs.shape)))
-    marginals = [
-        math.sum(probs, axes=modes[:k] + modes[k + 1 :]) for k in range(len(modes))
-    ]
+    marginals = [math.sum(probs, axes=modes[:k] + modes[k + 1 :]) for k in range(len(modes))]
     return math.astensor(
         [
             (
-                math.sum(
-                    marginal * math.arange(marginal.shape[0], dtype=marginal.dtype) ** 2
-                )
-                - math.sum(
-                    marginal * math.arange(marginal.shape[0], dtype=marginal.dtype)
-                )
-                ** 2
+                math.sum(marginal * math.arange(marginal.shape[0], dtype=marginal.dtype) ** 2)
+                - math.sum(marginal * math.arange(marginal.shape[0], dtype=marginal.dtype)) ** 2
             )
             for marginal in marginals
         ]
@@ -361,9 +344,7 @@ def purity(dm: Tensor) -> Scalar:
     cutoffs = dm.shape[: len(dm.shape) // 2]
     d = int(np.prod(cutoffs))  # combined cutoffs in all modes
     dm = math.reshape(dm, (d, d))
-    dm = dm / math.trace(
-        dm
-    )  # assumes all nonzero values are included in the density matrix
+    dm = dm / math.trace(dm)  # assumes all nonzero values are included in the density matrix
     return math.abs(math.sum(math.transpose(dm) * dm))  # tr(rho^2)
 
 
@@ -443,9 +424,7 @@ def apply_kraus_to_dm(kraus, dm, kraus_in_modes, kraus_out_modes=None):
         kraus_out_modes = kraus_in_modes
 
     if not set(kraus_in_modes).issubset(range(dm.ndim // 2)):
-        raise ValueError(
-            "kraus_in_modes should be a subset of the density matrix indices."
-        )
+        raise ValueError("kraus_in_modes should be a subset of the density matrix indices.")
 
     # check that there are no repeated indices in kraus_in_modes and kraus_out_modes (separately)
     validate_contraction_indices(kraus_in_modes, kraus_out_modes, dm.ndim // 2, "kraus")
@@ -503,9 +482,7 @@ def apply_choi_to_dm(
     if choi_out_modes is None:
         choi_out_modes = choi_in_modes
     if not set(choi_in_modes).issubset(range(dm.ndim // 2)):
-        raise ValueError(
-            "choi_in_modes should be a subset of the density matrix indices."
-        )
+        raise ValueError("choi_in_modes should be a subset of the density matrix indices.")
 
     # check that there are no repeated indices in kraus_in_modes and kraus_out_modes (separately)
     validate_contraction_indices(choi_in_modes, choi_out_modes, dm.ndim // 2, "choi")
@@ -562,9 +539,7 @@ def apply_choi_to_ket(choi, ket, choi_in_modes, choi_out_modes=None):
     validate_contraction_indices(choi_in_modes, choi_out_modes, ket.ndim, "choi")
 
     ket = MMTensor(ket, axis_labels=[f"left_{i}" for i in range(ket.ndim)])
-    ket_dual = MMTensor(
-        math.conj(ket.tensor), axis_labels=[f"right_{i}" for i in range(ket.ndim)]
-    )
+    ket_dual = MMTensor(math.conj(ket.tensor), axis_labels=[f"right_{i}" for i in range(ket.ndim)])
     choi = MMTensor(
         choi,
         axis_labels=[f"out_left_{i}" for i in choi_out_modes]
@@ -606,9 +581,7 @@ def contract_states(
 
     if a_is_dm:
         if b_is_dm:  # a DM, b DM
-            dm = apply_choi_to_dm(
-                choi=stateB, dm=stateA, choi_in_modes=modes, choi_out_modes=[]
-            )
+            dm = apply_choi_to_dm(choi=stateB, dm=stateA, choi_in_modes=modes, choi_out_modes=[])
         else:  # a DM, b ket
             dm = apply_kraus_to_dm(
                 kraus=math.conj(stateB),
@@ -687,13 +660,9 @@ def trace(dm, keep: List[int]):
     dm = MMTensor(
         dm,
         axis_labels=[
-            f"out_{i}" if i in keep else f"contract_{i}"
-            for i in range(len(dm.shape) // 2)
+            f"out_{i}" if i in keep else f"contract_{i}" for i in range(len(dm.shape) // 2)
         ]
-        + [
-            f"in_{i}" if i in keep else f"contract_{i}"
-            for i in range(len(dm.shape) // 2)
-        ],
+        + [f"in_{i}" if i in keep else f"contract_{i}" for i in range(len(dm.shape) // 2)],
     )
     return dm.contract().tensor
 
@@ -728,9 +697,7 @@ def oscillator_eigenstate(q: Vector, cutoff: int) -> Tensor:
     x_tensor = math.sqrt(omega_over_hbar) * math.cast(q, "float64")  # unit-less vector
 
     # prefactor term (\Omega/\hbar \pi)**(1/4) * 1 / sqrt(2**n)
-    prefactor = (omega_over_hbar / np.pi) ** (1 / 4) * math.sqrt(
-        2 ** (-math.arange(0, cutoff))
-    )
+    prefactor = (omega_over_hbar / np.pi) ** (1 / 4) * math.sqrt(2 ** (-math.arange(0, cutoff)))
 
     # Renormalized physicist hermite polys: Hn / sqrt(n!)
     R = -np.array([[2 + 0j]])  # to get the physicist polys
@@ -861,9 +828,7 @@ def quadrature_distribution(
         )
 
     if x is None:
-        x = np.sqrt(settings.HBAR) * math.new_constant(
-            estimate_quadrature_axis(cutoff), "q_tensor"
-        )
+        x = np.sqrt(settings.HBAR) * math.new_constant(estimate_quadrature_axis(cutoff), "q_tensor")
 
     psi_x = math.cast(oscillator_eigenstate(x, cutoff), "complex128")
     pdf = (
@@ -875,9 +840,7 @@ def quadrature_distribution(
     return x, math.cast(pdf, "float64")
 
 
-def sample_homodyne(
-    state: Tensor, quadrature_angle: float = 0.0
-) -> Tuple[float, float]:
+def sample_homodyne(state: Tensor, quadrature_angle: float = 0.0) -> Tuple[float, float]:
     r"""Given a single-mode state, it generates the pdf of :math:`\tr [ \rho |x_\phi><x_\phi| ]`
     where `\rho` is the reduced density matrix of the state.
 
@@ -936,9 +899,7 @@ def beamsplitter(theta: float, phi: float, shape: Sequence[int], method: str):
         cutoffs (int,int): cutoff dimensions of the two modes
     """
     if method == "vanilla":
-        bs_unitary = strategies.beamsplitter(
-            shape, math.asnumpy(theta), math.asnumpy(phi)
-        )
+        bs_unitary = strategies.beamsplitter(shape, math.asnumpy(theta), math.asnumpy(phi))
     elif method == "schwinger":
         bs_unitary = strategies.beamsplitter_schwinger(
             shape, math.asnumpy(theta), math.asnumpy(phi)
@@ -955,9 +916,7 @@ def beamsplitter(theta: float, phi: float, shape: Sequence[int], method: str):
             math.asnumpy(theta),
             math.asnumpy(phi),
         )
-        return math.astensor(dtheta, dtype=theta.dtype), math.astensor(
-            dphi, dtype=phi.dtype
-        )
+        return math.astensor(dtheta, dtype=theta.dtype), math.astensor(dphi, dtype=phi.dtype)
 
     return math.astensor(bs_unitary, dtype=bs_unitary.dtype.name), vjp
 

--- a/mrmustard/physics/gaussian.py
+++ b/mrmustard/physics/gaussian.py
@@ -33,25 +33,23 @@ math = Math()
 #  ~~~~~~
 
 
-def vacuum_cov(num_modes: int, hbar: float) -> Matrix:
+def vacuum_cov(num_modes: int) -> Matrix:
     r"""Returns the real covariance matrix of the vacuum state.
 
     Args:
         num_modes (int): number of modes
-        hbar (float): value of ``hbar``
 
     Returns:
         Matrix: vacuum covariance matrix
     """
-    return math.eye(num_modes * 2, dtype=math.float64) * hbar / 2
+    return math.eye(num_modes * 2, dtype=math.float64) * settings.HBAR / 2
 
 
-def vacuum_means(num_modes: int, hbar: float) -> Tuple[Matrix, Vector]:
+def vacuum_means(num_modes: int) -> Tuple[Matrix, Vector]:
     r"""Returns the real covariance matrix and real means vector of the vacuum state.
 
     Args:
         num_modes (int): number of modes
-        hbar (float): value of ``hbar``
 
     Returns:
         Matrix, Vector: thermal state covariance matrix or means vector
@@ -59,11 +57,11 @@ def vacuum_means(num_modes: int, hbar: float) -> Tuple[Matrix, Vector]:
     return displacement(
         math.zeros(num_modes, dtype="float64"),
         math.zeros(num_modes, dtype="float64"),
-        hbar,
+        settings.HBAR,
     )
 
 
-def squeezed_vacuum_cov(r: Vector, phi: Vector, hbar: float) -> Matrix:
+def squeezed_vacuum_cov(r: Vector, phi: Vector) -> Matrix:
     r"""Returns the real covariance matrix and real means vector of a squeezed vacuum state.
 
     The dimension depends on the dimensions of ``r`` and ``phi``.
@@ -71,32 +69,30 @@ def squeezed_vacuum_cov(r: Vector, phi: Vector, hbar: float) -> Matrix:
     Args:
         r (vector): squeezing magnitude
         phi (vector): squeezing angle
-        hbar: value of ``hbar``
 
     Returns:
         Matrix, Vector: thermal state covariance matrix or means vector
     """
     S = squeezing_symplectic(r, phi)
-    return math.matmul(S, math.transpose(S)) * hbar / 2
+    return math.matmul(S, math.transpose(S)) * settings.HBAR / 2
 
 
-def thermal_cov(nbar: Vector, hbar: float) -> Tuple[Matrix, Vector]:
+def thermal_cov(nbar: Vector) -> Tuple[Matrix, Vector]:
     r"""Returns the real covariance matrix and real means vector of a thermal state.
 
     The dimension depends on the dimensions of ``nbar``.
 
     Args:
         nbar (vector): average number of photons per mode
-        hbar: value of ``hbar``
 
     Returns:
         Matrix, Vector: thermal state covariance matrix or means vector
     """
-    g = (2 * math.atleast_1d(nbar) + 1) * hbar / 2
+    g = (2 * math.atleast_1d(nbar) + 1) * settings.HBAR / 2
     return math.diag(math.concat([g, g], axis=-1))
 
 
-def two_mode_squeezed_vacuum_cov(r: Vector, phi: Vector, hbar: float) -> Matrix:
+def two_mode_squeezed_vacuum_cov(r: Vector, phi: Vector) -> Matrix:
     r"""Returns the real covariance matrix and real means vector of a two-mode squeezed vacuum state.
 
     The dimension depends on the dimensions of ``r`` and ``phi``.
@@ -104,14 +100,13 @@ def two_mode_squeezed_vacuum_cov(r: Vector, phi: Vector, hbar: float) -> Matrix:
     Args:
         r (vector): squeezing magnitude
         phi (vector): squeezing angle
-        hbar: value of hbar
 
     Returns:
         Matrix: two-mode squeezed state covariance matrix
         Vector: two-mode squeezed state means vector
     """
     S = two_mode_squeezing_symplectic(r, phi)
-    return math.matmul(S, math.transpose(S)) * hbar / 2
+    return math.matmul(S, math.transpose(S)) * settings.HBAR / 2
 
 
 def gaussian_cov(symplectic: Matrix, eigenvalues: Vector = None) -> Matrix:
@@ -128,7 +123,9 @@ def gaussian_cov(symplectic: Matrix, eigenvalues: Vector = None) -> Matrix:
         return math.matmul(symplectic, math.transpose(symplectic))
 
     return math.matmul(
-        math.matmul(symplectic, math.diag(math.concat([eigenvalues, eigenvalues], axis=0))),
+        math.matmul(
+            symplectic, math.diag(math.concat([eigenvalues, eigenvalues], axis=0))
+        ),
         math.transpose(symplectic),
     )
 
@@ -160,7 +157,9 @@ def rotation_symplectic(angle: Union[Scalar, Vector]) -> Matrix:
     )
 
 
-def squeezing_symplectic(r: Union[Scalar, Vector], phi: Union[Scalar, Vector]) -> Matrix:
+def squeezing_symplectic(
+    r: Union[Scalar, Vector], phi: Union[Scalar, Vector]
+) -> Matrix:
     r"""Symplectic matrix of a squeezing gate.
 
     The dimension depends on the dimension of ``r`` and ``phi``.
@@ -192,14 +191,13 @@ def squeezing_symplectic(r: Union[Scalar, Vector], phi: Union[Scalar, Vector]) -
     )
 
 
-def displacement(x: Union[Scalar, Vector], y: Union[Scalar, Vector], hbar: float) -> Vector:
+def displacement(x: Union[Scalar, Vector], y: Union[Scalar, Vector]) -> Vector:
     r"""Returns the displacement vector for a displacement by :math:`alpha = x + iy`.
     The dimension depends on the dimensions of ``x`` and ``y``.
 
     Args:
         x (scalar or vector): real part of displacement
         y (scalar or vector): imaginary part of displacement
-        hbar: value of hbar
 
     Returns:
         Vector: displacement vector of a displacement gate
@@ -210,7 +208,7 @@ def displacement(x: Union[Scalar, Vector], y: Union[Scalar, Vector], hbar: float
         x = math.tile(x, y.shape)
     if y.shape[-1] == 1:
         y = math.tile(y, x.shape)
-    return math.sqrt(2 * hbar, dtype=x.dtype) * math.concat([x, y], axis=0)
+    return math.sqrt(2 * settings.HBAR, dtype=x.dtype) * math.concat([x, y], axis=0)
 
 
 def beam_splitter_symplectic(theta: Scalar, phi: Scalar) -> Matrix:
@@ -419,7 +417,6 @@ def CPTP(
         d (Vector): displacement vector of the CPTP channel
         state_modes (Sequence[int]): modes the state is defined on
         transf_modes (Sequence[int]): modes on which the channel acts
-        hbar (float): value of hbar
 
     Returns:
         Tuple[Matrix, Vector]: the covariance matrix and the means vector of the state after the CPTP channel
@@ -447,7 +444,7 @@ def CPTP(
 
 
 def loss_XYd(
-    transmissivity: Union[Scalar, Vector], nbar: Union[Scalar, Vector], hbar: float
+    transmissivity: Union[Scalar, Vector], nbar: Union[Scalar, Vector]
 ) -> Tuple[Matrix, Matrix, None]:
     r"""Returns the ``X``, ``Y`` matrices and the ``d`` vector for the noisy loss (attenuator) channel.
 
@@ -470,12 +467,12 @@ def loss_XYd(
         raise ValueError("transmissivity must be between 0 and 1")
     x = math.sqrt(transmissivity)
     X = math.diag(math.concat([x, x], axis=0))
-    y = (1 - transmissivity) * (2 * nbar + 1) * hbar / 2
+    y = (1 - transmissivity) * (2 * nbar + 1) * settings.HBAR / 2
     Y = math.diag(math.concat([y, y], axis=0))
     return X, Y, None
 
 
-def amp_XYd(gain: Union[Scalar, Vector], nbar: Union[Scalar, Vector], hbar: float) -> Matrix:
+def amp_XYd(gain: Union[Scalar, Vector], nbar: Union[Scalar, Vector]) -> Matrix:
     r"""Returns the ``X``, ``Y`` matrices and the d vector for the noisy amplifier channel.
 
     The quantum limited amplifier channel is recovered for ``nbar = 0.0``.
@@ -493,12 +490,12 @@ def amp_XYd(gain: Union[Scalar, Vector], nbar: Union[Scalar, Vector], hbar: floa
         raise ValueError("Gain must be larger than 1")
     x = math.sqrt(gain)
     X = math.diag(math.concat([x, x], axis=0))
-    y = (gain - 1) * (2 * nbar + 1) * hbar / 2
+    y = (gain - 1) * (2 * nbar + 1) * settings.HBAR / 2
     Y = math.diag(math.concat([y, y], axis=0))
     return X, Y, None
 
 
-def noise_Y(noise: Union[Scalar, Vector], hbar: float) -> Matrix:
+def noise_Y(noise: Union[Scalar, Vector]) -> Matrix:
     r"""Returns the ``X``, ``Y`` matrices and the d vector for the additive noise channel ``(Y = noise * (\hbar / 2) * I)``
 
     Args:
@@ -507,7 +504,7 @@ def noise_Y(noise: Union[Scalar, Vector], hbar: float) -> Matrix:
     Returns:
         Tuple[None, Matrix, None]: the ``X``, ``Y`` matrices and the ``d`` vector of the noise channel.
     """
-    return math.diag(math.concat([noise, noise], axis=0)) * hbar / 2
+    return math.diag(math.concat([noise, noise], axis=0)) * settings.HBAR / 2
 
 
 def compose_channels_XYd(
@@ -592,7 +589,9 @@ def general_dyne(
     # (MrMustard uses Serafini convention where `sigma_MM = 2 sigma_TF`)
     pdf = math.MultivariateNormalTriL(loc=b, scale_tril=math.cholesky(reduced_cov / 2))
     outcome = (
-        pdf.sample(dtype=cov.dtype) if proj_means is None else math.cast(proj_means, cov.dtype)
+        pdf.sample(dtype=cov.dtype)
+        if proj_means is None
+        else math.cast(proj_means, cov.dtype)
     )
     prob = pdf.prob(outcome)
 
@@ -611,13 +610,12 @@ def general_dyne(
 # ~~~~~~~~~
 # utilities
 # ~~~~~~~~~
-def number_means(cov: Matrix, means: Vector, hbar: float) -> Vector:
+def number_means(cov: Matrix, means: Vector) -> Vector:
     r"""Returns the photon number means vector given a Wigner covariance matrix and a means vector.
 
     Args:
         cov: the Wigner covariance matrix
         means: the Wigner means vector
-        hbar: the value of the Planck constant
 
     Returns:
         Vector: the photon number means vector
@@ -628,35 +626,41 @@ def number_means(cov: Matrix, means: Vector, hbar: float) -> Vector:
         + means[N:] ** 2
         + math.diag_part(cov[:N, :N])
         + math.diag_part(cov[N:, N:])
-        - hbar
-    ) / (2 * hbar)
+        - settings.HBAR
+    ) / (2 * settings.HBAR)
 
 
-def number_cov(cov: Matrix, means: Vector, hbar: float) -> Matrix:
+def number_cov(cov: Matrix, means: Vector) -> Matrix:
     r"""Returns the photon number covariance matrix given a Wigner covariance matrix and a means vector.
 
     Args:
         cov: the Wigner covariance matrix
         means: the Wigner means vector
-        hbar: the value of the Planck constant
 
     Returns:
         Matrix: the photon number covariance matrix
     """
     N = means.shape[-1] // 2
     mCm = cov * means[:, None] * means[None, :]
-    dd = math.diag(math.diag_part(mCm[:N, :N] + mCm[N:, N:] + mCm[:N, N:] + mCm[N:, :N])) / (
-        2 * hbar**2  # TODO: sum(diag_part) is better than diag_part(sum)
+    dd = math.diag(
+        math.diag_part(mCm[:N, :N] + mCm[N:, N:] + mCm[:N, N:] + mCm[N:, :N])
+    ) / (
+        2 * settings.HBAR**2  # TODO: sum(diag_part) is better than diag_part(sum)
     )
-    CC = (cov**2 + mCm) / (2 * hbar**2)
+    CC = (cov**2 + mCm) / (2 * settings.HBAR**2)
     return (
-        CC[:N, :N] + CC[N:, N:] + CC[:N, N:] + CC[N:, :N] + dd - 0.25 * math.eye(N, dtype=CC.dtype)
+        CC[:N, :N]
+        + CC[N:, N:]
+        + CC[:N, N:]
+        + CC[N:, :N]
+        + dd
+        - 0.25 * math.eye(N, dtype=CC.dtype)
     )
 
 
 def is_mixed_cov(cov: Matrix) -> bool:  # TODO: deprecate
     r"""Returns ``True`` if the covariance matrix is mixed, ``False`` otherwise."""
-    return not is_pure_cov(math.asnumpy(cov), hbar=settings.HBAR)
+    return not is_pure_cov(math.asnumpy(cov))
 
 
 def trace(cov: Matrix, means: Vector, Bmodes: Sequence[int]) -> Tuple[Matrix, Vector]:
@@ -672,7 +676,8 @@ def trace(cov: Matrix, means: Vector, Bmodes: Sequence[int]) -> Tuple[Matrix, Ve
     """
     N = len(cov) // 2
     Aindices = math.astensor(
-        [i for i in range(N) if i not in Bmodes] + [i + N for i in range(N) if i not in Bmodes]
+        [i for i in range(N) if i not in Bmodes]
+        + [i + N for i in range(N) if i not in Bmodes]
     )
     A_cov_block = math.gather(math.gather(cov, Aindices, axis=0), Aindices, axis=1)
     A_means_vec = math.gather(means, Aindices)
@@ -691,7 +696,8 @@ def partition_cov(cov: Matrix, Amodes: Sequence[int]) -> Tuple[Matrix, Matrix, M
     """
     N = cov.shape[-1] // 2
     Bindices = math.cast(
-        [i for i in range(N) if i not in Amodes] + [i + N for i in range(N) if i not in Amodes],
+        [i for i in range(N) if i not in Amodes]
+        + [i + N for i in range(N) if i not in Amodes],
         "int32",
     )
     Aindices = math.cast(Amodes + [i + N for i in Amodes], "int32")
@@ -713,7 +719,8 @@ def partition_means(means: Vector, Amodes: Sequence[int]) -> Tuple[Vector, Vecto
     """
     N = len(means) // 2
     Bindices = math.cast(
-        [i for i in range(N) if i not in Amodes] + [i + N for i in range(N) if i not in Amodes],
+        [i for i in range(N) if i not in Amodes]
+        + [i + N for i in range(N) if i not in Amodes],
         "int32",
     )
     Aindices = math.cast(Amodes + [i + N for i in Amodes], "int32")
@@ -765,7 +772,9 @@ def von_neumann_entropy(cov: Matrix, hbar: float) -> float:
     """
 
     def g(x):
-        return math.xlogy((x + 1) / 2, (x + 1) / 2) - math.xlogy((x - 1) / 2, (x - 1) / 2 + 1e-9)
+        return math.xlogy((x + 1) / 2, (x + 1) / 2) - math.xlogy(
+            (x - 1) / 2, (x - 1) / 2 + 1e-9
+        )
 
     symp_vals = symplectic_eigenvals(cov, hbar)
     entropy = math.sum(g(symp_vals))
@@ -793,7 +802,9 @@ def fidelity(mu1: Vector, cov1: Matrix, mu2: Vector, cov2: Matrix, hbar=2.0) -> 
 
     mu1 = math.cast(mu1, "complex128")
     mu2 = math.cast(mu2, "complex128")
-    deltar = (mu2 - mu1) / math.sqrt(hbar, dtype=mu1.dtype)  # convert to units where hbar = 1
+    deltar = (mu2 - mu1) / math.sqrt(
+        hbar, dtype=mu1.dtype
+    )  # convert to units where hbar = 1
     J = math.J(cov1.shape[0] // 2)
     I = math.eye(cov1.shape[0])
     J = math.cast(J, "complex128")
@@ -861,7 +872,8 @@ def log_negativity(cov: Matrix, hbar: float) -> float:
     )  # Get rid of terms that would lead to zero contribution.
     if len(vals_filtered) > 0:
         return -math.sum(
-            math.log(vals_filtered) / math.cast(math.log(2.0), dtype=vals_filtered.dtype)
+            math.log(vals_filtered)
+            / math.cast(math.log(2.0), dtype=vals_filtered.dtype)
         )
 
     return 0
@@ -936,7 +948,9 @@ def XYd_dual(X: Matrix, Y: Matrix, d: Vector):
     d_dual = d
     if Y is not None:
         Y_dual = (
-            math.matmul(X_dual, math.matmul(Y, math.transpose(X_dual))) if X_dual is not None else Y
+            math.matmul(X_dual, math.matmul(Y, math.transpose(X_dual)))
+            if X_dual is not None
+            else Y
         )
     if d is not None:
         d_dual = math.matvec(X_dual, d) if X_dual is not None else d

--- a/mrmustard/physics/gaussian.py
+++ b/mrmustard/physics/gaussian.py
@@ -122,9 +122,7 @@ def gaussian_cov(symplectic: Matrix, eigenvalues: Vector = None) -> Matrix:
         return math.matmul(symplectic, math.transpose(symplectic))
 
     return math.matmul(
-        math.matmul(
-            symplectic, math.diag(math.concat([eigenvalues, eigenvalues], axis=0))
-        ),
+        math.matmul(symplectic, math.diag(math.concat([eigenvalues, eigenvalues], axis=0))),
         math.transpose(symplectic),
     )
 
@@ -156,9 +154,7 @@ def rotation_symplectic(angle: Union[Scalar, Vector]) -> Matrix:
     )
 
 
-def squeezing_symplectic(
-    r: Union[Scalar, Vector], phi: Union[Scalar, Vector]
-) -> Matrix:
+def squeezing_symplectic(r: Union[Scalar, Vector], phi: Union[Scalar, Vector]) -> Matrix:
     r"""Symplectic matrix of a squeezing gate.
 
     The dimension depends on the dimension of ``r`` and ``phi``.
@@ -588,9 +584,7 @@ def general_dyne(
     # (MrMustard uses Serafini convention where `sigma_MM = 2 sigma_TF`)
     pdf = math.MultivariateNormalTriL(loc=b, scale_tril=math.cholesky(reduced_cov / 2))
     outcome = (
-        pdf.sample(dtype=cov.dtype)
-        if proj_means is None
-        else math.cast(proj_means, cov.dtype)
+        pdf.sample(dtype=cov.dtype) if proj_means is None else math.cast(proj_means, cov.dtype)
     )
     prob = pdf.prob(outcome)
 
@@ -641,19 +635,12 @@ def number_cov(cov: Matrix, means: Vector) -> Matrix:
     """
     N = means.shape[-1] // 2
     mCm = cov * means[:, None] * means[None, :]
-    dd = math.diag(
-        math.diag_part(mCm[:N, :N] + mCm[N:, N:] + mCm[:N, N:] + mCm[N:, :N])
-    ) / (
+    dd = math.diag(math.diag_part(mCm[:N, :N] + mCm[N:, N:] + mCm[:N, N:] + mCm[N:, :N])) / (
         2 * settings.HBAR**2  # TODO: sum(diag_part) is better than diag_part(sum)
     )
     CC = (cov**2 + mCm) / (2 * settings.HBAR**2)
     return (
-        CC[:N, :N]
-        + CC[N:, N:]
-        + CC[:N, N:]
-        + CC[N:, :N]
-        + dd
-        - 0.25 * math.eye(N, dtype=CC.dtype)
+        CC[:N, :N] + CC[N:, N:] + CC[:N, N:] + CC[N:, :N] + dd - 0.25 * math.eye(N, dtype=CC.dtype)
     )
 
 
@@ -675,8 +662,7 @@ def trace(cov: Matrix, means: Vector, Bmodes: Sequence[int]) -> Tuple[Matrix, Ve
     """
     N = len(cov) // 2
     Aindices = math.astensor(
-        [i for i in range(N) if i not in Bmodes]
-        + [i + N for i in range(N) if i not in Bmodes]
+        [i for i in range(N) if i not in Bmodes] + [i + N for i in range(N) if i not in Bmodes]
     )
     A_cov_block = math.gather(math.gather(cov, Aindices, axis=0), Aindices, axis=1)
     A_means_vec = math.gather(means, Aindices)
@@ -695,8 +681,7 @@ def partition_cov(cov: Matrix, Amodes: Sequence[int]) -> Tuple[Matrix, Matrix, M
     """
     N = cov.shape[-1] // 2
     Bindices = math.cast(
-        [i for i in range(N) if i not in Amodes]
-        + [i + N for i in range(N) if i not in Amodes],
+        [i for i in range(N) if i not in Amodes] + [i + N for i in range(N) if i not in Amodes],
         "int32",
     )
     Aindices = math.cast(Amodes + [i + N for i in Amodes], "int32")
@@ -718,8 +703,7 @@ def partition_means(means: Vector, Amodes: Sequence[int]) -> Tuple[Vector, Vecto
     """
     N = len(means) // 2
     Bindices = math.cast(
-        [i for i in range(N) if i not in Amodes]
-        + [i + N for i in range(N) if i not in Amodes],
+        [i for i in range(N) if i not in Amodes] + [i + N for i in range(N) if i not in Amodes],
         "int32",
     )
     Aindices = math.cast(Amodes + [i + N for i in Amodes], "int32")
@@ -770,9 +754,7 @@ def von_neumann_entropy(cov: Matrix) -> float:
     """
 
     def g(x):
-        return math.xlogy((x + 1) / 2, (x + 1) / 2) - math.xlogy(
-            (x - 1) / 2, (x - 1) / 2 + 1e-9
-        )
+        return math.xlogy((x + 1) / 2, (x + 1) / 2) - math.xlogy((x - 1) / 2, (x - 1) / 2 + 1e-9)
 
     symp_vals = symplectic_eigenvals(cov)
     entropy = math.sum(g(symp_vals))
@@ -795,12 +777,8 @@ def fidelity(mu1: Vector, cov1: Matrix, mu2: Vector, cov2: Matrix) -> float:
         float: the fidelity
     """
 
-    cov1 = math.cast(
-        cov1 / settings.HBAR, "complex128"
-    )  # convert to units where hbar = 1
-    cov2 = math.cast(
-        cov2 / settings.HBAR, "complex128"
-    )  # convert to units where hbar = 1
+    cov1 = math.cast(cov1 / settings.HBAR, "complex128")  # convert to units where hbar = 1
+    cov2 = math.cast(cov2 / settings.HBAR, "complex128")  # convert to units where hbar = 1
 
     mu1 = math.cast(mu1, "complex128")
     mu2 = math.cast(mu2, "complex128")
@@ -874,8 +852,7 @@ def log_negativity(cov: Matrix) -> float:
     )  # Get rid of terms that would lead to zero contribution.
     if len(vals_filtered) > 0:
         return -math.sum(
-            math.log(vals_filtered)
-            / math.cast(math.log(2.0), dtype=vals_filtered.dtype)
+            math.log(vals_filtered) / math.cast(math.log(2.0), dtype=vals_filtered.dtype)
         )
 
     return 0
@@ -950,9 +927,7 @@ def XYd_dual(X: Matrix, Y: Matrix, d: Vector):
     d_dual = d
     if Y is not None:
         Y_dual = (
-            math.matmul(X_dual, math.matmul(Y, math.transpose(X_dual)))
-            if X_dual is not None
-            else Y
+            math.matmul(X_dual, math.matmul(Y, math.transpose(X_dual))) if X_dual is not None else Y
         )
     if d is not None:
         d_dual = math.matvec(X_dual, d) if X_dual is not None else d

--- a/mrmustard/utils/graphics.py
+++ b/mrmustard/utils/graphics.py
@@ -38,7 +38,9 @@ class Progressbar:
             )
         else:
             self.bar = Progress(
-                TextColumn("Step {task.completed}/{task.total} | {task.fields[speed]:.1f} it/s"),
+                TextColumn(
+                    "Step {task.completed}/{task.total} | {task.fields[speed]:.1f} it/s"
+                ),
                 BarColumn(),
                 TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
                 TextColumn("Cost = {task.fields[loss]:.5f} | ⏳ "),
@@ -113,23 +115,30 @@ def mikkel_plot(
 
     xvec = np.linspace(*xbounds, plot_args["resolution"])
     pvec = np.linspace(*ybounds, plot_args["resolution"])
-    W, X, P = wigner_discretized(rho, xvec, pvec, settings.HBAR)
+    W, X, P = wigner_discretized(rho, xvec, pvec)
 
     ### PLOTTING ###
 
     fig, ax = plt.subplots(
-        2, 2, figsize=(6, 6), gridspec_kw={"width_ratios": [2, 1], "height_ratios": [1, 2]}
+        2,
+        2,
+        figsize=(6, 6),
+        gridspec_kw={"width_ratios": [2, 1], "height_ratios": [1, 2]},
     )
     plt.subplots_adjust(wspace=0.05, hspace=0.05)
 
     # Wigner function
-    ax[1][0].contourf(X, P, W, 120, cmap=plot_args["cmap"], vmin=-abs(W).max(), vmax=abs(W).max())
+    ax[1][0].contourf(
+        X, P, W, 120, cmap=plot_args["cmap"], vmin=-abs(W).max(), vmax=abs(W).max()
+    )
     ax[1][0].set_xlabel("$x$", fontsize=12)
     ax[1][0].set_ylabel("$p$", fontsize=12)
     ax[1][0].get_xaxis().set_ticks(plot_args["xticks"])
     ax[1][0].xaxis.set_ticklabels(plot_args["xtick_labels"])
     ax[1][0].get_yaxis().set_ticks(plot_args["yticks"])
-    ax[1][0].yaxis.set_ticklabels(plot_args["ytick_labels"], rotation="vertical", va="center")
+    ax[1][0].yaxis.set_ticklabels(
+        plot_args["ytick_labels"], rotation="vertical", va="center"
+    )
     ax[1][0].tick_params(direction="in")
     ax[1][0].set_xlim(xbounds)
     ax[1][0].set_ylim(ybounds)
@@ -160,7 +169,9 @@ def mikkel_plot(
     ax[1][1].grid(plot_args["grid"])
 
     # Density matrix
-    ax[0][1].matshow(abs(rho), cmap=plot_args["cmap"], vmin=-abs(rho).max(), vmax=abs(rho).max())
+    ax[0][1].matshow(
+        abs(rho), cmap=plot_args["cmap"], vmin=-abs(rho).max(), vmax=abs(rho).max()
+    )
     ax[0][1].set_title(r"abs($\rho$)", fontsize=12)
     ax[0][1].tick_params(direction="in")
     ax[0][1].get_xaxis().set_ticks([])

--- a/mrmustard/utils/graphics.py
+++ b/mrmustard/utils/graphics.py
@@ -38,9 +38,7 @@ class Progressbar:
             )
         else:
             self.bar = Progress(
-                TextColumn(
-                    "Step {task.completed}/{task.total} | {task.fields[speed]:.1f} it/s"
-                ),
+                TextColumn("Step {task.completed}/{task.total} | {task.fields[speed]:.1f} it/s"),
                 BarColumn(),
                 TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
                 TextColumn("Cost = {task.fields[loss]:.5f} | ⏳ "),
@@ -128,17 +126,13 @@ def mikkel_plot(
     plt.subplots_adjust(wspace=0.05, hspace=0.05)
 
     # Wigner function
-    ax[1][0].contourf(
-        X, P, W, 120, cmap=plot_args["cmap"], vmin=-abs(W).max(), vmax=abs(W).max()
-    )
+    ax[1][0].contourf(X, P, W, 120, cmap=plot_args["cmap"], vmin=-abs(W).max(), vmax=abs(W).max())
     ax[1][0].set_xlabel("$x$", fontsize=12)
     ax[1][0].set_ylabel("$p$", fontsize=12)
     ax[1][0].get_xaxis().set_ticks(plot_args["xticks"])
     ax[1][0].xaxis.set_ticklabels(plot_args["xtick_labels"])
     ax[1][0].get_yaxis().set_ticks(plot_args["yticks"])
-    ax[1][0].yaxis.set_ticklabels(
-        plot_args["ytick_labels"], rotation="vertical", va="center"
-    )
+    ax[1][0].yaxis.set_ticklabels(plot_args["ytick_labels"], rotation="vertical", va="center")
     ax[1][0].tick_params(direction="in")
     ax[1][0].set_xlim(xbounds)
     ax[1][0].set_ylim(ybounds)
@@ -169,9 +163,7 @@ def mikkel_plot(
     ax[1][1].grid(plot_args["grid"])
 
     # Density matrix
-    ax[0][1].matshow(
-        abs(rho), cmap=plot_args["cmap"], vmin=-abs(rho).max(), vmax=abs(rho).max()
-    )
+    ax[0][1].matshow(abs(rho), cmap=plot_args["cmap"], vmin=-abs(rho).max(), vmax=abs(rho).max())
     ax[0][1].set_title(r"abs($\rho$)", fontsize=12)
     ax[0][1].tick_params(direction="in")
     ax[0][1].get_xaxis().set_ticks([])

--- a/mrmustard/utils/wigner.py
+++ b/mrmustard/utils/wigner.py
@@ -37,10 +37,10 @@ def wigner_discretized(rho, qvec, pvec):
     hbar = settings.HBAR
     return _wigner_discretized(rho, qvec, pvec, hbar)
 
+
 @njit
 def _wigner_discretized(rho, qvec, pvec, hbar):
-    r""" Calculates the discretized Wigner function for a given value of hbar.
-    """
+    r"""Calculates the discretized Wigner function for a given value of hbar."""
     Q = np.outer(qvec, np.ones_like(pvec))
     P = np.outer(np.ones_like(qvec), pvec)
 

--- a/mrmustard/utils/wigner.py
+++ b/mrmustard/utils/wigner.py
@@ -56,16 +56,12 @@ def wigner_discretized(rho, qvec, pvec):
 
     for m in range(1, cutoff):
         # Wigner function for |m><m|
-        Wmat[1, m] = (
-            2 * np.conj(A) * Wmat[0, m] - np.sqrt(m) * Wmat[0, m - 1]
-        ) / np.sqrt(m)
+        Wmat[1, m] = (2 * np.conj(A) * Wmat[0, m] - np.sqrt(m) * Wmat[0, m - 1]) / np.sqrt(m)
         W += np.real(rho[m, m] * Wmat[1, m])
 
         for n in range(m + 1, cutoff):
             # Wigner function for |m><n|
-            Wmat[1, n] = (
-                2 * A * Wmat[1, n - 1] - np.sqrt(m) * Wmat[0, n - 1]
-            ) / np.sqrt(n)
+            Wmat[1, n] = (2 * A * Wmat[1, n - 1] - np.sqrt(m) * Wmat[0, n - 1]) / np.sqrt(n)
             W += 2 * np.real(rho[m, n] * Wmat[1, n])
         Wmat[0] = Wmat[1]
 

--- a/mrmustard/utils/wigner.py
+++ b/mrmustard/utils/wigner.py
@@ -19,9 +19,11 @@ from numba import njit
 
 from mrmustard import settings
 
+hbar = settings.HBAR
+
 
 @njit
-def wigner_discretized(rho, qvec, pvec, hbar=settings.HBAR):
+def wigner_discretized(rho, qvec, pvec):
     r"""Calculates the discretized Wigner function for a single mode.
 
     Adapted from `strawberryfields <https://github.com/XanaduAI/strawberryfields/blob/master/strawberryfields/backends/states.py#L725>`
@@ -30,7 +32,6 @@ def wigner_discretized(rho, qvec, pvec, hbar=settings.HBAR):
         rho (complex array): the density matrix of the state in Fock representation
         qvec (array): array of discretized :math:`q` quadrature values
         pvec (array): array of discretized :math:`p` quadrature values
-        hbar (optional float): the value of `\hbar`, defaults to ``settings.HBAR``.
 
     Retunrs:
         tuple(array, array, array): array containing the discretized Wigner function, and the Q and
@@ -55,12 +56,16 @@ def wigner_discretized(rho, qvec, pvec, hbar=settings.HBAR):
 
     for m in range(1, cutoff):
         # Wigner function for |m><m|
-        Wmat[1, m] = (2 * np.conj(A) * Wmat[0, m] - np.sqrt(m) * Wmat[0, m - 1]) / np.sqrt(m)
+        Wmat[1, m] = (
+            2 * np.conj(A) * Wmat[0, m] - np.sqrt(m) * Wmat[0, m - 1]
+        ) / np.sqrt(m)
         W += np.real(rho[m, m] * Wmat[1, m])
 
         for n in range(m + 1, cutoff):
             # Wigner function for |m><n|
-            Wmat[1, n] = (2 * A * Wmat[1, n - 1] - np.sqrt(m) * Wmat[0, n - 1]) / np.sqrt(n)
+            Wmat[1, n] = (
+                2 * A * Wmat[1, n - 1] - np.sqrt(m) * Wmat[0, n - 1]
+            ) / np.sqrt(n)
             W += 2 * np.real(rho[m, n] * Wmat[1, n])
         Wmat[0] = Wmat[1]
 

--- a/mrmustard/utils/wigner.py
+++ b/mrmustard/utils/wigner.py
@@ -19,10 +19,7 @@ from numba import njit
 
 from mrmustard import settings
 
-hbar = settings.HBAR
 
-
-@njit
 def wigner_discretized(rho, qvec, pvec):
     r"""Calculates the discretized Wigner function for a single mode.
 
@@ -37,7 +34,13 @@ def wigner_discretized(rho, qvec, pvec):
         tuple(array, array, array): array containing the discretized Wigner function, and the Q and
             P coordinates (in meshgrid form) in which the function is calculated
     """
+    hbar = settings.HBAR
+    return _wigner_discretized(rho, qvec, pvec, hbar)
 
+@njit
+def _wigner_discretized(rho, qvec, pvec, hbar):
+    r""" Calculates the discretized Wigner function for a given value of hbar.
+    """
     Q = np.outer(qvec, np.ones_like(pvec))
     P = np.outer(np.ones_like(qvec), pvec)
 

--- a/tests/test_lab/test_detectors.py
+++ b/tests/test_lab/test_detectors.py
@@ -74,9 +74,7 @@ class TestPNRDetector:
         expected_mean = eta * np.sinh(r) ** 2 + dc
         assert np.allclose(mean, expected_mean)
         variance = np.arange(len(ps)) ** 2 @ ps.numpy() - mean**2
-        expected_variance = (
-            eta * np.sinh(r) ** 2 * (1 + eta * (1 + 2 * np.sinh(r) ** 2)) + dc
-        )
+        expected_variance = eta * np.sinh(r) ** 2 * (1 + eta * (1 + 2 * np.sinh(r) ** 2)) + dc
         assert np.allclose(variance, expected_variance)
 
     @given(
@@ -144,9 +142,7 @@ class TestPNRDetector:
 class TestHomodyneDetector:
     """tests related to homodyne detectors"""
 
-    @pytest.mark.parametrize(
-        "outcome", [None] + np.random.uniform(-5, 5, size=(10, 2)).tolist()
-    )
+    @pytest.mark.parametrize("outcome", [None] + np.random.uniform(-5, 5, size=(10, 2)).tolist())
     def test_homodyne_mode_kwargs(self, outcome):
         """Test that S gates and Homodyne mesurements are applied to the correct modes via the
         `modes` kwarg.
@@ -271,8 +267,7 @@ class TestHomodyneDetector:
                 + (2 * np.sqrt(s * (s + 1)) * (X - xb))
                 / (1 + 2 * s + np.cosh(2 * r) - np.sinh(2 * r)),
                 pa
-                + (2 * np.sqrt(s * (s + 1)) * pb)
-                / (1 + 2 * s + np.cosh(2 * r) + np.sinh(2 * r)),
+                + (2 * np.sqrt(s * (s + 1)) * pb) / (1 + 2 * s + np.cosh(2 * r) + np.sinh(2 * r)),
             ]
         )
 
@@ -292,9 +287,7 @@ class TestHomodyneDetector:
         ],
     )
     @pytest.mark.parametrize("gaussian_state", [True, False])
-    def test_sampling_mean_and_var(
-        self, state, mean_expected, var_expected, gaussian_state
-    ):
+    def test_sampling_mean_and_var(self, state, mean_expected, var_expected, gaussian_state):
         """Tests that the mean and variance estimates of many homodyne
         measurements are in agreement with the expected values for the states"""
 

--- a/tests/test_lab/test_detectors.py
+++ b/tests/test_lab/test_detectors.py
@@ -74,7 +74,9 @@ class TestPNRDetector:
         expected_mean = eta * np.sinh(r) ** 2 + dc
         assert np.allclose(mean, expected_mean)
         variance = np.arange(len(ps)) ** 2 @ ps.numpy() - mean**2
-        expected_variance = eta * np.sinh(r) ** 2 * (1 + eta * (1 + 2 * np.sinh(r) ** 2)) + dc
+        expected_variance = (
+            eta * np.sinh(r) ** 2 * (1 + eta * (1 + 2 * np.sinh(r) ** 2)) + dc
+        )
         assert np.allclose(variance, expected_variance)
 
     @given(
@@ -142,7 +144,9 @@ class TestPNRDetector:
 class TestHomodyneDetector:
     """tests related to homodyne detectors"""
 
-    @pytest.mark.parametrize("outcome", [None] + np.random.uniform(-5, 5, size=(10, 2)).tolist())
+    @pytest.mark.parametrize(
+        "outcome", [None] + np.random.uniform(-5, 5, size=(10, 2)).tolist()
+    )
     def test_homodyne_mode_kwargs(self, outcome):
         """Test that S gates and Homodyne mesurements are applied to the correct modes via the
         `modes` kwarg.
@@ -171,7 +175,10 @@ class TestHomodyneDetector:
             x_outcome = detector.outcome.numpy()[:2]
             assert np.allclose(x_outcome, outcome)
 
-    @given(s=st.floats(min_value=0.0, max_value=10.0), outcome=none_or_(st.floats(-10.0, 10.0)))
+    @given(
+        s=st.floats(min_value=0.0, max_value=10.0),
+        outcome=none_or_(st.floats(-10.0, 10.0)),
+    )
     def test_homodyne_on_2mode_squeezed_vacuum(self, s, outcome):
         """Check that homodyne detection on TMSV for q-quadrature (``quadrature_angle=0.0``)"""
         r = settings.HOMODYNE_SQUEEZING
@@ -195,7 +202,11 @@ class TestHomodyneDetector:
             )
             assert np.allclose(remaining_state.means.numpy(), means)
 
-    @given(s=st.floats(1.0, 10.0), outcome=none_or_(st.floats(-2, 2)), angle=st.floats(0, np.pi))
+    @given(
+        s=st.floats(1.0, 10.0),
+        outcome=none_or_(st.floats(-2, 2)),
+        angle=st.floats(0, np.pi),
+    )
     def test_homodyne_on_2mode_squeezed_vacuum_with_angle(self, s, outcome, angle):
         """Check that homodyne detection on TMSV works with an arbitrary quadrature angle"""
         r = settings.HOMODYNE_SQUEEZING
@@ -260,7 +271,8 @@ class TestHomodyneDetector:
                 + (2 * np.sqrt(s * (s + 1)) * (X - xb))
                 / (1 + 2 * s + np.cosh(2 * r) - np.sinh(2 * r)),
                 pa
-                + (2 * np.sqrt(s * (s + 1)) * pb) / (1 + 2 * s + np.cosh(2 * r) + np.sinh(2 * r)),
+                + (2 * np.sqrt(s * (s + 1)) * pb)
+                / (1 + 2 * s + np.cosh(2 * r) + np.sinh(2 * r)),
             ]
         )
 
@@ -280,24 +292,26 @@ class TestHomodyneDetector:
         ],
     )
     @pytest.mark.parametrize("gaussian_state", [True, False])
-    def test_sampling_mean_and_var(self, state, mean_expected, var_expected, gaussian_state):
+    def test_sampling_mean_and_var(
+        self, state, mean_expected, var_expected, gaussian_state
+    ):
         """Tests that the mean and variance estimates of many homodyne
         measurements are in agreement with the expected values for the states"""
 
         tf.random.set_seed(123)
-        if not gaussian_state:
-            state = State(dm=state.dm(cutoffs=[40]))
-        detector = Homodyne(0.0)
+        # if not gaussian_state:
+        #     state = State(dm=state.dm(cutoffs=[40]))
+        # detector = Homodyne(0.0)
 
-        results = np.empty((self.N_MEAS, 2))
-        for i in range(self.N_MEAS):
-            _ = state << detector
-            results[i] = detector.outcome.numpy()
+        # results = np.empty((self.N_MEAS, 2))
+        # for i in range(self.N_MEAS):
+        #     _ = state << detector
+        #     results[i] = detector.outcome.numpy()
 
-        mean = results.mean(axis=0)
-        assert np.allclose(mean[0], mean_expected, atol=self.std_10, rtol=0)
-        var = results.var(axis=0)
-        assert np.allclose(var[0], var_expected, atol=self.std_10, rtol=0)
+        # mean = results.mean(axis=0)
+        # assert np.allclose(mean[0], mean_expected, atol=self.std_10, rtol=0)
+        # var = results.var(axis=0)
+        # assert np.allclose(var[0], var_expected, atol=self.std_10, rtol=0)
 
     def test_homodyne_squeezing_setting(self):
         r"""Check default homodyne squeezing on settings leads to the correct generaldyne

--- a/tests/test_lab/test_detectors.py
+++ b/tests/test_lab/test_detectors.py
@@ -74,7 +74,9 @@ class TestPNRDetector:
         expected_mean = eta * np.sinh(r) ** 2 + dc
         assert np.allclose(mean, expected_mean)
         variance = np.arange(len(ps)) ** 2 @ ps.numpy() - mean**2
-        expected_variance = eta * np.sinh(r) ** 2 * (1 + eta * (1 + 2 * np.sinh(r) ** 2)) + dc
+        expected_variance = (
+            eta * np.sinh(r) ** 2 * (1 + eta * (1 + 2 * np.sinh(r) ** 2)) + dc
+        )
         assert np.allclose(variance, expected_variance)
 
     @given(
@@ -142,7 +144,9 @@ class TestPNRDetector:
 class TestHomodyneDetector:
     """tests related to homodyne detectors"""
 
-    @pytest.mark.parametrize("outcome", [None] + np.random.uniform(-5, 5, size=(10, 2)).tolist())
+    @pytest.mark.parametrize(
+        "outcome", [None] + np.random.uniform(-5, 5, size=(10, 2)).tolist()
+    )
     def test_homodyne_mode_kwargs(self, outcome):
         """Test that S gates and Homodyne mesurements are applied to the correct modes via the
         `modes` kwarg.
@@ -267,7 +271,8 @@ class TestHomodyneDetector:
                 + (2 * np.sqrt(s * (s + 1)) * (X - xb))
                 / (1 + 2 * s + np.cosh(2 * r) - np.sinh(2 * r)),
                 pa
-                + (2 * np.sqrt(s * (s + 1)) * pb) / (1 + 2 * s + np.cosh(2 * r) + np.sinh(2 * r)),
+                + (2 * np.sqrt(s * (s + 1)) * pb)
+                / (1 + 2 * s + np.cosh(2 * r) + np.sinh(2 * r)),
             ]
         )
 
@@ -287,24 +292,26 @@ class TestHomodyneDetector:
         ],
     )
     @pytest.mark.parametrize("gaussian_state", [True, False])
-    def test_sampling_mean_and_var(self, state, mean_expected, var_expected, gaussian_state):
+    def test_sampling_mean_and_var(
+        self, state, mean_expected, var_expected, gaussian_state
+    ):
         """Tests that the mean and variance estimates of many homodyne
         measurements are in agreement with the expected values for the states"""
 
         tf.random.set_seed(123)
-        # if not gaussian_state:
-        #     state = State(dm=state.dm(cutoffs=[40]))
-        # detector = Homodyne(0.0)
+        if not gaussian_state:
+            state = State(dm=state.dm(cutoffs=[40]))
+        detector = Homodyne(0.0)
 
-        # results = np.empty((self.N_MEAS, 2))
-        # for i in range(self.N_MEAS):
-        #     _ = state << detector
-        #     results[i] = detector.outcome.numpy()
+        results = np.empty((self.N_MEAS, 2))
+        for i in range(self.N_MEAS):
+            _ = state << detector
+            results[i] = detector.outcome.numpy()
 
-        # mean = results.mean(axis=0)
-        # assert np.allclose(mean[0], mean_expected, atol=self.std_10, rtol=0)
-        # var = results.var(axis=0)
-        # assert np.allclose(var[0], var_expected, atol=self.std_10, rtol=0)
+        mean = results.mean(axis=0)
+        assert np.allclose(mean[0], mean_expected, atol=self.std_10, rtol=0)
+        var = results.var(axis=0)
+        assert np.allclose(var[0], var_expected, atol=self.std_10, rtol=0)
 
     def test_homodyne_squeezing_setting(self):
         r"""Check default homodyne squeezing on settings leads to the correct generaldyne

--- a/tests/test_lab/test_states.py
+++ b/tests/test_lab/test_states.py
@@ -41,7 +41,9 @@ hbar0 = settings.HBAR
 @st.composite
 def xy_arrays(draw):
     length = draw(st.integers(2, 10))
-    return draw(arrays(dtype=np.float, shape=(2, length), elements=st.floats(-5.0, 5.0)))
+    return draw(
+        arrays(dtype=np.float, shape=(2, length), elements=st.floats(-5.0, 5.0))
+    )
 
 
 @given(nmodes, st.floats(0.1, 5.0))
@@ -58,7 +60,9 @@ def test_vacuum_state(nmodes, hbar):
 @given(x=medium_float, y=medium_float)
 def test_coherent_state_single(x, y):
     state = Coherent(x, y)
-    assert np.allclose(state.cov, np.array([[settings.HBAR / 2, 0], [0, settings.HBAR / 2]]))
+    assert np.allclose(
+        state.cov, np.array([[settings.HBAR / 2, 0], [0, settings.HBAR / 2]])
+    )
     assert np.allclose(state.means, np.array([x, y]) * np.sqrt(2 * settings.HBAR))
 
 
@@ -89,7 +93,9 @@ def test_coherent_state_multiple(xy):
     state = Coherent(x, y)
     assert np.allclose(state.cov, np.eye(2 * len(x)) * settings.HBAR / 2)
     assert len(x) == len(y)
-    assert np.allclose(state.means, np.concatenate([x, y], axis=-1) * np.sqrt(2 * settings.HBAR))
+    assert np.allclose(
+        state.means, np.concatenate([x, y], axis=-1) * np.sqrt(2 * settings.HBAR)
+    )
 
     # restoring hbar to its original value
     settings.HBAR = hbar0
@@ -256,7 +262,9 @@ def test_concat_pure_states(pure):
     psi = state1 & state2
 
     # test concatenated state
-    psi_dm = math.transpose(math.tensordot(state1.dm(), state2.dm(), [[], []]), [0, 2, 1, 3])
+    psi_dm = math.transpose(
+        math.tensordot(state1.dm(), state2.dm(), [[], []]), [0, 2, 1, 3]
+    )
     assert np.allclose(psi.dm(), psi_dm)
 
 
@@ -306,10 +314,7 @@ def test_padding_dm():
     "Test that padding a density matrix works correctly."
     state = State(dm=(SqueezedVacuum(r=1.0) >> Attenuator(0.6)).dm(cutoffs=[20]))
     assert tuple(int(c) for c in state.dm(cutoffs=[10]).shape) == (10, 10)
-    assert tuple(int(c) for c in state._dm.shape) == (
-        20,
-        20,
-    )  # pylint: disable=protected-access
+    assert tuple(int(c) for c in state._dm.shape) == (20, 20)  # pylint: disable=protected-access
 
 
 def test_state_repr_small_prob():

--- a/tests/test_lab/test_states.py
+++ b/tests/test_lab/test_states.py
@@ -41,9 +41,7 @@ hbar0 = settings.HBAR
 @st.composite
 def xy_arrays(draw):
     length = draw(st.integers(2, 10))
-    return draw(
-        arrays(dtype=np.float, shape=(2, length), elements=st.floats(-5.0, 5.0))
-    )
+    return draw(arrays(dtype=np.float, shape=(2, length), elements=st.floats(-5.0, 5.0)))
 
 
 @given(nmodes, st.floats(0.1, 5.0))
@@ -60,9 +58,7 @@ def test_vacuum_state(nmodes, hbar):
 @given(x=medium_float, y=medium_float)
 def test_coherent_state_single(x, y):
     state = Coherent(x, y)
-    assert np.allclose(
-        state.cov, np.array([[settings.HBAR / 2, 0], [0, settings.HBAR / 2]])
-    )
+    assert np.allclose(state.cov, np.array([[settings.HBAR / 2, 0], [0, settings.HBAR / 2]]))
     assert np.allclose(state.means, np.array([x, y]) * np.sqrt(2 * settings.HBAR))
 
 
@@ -93,9 +89,7 @@ def test_coherent_state_multiple(xy):
     state = Coherent(x, y)
     assert np.allclose(state.cov, np.eye(2 * len(x)) * settings.HBAR / 2)
     assert len(x) == len(y)
-    assert np.allclose(
-        state.means, np.concatenate([x, y], axis=-1) * np.sqrt(2 * settings.HBAR)
-    )
+    assert np.allclose(state.means, np.concatenate([x, y], axis=-1) * np.sqrt(2 * settings.HBAR))
 
     # restoring hbar to its original value
     settings.HBAR = hbar0
@@ -262,9 +256,7 @@ def test_concat_pure_states(pure):
     psi = state1 & state2
 
     # test concatenated state
-    psi_dm = math.transpose(
-        math.tensordot(state1.dm(), state2.dm(), [[], []]), [0, 2, 1, 3]
-    )
+    psi_dm = math.transpose(math.tensordot(state1.dm(), state2.dm(), [[], []]), [0, 2, 1, 3])
     assert np.allclose(psi.dm(), psi_dm)
 
 

--- a/tests/test_lab/test_states.py
+++ b/tests/test_lab/test_states.py
@@ -35,16 +35,13 @@ from mrmustard.physics import gaussian as gp
 from tests.random import angle, medium_float, n_mode_pure_state, nmodes, r
 
 math = Math()
-
 hbar0 = settings.HBAR
 
 
 @st.composite
 def xy_arrays(draw):
     length = draw(st.integers(2, 10))
-    return draw(
-        arrays(dtype=np.float, shape=(2, length), elements=st.floats(-5.0, 5.0))
-    )
+    return draw(arrays(dtype=np.float, shape=(2, length), elements=st.floats(-5.0, 5.0)))
 
 
 @given(nmodes, st.floats(0.1, 5.0))
@@ -61,9 +58,7 @@ def test_vacuum_state(nmodes, hbar):
 @given(x=medium_float, y=medium_float)
 def test_coherent_state_single(x, y):
     state = Coherent(x, y)
-    assert np.allclose(
-        state.cov, np.array([[settings.HBAR / 2, 0], [0, settings.HBAR / 2]])
-    )
+    assert np.allclose(state.cov, np.array([[settings.HBAR / 2, 0], [0, settings.HBAR / 2]]))
     assert np.allclose(state.means, np.array([x, y]) * np.sqrt(2 * settings.HBAR))
 
 
@@ -94,9 +89,7 @@ def test_coherent_state_multiple(xy):
     state = Coherent(x, y)
     assert np.allclose(state.cov, np.eye(2 * len(x)) * settings.HBAR / 2)
     assert len(x) == len(y)
-    assert np.allclose(
-        state.means, np.concatenate([x, y], axis=-1) * np.sqrt(2 * settings.HBAR)
-    )
+    assert np.allclose(state.means, np.concatenate([x, y], axis=-1) * np.sqrt(2 * settings.HBAR))
 
     # restoring hbar to its original value
     settings.HBAR = hbar0
@@ -263,9 +256,7 @@ def test_concat_pure_states(pure):
     psi = state1 & state2
 
     # test concatenated state
-    psi_dm = math.transpose(
-        math.tensordot(state1.dm(), state2.dm(), [[], []]), [0, 2, 1, 3]
-    )
+    psi_dm = math.transpose(math.tensordot(state1.dm(), state2.dm(), [[], []]), [0, 2, 1, 3])
     assert np.allclose(psi.dm(), psi_dm)
 
 

--- a/tests/test_physics/test_fidelity.py
+++ b/tests/test_physics/test_fidelity.py
@@ -3,13 +3,14 @@ import pytest
 from thewalrus.quantum import real_to_complex_displacements
 from thewalrus.random import random_covariance
 
-from mrmustard import physics
+from mrmustard import physics, settings
 from mrmustard.lab import Coherent, Fock, State
 from mrmustard.math import Math
 from mrmustard.physics import fock as fp
 from mrmustard.physics import gaussian as gp
 
 math = Math()
+hbar0 = settings.HBAR
 
 
 class TestGaussianStates:
@@ -19,13 +20,17 @@ class TestGaussianStates:
     @pytest.mark.parametrize("block_diag", [True, False])
     def test_fidelity_is_symmetric(self, num_modes, hbar, pure, block_diag):
         """Test that the fidelity is symmetric"""
+        settings.HBAR = hbar
         cov1 = random_covariance(num_modes, hbar=hbar, pure=pure, block_diag=block_diag)
         means1 = np.sqrt(2 * hbar) * np.random.rand(2 * num_modes)
         cov2 = random_covariance(num_modes, hbar=hbar, pure=pure, block_diag=block_diag)
         means2 = np.sqrt(2 * hbar) * np.random.rand(2 * num_modes)
-        f12 = gp.fidelity(means1, cov1, means2, cov2, hbar)
-        f21 = gp.fidelity(means2, cov2, means1, cov1, hbar)
+        f12 = gp.fidelity(means1, cov1, means2, cov2)
+        f21 = gp.fidelity(means2, cov2, means1, cov1)
         assert np.allclose(f12, f21)
+
+        # restoring hbar to its original value
+        settings.HBAR = hbar0
 
     @pytest.mark.parametrize("hbar", [1 / 2, 1.0, 2.0, 1.6])
     @pytest.mark.parametrize("num_modes", np.arange(5, 10))
@@ -33,12 +38,16 @@ class TestGaussianStates:
     @pytest.mark.parametrize("block_diag", [True, False])
     def test_fidelity_is_leq_one(self, num_modes, hbar, pure, block_diag):
         """Test that the fidelity is between 0 and 1"""
+        settings.HBAR = hbar
         cov1 = random_covariance(num_modes, hbar=hbar, pure=pure, block_diag=block_diag)
         means1 = np.sqrt(2 * hbar) * np.random.rand(2 * num_modes)
         cov2 = random_covariance(num_modes, hbar=hbar, pure=pure, block_diag=block_diag)
         means2 = np.sqrt(2 * hbar) * np.random.rand(2 * num_modes)
-        f12 = gp.fidelity(means1, cov1, means2, cov2, hbar)
+        f12 = gp.fidelity(means1, cov1, means2, cov2)
         assert 0 <= np.real_if_close(f12) < 1.0
+
+        # restoring hbar to its original value
+        settings.HBAR = hbar0
 
     @pytest.mark.parametrize("hbar", [1 / 2, 1.0, 2.0, 1.6])
     @pytest.mark.parametrize("num_modes", np.arange(2, 6))
@@ -46,53 +55,78 @@ class TestGaussianStates:
     @pytest.mark.parametrize("block_diag", [True, False])
     def test_fidelity_with_self(self, num_modes, hbar, pure, block_diag):
         """Test that the fidelity of two identical quantum states is 1"""
+        settings.HBAR = hbar
         cov = random_covariance(num_modes, hbar=hbar, pure=pure, block_diag=block_diag)
         means = np.random.rand(2 * num_modes)
-        assert np.allclose(gp.fidelity(means, cov, means, cov, hbar=hbar), 1, atol=1e-3)
+        assert np.allclose(gp.fidelity(means, cov, means, cov), 1, atol=1e-3)
+
+        # restoring hbar to its original value
+        settings.HBAR = hbar0
 
     @pytest.mark.parametrize("num_modes", np.arange(5, 10))
     @pytest.mark.parametrize("hbar", [0.5, 1.0, 2.0, 1.6])
     def test_fidelity_coherent_state(self, num_modes, hbar):
         """Test the fidelity of two multimode coherent states"""
+        settings.HBAR = hbar
         beta1 = np.random.rand(num_modes) + 1j * np.random.rand(num_modes)
         beta2 = np.random.rand(num_modes) + 1j * np.random.rand(num_modes)
-        means1 = real_to_complex_displacements(np.concatenate([beta1, beta1.conj()]), hbar=hbar)
-        means2 = real_to_complex_displacements(np.concatenate([beta2, beta2.conj()]), hbar=hbar)
+        means1 = real_to_complex_displacements(
+            np.concatenate([beta1, beta1.conj()]), hbar=hbar
+        )
+        means2 = real_to_complex_displacements(
+            np.concatenate([beta2, beta2.conj()]), hbar=hbar
+        )
         cov1 = hbar * np.identity(2 * num_modes) / 2
         cov2 = hbar * np.identity(2 * num_modes) / 2
-        fid = gp.fidelity(means1, cov1, means2, cov2, hbar=hbar)
+        fid = gp.fidelity(means1, cov1, means2, cov2)
         expected = np.exp(-np.linalg.norm(beta1 - beta2) ** 2)
         assert np.allclose(expected, fid)
+
+        # restoring hbar to its original value
+        settings.HBAR = hbar0
 
     @pytest.mark.parametrize("hbar", [0.5, 1.0, 2.0, 1.6])
     @pytest.mark.parametrize("r1", np.random.rand(3))
     @pytest.mark.parametrize("r2", np.random.rand(3))
     def test_fidelity_squeezed_vacuum(self, r1, r2, hbar):
         """Tests fidelity between two squeezed states"""
+        settings.HBAR = hbar
         cov1 = np.diag([np.exp(2 * r1), np.exp(-2 * r1)]) * hbar / 2
         cov2 = np.diag([np.exp(2 * r2), np.exp(-2 * r2)]) * hbar / 2
         mu = np.zeros([2])
-        assert np.allclose(1 / np.cosh(r1 - r2), gp.fidelity(mu, cov1, mu, cov2, hbar=hbar))
+        assert np.allclose(1 / np.cosh(r1 - r2), gp.fidelity(mu, cov1, mu, cov2))
+
+        # restoring hbar to its original value
+        settings.HBAR = hbar0
 
     @pytest.mark.parametrize("n1", [0.5, 1.0, 2.0, 1.6])
     @pytest.mark.parametrize("n2", [0.5, 1.0, 2.0, 1.6])
     @pytest.mark.parametrize("hbar", [0.5, 1.0, 2.0, 1.6])
     def test_fidelity_thermal(self, n1, n2, hbar):
         """Test fidelity between two thermal states"""
-        expected = 1 / (1 + n1 + n2 + 2 * n1 * n2 - 2 * np.sqrt(n1 * n2 * (n1 + 1) * (n2 + 1)))
+        settings.HBAR = hbar
+        expected = 1 / (
+            1 + n1 + n2 + 2 * n1 * n2 - 2 * np.sqrt(n1 * n2 * (n1 + 1) * (n2 + 1))
+        )
         cov1 = hbar * (n1 + 0.5) * np.identity(2)
         cov2 = hbar * (n2 + 0.5) * np.identity(2)
         mu1 = np.zeros([2])
         mu2 = np.zeros([2])
-        assert np.allclose(expected, gp.fidelity(mu1, cov1, mu2, cov2, hbar=hbar))
+        assert np.allclose(expected, gp.fidelity(mu1, cov1, mu2, cov2))
+
+        # restoring hbar to its original value
+        settings.HBAR = hbar0
 
     @pytest.mark.parametrize("hbar", [0.5, 1.0, 2.0, 1.6])
     @pytest.mark.parametrize("r", [-2.0, 0.0, 2.0])
     @pytest.mark.parametrize("alpha", np.random.rand(10) + 1j * np.random.rand(10))
     def test_fidelity_vac_to_displaced_squeezed(self, r, alpha, hbar):
         """Calculates the fidelity between a coherent squeezed state and vacuum"""
+        settings.HBAR = hbar
         cov1 = np.diag([np.exp(2 * r), np.exp(-2 * r)]) * hbar / 2
-        means1 = real_to_complex_displacements(np.array([alpha, np.conj(alpha)]), hbar=hbar)
+        means1 = real_to_complex_displacements(
+            np.array([alpha, np.conj(alpha)]), hbar=hbar
+        )
         means2 = np.zeros([2])
         cov2 = np.identity(2) * hbar / 2
         expected = (
@@ -100,7 +134,10 @@ class TestGaussianStates:
             * np.abs(np.exp(np.tanh(r) * np.conj(alpha) ** 2))
             / np.cosh(r)
         )
-        assert np.allclose(expected, gp.fidelity(means1, cov1, means2, cov2, hbar=hbar))
+        assert np.allclose(expected, gp.fidelity(means1, cov1, means2, cov2))
+
+        # restoring hbar to its original value
+        settings.HBAR = hbar0
 
 
 class TestMixedStates:
@@ -111,7 +148,9 @@ class TestMixedStates:
 
     def test_fidelity_with_self(self):
         """Test that the fidelity of two identical quantum states is 1"""
-        assert np.allclose(fp.fidelity(self.state1, self.state1, False, False), 1, atol=1e-4)
+        assert np.allclose(
+            fp.fidelity(self.state1, self.state1, False, False), 1, atol=1e-4
+        )
 
     def test_fidelity_is_symmetric(self):
         """Test that the fidelity is symmetric and between 0 and 1"""
@@ -127,7 +166,9 @@ class TestMixedStates:
     def test_fidelity_formula(self):
         """Test fidelity of known mixed states."""
         expected = 5 / 6
-        assert np.allclose(expected, fp.fidelity(self.state1, self.state2, False, False))
+        assert np.allclose(
+            expected, fp.fidelity(self.state1, self.state2, False, False)
+        )
 
 
 class TestGaussianFock:
@@ -140,16 +181,24 @@ class TestGaussianFock:
 
     def test_fidelity_across_representations_ket_ket(self):
         """Test that the fidelity of these two states is what it should be"""
-        assert np.allclose(physics.fidelity(self.state1ket, self.state2ket), 0.36787944, atol=1e-4)
+        assert np.allclose(
+            physics.fidelity(self.state1ket, self.state2ket), 0.36787944, atol=1e-4
+        )
 
     def test_fidelity_across_representations_ket_dm(self):
         """Test that the fidelity of these two states is what it should be"""
-        assert np.allclose(physics.fidelity(self.state1ket, self.state2dm), 0.36787944, atol=1e-4)
+        assert np.allclose(
+            physics.fidelity(self.state1ket, self.state2dm), 0.36787944, atol=1e-4
+        )
 
     def test_fidelity_across_representations_dm_ket(self):
         """Test that the fidelity of these two states is what it should be"""
-        assert np.allclose(physics.fidelity(self.state1dm, self.state2ket), 0.36787944, atol=1e-4)
+        assert np.allclose(
+            physics.fidelity(self.state1dm, self.state2ket), 0.36787944, atol=1e-4
+        )
 
     def test_fidelity_across_representations_dm_dm(self):
         """Test that the fidelity of these two states is what it should be"""
-        assert np.allclose(physics.fidelity(self.state1dm, self.state2dm), 0.36787944, atol=1e-4)
+        assert np.allclose(
+            physics.fidelity(self.state1dm, self.state2dm), 0.36787944, atol=1e-4
+        )

--- a/tests/test_physics/test_fidelity.py
+++ b/tests/test_physics/test_fidelity.py
@@ -70,12 +70,8 @@ class TestGaussianStates:
         settings.HBAR = hbar
         beta1 = np.random.rand(num_modes) + 1j * np.random.rand(num_modes)
         beta2 = np.random.rand(num_modes) + 1j * np.random.rand(num_modes)
-        means1 = real_to_complex_displacements(
-            np.concatenate([beta1, beta1.conj()]), hbar=hbar
-        )
-        means2 = real_to_complex_displacements(
-            np.concatenate([beta2, beta2.conj()]), hbar=hbar
-        )
+        means1 = real_to_complex_displacements(np.concatenate([beta1, beta1.conj()]), hbar=hbar)
+        means2 = real_to_complex_displacements(np.concatenate([beta2, beta2.conj()]), hbar=hbar)
         cov1 = hbar * np.identity(2 * num_modes) / 2
         cov2 = hbar * np.identity(2 * num_modes) / 2
         fid = gp.fidelity(means1, cov1, means2, cov2)
@@ -105,9 +101,7 @@ class TestGaussianStates:
     def test_fidelity_thermal(self, n1, n2, hbar):
         """Test fidelity between two thermal states"""
         settings.HBAR = hbar
-        expected = 1 / (
-            1 + n1 + n2 + 2 * n1 * n2 - 2 * np.sqrt(n1 * n2 * (n1 + 1) * (n2 + 1))
-        )
+        expected = 1 / (1 + n1 + n2 + 2 * n1 * n2 - 2 * np.sqrt(n1 * n2 * (n1 + 1) * (n2 + 1)))
         cov1 = hbar * (n1 + 0.5) * np.identity(2)
         cov2 = hbar * (n2 + 0.5) * np.identity(2)
         mu1 = np.zeros([2])
@@ -124,9 +118,7 @@ class TestGaussianStates:
         """Calculates the fidelity between a coherent squeezed state and vacuum"""
         settings.HBAR = hbar
         cov1 = np.diag([np.exp(2 * r), np.exp(-2 * r)]) * hbar / 2
-        means1 = real_to_complex_displacements(
-            np.array([alpha, np.conj(alpha)]), hbar=hbar
-        )
+        means1 = real_to_complex_displacements(np.array([alpha, np.conj(alpha)]), hbar=hbar)
         means2 = np.zeros([2])
         cov2 = np.identity(2) * hbar / 2
         expected = (
@@ -148,9 +140,7 @@ class TestMixedStates:
 
     def test_fidelity_with_self(self):
         """Test that the fidelity of two identical quantum states is 1"""
-        assert np.allclose(
-            fp.fidelity(self.state1, self.state1, False, False), 1, atol=1e-4
-        )
+        assert np.allclose(fp.fidelity(self.state1, self.state1, False, False), 1, atol=1e-4)
 
     def test_fidelity_is_symmetric(self):
         """Test that the fidelity is symmetric and between 0 and 1"""
@@ -166,9 +156,7 @@ class TestMixedStates:
     def test_fidelity_formula(self):
         """Test fidelity of known mixed states."""
         expected = 5 / 6
-        assert np.allclose(
-            expected, fp.fidelity(self.state1, self.state2, False, False)
-        )
+        assert np.allclose(expected, fp.fidelity(self.state1, self.state2, False, False))
 
 
 class TestGaussianFock:
@@ -181,24 +169,16 @@ class TestGaussianFock:
 
     def test_fidelity_across_representations_ket_ket(self):
         """Test that the fidelity of these two states is what it should be"""
-        assert np.allclose(
-            physics.fidelity(self.state1ket, self.state2ket), 0.36787944, atol=1e-4
-        )
+        assert np.allclose(physics.fidelity(self.state1ket, self.state2ket), 0.36787944, atol=1e-4)
 
     def test_fidelity_across_representations_ket_dm(self):
         """Test that the fidelity of these two states is what it should be"""
-        assert np.allclose(
-            physics.fidelity(self.state1ket, self.state2dm), 0.36787944, atol=1e-4
-        )
+        assert np.allclose(physics.fidelity(self.state1ket, self.state2dm), 0.36787944, atol=1e-4)
 
     def test_fidelity_across_representations_dm_ket(self):
         """Test that the fidelity of these two states is what it should be"""
-        assert np.allclose(
-            physics.fidelity(self.state1dm, self.state2ket), 0.36787944, atol=1e-4
-        )
+        assert np.allclose(physics.fidelity(self.state1dm, self.state2ket), 0.36787944, atol=1e-4)
 
     def test_fidelity_across_representations_dm_dm(self):
         """Test that the fidelity of these two states is what it should be"""
-        assert np.allclose(
-            physics.fidelity(self.state1dm, self.state2dm), 0.36787944, atol=1e-4
-        )
+        assert np.allclose(physics.fidelity(self.state1dm, self.state2dm), 0.36787944, atol=1e-4)

--- a/tests/test_physics/test_fock/test_fock.py
+++ b/tests/test_physics/test_fock/test_fock.py
@@ -127,18 +127,14 @@ def test_lossy_squeezing(n_mean, phi, eta):
     """Tests the total photon number distribution of a lossy squeezed state"""
     r = np.arcsinh(np.sqrt(n_mean))
     cutoff = 40
-    ps = (
-        SqueezedVacuum(r=r, phi=phi) >> Attenuator(transmissivity=eta)
-    ).fock_probabilities([cutoff])
-    expected = np.array(
-        [total_photon_number_distribution(n, 1, r, eta) for n in range(cutoff)]
+    ps = (SqueezedVacuum(r=r, phi=phi) >> Attenuator(transmissivity=eta)).fock_probabilities(
+        [cutoff]
     )
+    expected = np.array([total_photon_number_distribution(n, 1, r, eta) for n in range(cutoff)])
     assert np.allclose(ps, expected, atol=1e-5)
 
 
-@given(
-    n_mean=st.floats(0, 2), phi=st_angle, eta_0=st.floats(0, 1), eta_1=st.floats(0, 1)
-)
+@given(n_mean=st.floats(0, 2), phi=st_angle, eta_0=st.floats(0, 1), eta_1=st.floats(0, 1))
 def test_lossy_two_mode_squeezing(n_mean, phi, eta_0, eta_1):
     """Tests the photon number distribution of a lossy two-mode squeezed state"""
     cutoff = 40
@@ -241,18 +237,14 @@ def test_fock_trace_function():
 def test_dm_choi():
     """tests that choi op is correctly applied to a dm"""
     circ = Ggate(1) >> Attenuator([0.1])
-    dm_out = fock.apply_choi_to_dm(
-        circ.choi([10, 10, 10, 10]), Vacuum(1).dm([10]), [0], [0]
-    )
+    dm_out = fock.apply_choi_to_dm(circ.choi([10, 10, 10, 10]), Vacuum(1).dm([10]), [0], [0])
     dm_expected = (Vacuum(1) >> circ).dm([10])
     assert np.allclose(dm_out, dm_expected, atol=1e-5)
 
 
 def test_single_mode_choi_application_order():
     """Test dual operations output the correct mode ordering"""
-    s = Attenuator(1.0) << State(
-        dm=SqueezedVacuum(1.0, np.pi / 2).dm([40])
-    )  # apply identity gate
+    s = Attenuator(1.0) << State(dm=SqueezedVacuum(1.0, np.pi / 2).dm([40]))  # apply identity gate
     assert np.allclose(s.dm([10]), SqueezedVacuum(1.0, np.pi / 2).dm([10]))
 
 
@@ -268,9 +260,7 @@ def test_apply_kraus_to_ket_1mode_with_argument_names():
     """Test that Kraus operators are applied to a ket on the correct indices with argument names"""
     ket = np.random.normal(size=(2, 3, 4))
     kraus = np.random.normal(size=(5, 3))
-    ket_out = fock.apply_kraus_to_ket(
-        kraus=kraus, ket=ket, kraus_in_modes=[1], kraus_out_modes=[1]
-    )
+    ket_out = fock.apply_kraus_to_ket(kraus=kraus, ket=ket, kraus_in_modes=[1], kraus_out_modes=[1])
     assert ket_out.shape == (2, 5, 4)
 
 
@@ -302,9 +292,7 @@ def test_apply_kraus_to_dm_1mode_with_argument_names():
     """Test that Kraus operators are applied to a dm on the correct indices with argument names"""
     dm = np.random.normal(size=(2, 3, 2, 3))
     kraus = np.random.normal(size=(5, 3))
-    dm_out = fock.apply_kraus_to_dm(
-        kraus=kraus, dm=dm, kraus_in_modes=[1], kraus_out_modes=[1]
-    )
+    dm_out = fock.apply_kraus_to_dm(kraus=kraus, dm=dm, kraus_in_modes=[1], kraus_out_modes=[1])
     assert dm_out.shape == (2, 5, 2, 5)
 
 
@@ -336,9 +324,7 @@ def test_apply_choi_to_ket_1mode_with_argument_names():
     """Test that choi operators are applied to a ket on the correct indices with argument names"""
     ket = np.random.normal(size=(3, 5))
     choi = np.random.normal(size=(4, 3, 4, 3))  # [out_l, in_l, out_r, in_r]
-    ket_out = fock.apply_choi_to_ket(
-        choi=choi, ket=ket, choi_in_modes=[0], choi_out_modes=[0]
-    )
+    ket_out = fock.apply_choi_to_ket(choi=choi, ket=ket, choi_in_modes=[0], choi_out_modes=[0])
     assert ket_out.shape == (4, 5, 4, 5)
 
 
@@ -362,18 +348,14 @@ def test_apply_choi_to_dm_1mode_with_argument_names():
     """Test that choi operators are applied to a dm on the correct indices with argument names"""
     dm = np.random.normal(size=(3, 5, 3, 5))
     choi = np.random.normal(size=(4, 3, 4, 3))  # [out_l, in_l, out_r, in_r]
-    dm_out = fock.apply_choi_to_dm(
-        choi=choi, dm=dm, choi_in_modes=[0], choi_out_modes=[0]
-    )
+    dm_out = fock.apply_choi_to_dm(choi=choi, dm=dm, choi_in_modes=[0], choi_out_modes=[0])
     assert dm_out.shape == (4, 5, 4, 5)
 
 
 def test_apply_choi_to_dm_2mode():
     """Test that choi operators are applied to a dm on the correct indices"""
     dm = np.random.normal(size=(4, 5, 4, 5))
-    choi = np.random.normal(
-        size=(2, 3, 5, 2, 3, 5)
-    )  # [out_l_1,2, in_l_1, out_r_1,2, in_r_1]
+    choi = np.random.normal(size=(2, 3, 5, 2, 3, 5))  # [out_l_1,2, in_l_1, out_r_1,2, in_r_1]
     dm_out = fock.apply_choi_to_dm(choi, dm, [1], [1, 2])
     assert dm_out.shape == (4, 2, 3, 4, 2, 3)
 
@@ -455,12 +437,8 @@ def test_number_means(x, y):
 
 @given(x=st.floats(-1, 1), y=st.floats(-1, 1))
 def test_number_variances_coh(x, y):
-    assert np.allclose(
-        fock.number_variances(Coherent(x, y).ket([80]), False)[0], x * x + y * y
-    )
-    assert np.allclose(
-        fock.number_variances(Coherent(x, y).dm([80]), True)[0], x * x + y * y
-    )
+    assert np.allclose(fock.number_variances(Coherent(x, y).ket([80]), False)[0], x * x + y * y)
+    assert np.allclose(fock.number_variances(Coherent(x, y).dm([80]), True)[0], x * x + y * y)
 
 
 def test_number_variances_fock():

--- a/tests/test_physics/test_fock/test_fock.py
+++ b/tests/test_physics/test_fock/test_fock.py
@@ -37,6 +37,10 @@ from mrmustard.lab import (
 from mrmustard.math.lattice.strategies import displacement, grad_displacement
 from mrmustard.physics import fock
 
+from mrmustard import settings
+
+settings.HBAR = 2
+
 # helper strategies
 st_angle = st.floats(min_value=0, max_value=2 * np.pi)
 
@@ -123,14 +127,18 @@ def test_lossy_squeezing(n_mean, phi, eta):
     """Tests the total photon number distribution of a lossy squeezed state"""
     r = np.arcsinh(np.sqrt(n_mean))
     cutoff = 40
-    ps = (SqueezedVacuum(r=r, phi=phi) >> Attenuator(transmissivity=eta)).fock_probabilities(
-        [cutoff]
+    ps = (
+        SqueezedVacuum(r=r, phi=phi) >> Attenuator(transmissivity=eta)
+    ).fock_probabilities([cutoff])
+    expected = np.array(
+        [total_photon_number_distribution(n, 1, r, eta) for n in range(cutoff)]
     )
-    expected = np.array([total_photon_number_distribution(n, 1, r, eta) for n in range(cutoff)])
     assert np.allclose(ps, expected, atol=1e-5)
 
 
-@given(n_mean=st.floats(0, 2), phi=st_angle, eta_0=st.floats(0, 1), eta_1=st.floats(0, 1))
+@given(
+    n_mean=st.floats(0, 2), phi=st_angle, eta_0=st.floats(0, 1), eta_1=st.floats(0, 1)
+)
 def test_lossy_two_mode_squeezing(n_mean, phi, eta_0, eta_1):
     """Tests the photon number distribution of a lossy two-mode squeezed state"""
     cutoff = 40
@@ -233,14 +241,18 @@ def test_fock_trace_function():
 def test_dm_choi():
     """tests that choi op is correctly applied to a dm"""
     circ = Ggate(1) >> Attenuator([0.1])
-    dm_out = fock.apply_choi_to_dm(circ.choi([10, 10, 10, 10]), Vacuum(1).dm([10]), [0], [0])
+    dm_out = fock.apply_choi_to_dm(
+        circ.choi([10, 10, 10, 10]), Vacuum(1).dm([10]), [0], [0]
+    )
     dm_expected = (Vacuum(1) >> circ).dm([10])
     assert np.allclose(dm_out, dm_expected, atol=1e-5)
 
 
 def test_single_mode_choi_application_order():
     """Test dual operations output the correct mode ordering"""
-    s = Attenuator(1.0) << State(dm=SqueezedVacuum(1.0, np.pi / 2).dm([40]))  # apply identity gate
+    s = Attenuator(1.0) << State(
+        dm=SqueezedVacuum(1.0, np.pi / 2).dm([40])
+    )  # apply identity gate
     assert np.allclose(s.dm([10]), SqueezedVacuum(1.0, np.pi / 2).dm([10]))
 
 
@@ -256,7 +268,9 @@ def test_apply_kraus_to_ket_1mode_with_argument_names():
     """Test that Kraus operators are applied to a ket on the correct indices with argument names"""
     ket = np.random.normal(size=(2, 3, 4))
     kraus = np.random.normal(size=(5, 3))
-    ket_out = fock.apply_kraus_to_ket(kraus=kraus, ket=ket, kraus_in_modes=[1], kraus_out_modes=[1])
+    ket_out = fock.apply_kraus_to_ket(
+        kraus=kraus, ket=ket, kraus_in_modes=[1], kraus_out_modes=[1]
+    )
     assert ket_out.shape == (2, 5, 4)
 
 
@@ -288,7 +302,9 @@ def test_apply_kraus_to_dm_1mode_with_argument_names():
     """Test that Kraus operators are applied to a dm on the correct indices with argument names"""
     dm = np.random.normal(size=(2, 3, 2, 3))
     kraus = np.random.normal(size=(5, 3))
-    dm_out = fock.apply_kraus_to_dm(kraus=kraus, dm=dm, kraus_in_modes=[1], kraus_out_modes=[1])
+    dm_out = fock.apply_kraus_to_dm(
+        kraus=kraus, dm=dm, kraus_in_modes=[1], kraus_out_modes=[1]
+    )
     assert dm_out.shape == (2, 5, 2, 5)
 
 
@@ -320,7 +336,9 @@ def test_apply_choi_to_ket_1mode_with_argument_names():
     """Test that choi operators are applied to a ket on the correct indices with argument names"""
     ket = np.random.normal(size=(3, 5))
     choi = np.random.normal(size=(4, 3, 4, 3))  # [out_l, in_l, out_r, in_r]
-    ket_out = fock.apply_choi_to_ket(choi=choi, ket=ket, choi_in_modes=[0], choi_out_modes=[0])
+    ket_out = fock.apply_choi_to_ket(
+        choi=choi, ket=ket, choi_in_modes=[0], choi_out_modes=[0]
+    )
     assert ket_out.shape == (4, 5, 4, 5)
 
 
@@ -344,14 +362,18 @@ def test_apply_choi_to_dm_1mode_with_argument_names():
     """Test that choi operators are applied to a dm on the correct indices with argument names"""
     dm = np.random.normal(size=(3, 5, 3, 5))
     choi = np.random.normal(size=(4, 3, 4, 3))  # [out_l, in_l, out_r, in_r]
-    dm_out = fock.apply_choi_to_dm(choi=choi, dm=dm, choi_in_modes=[0], choi_out_modes=[0])
+    dm_out = fock.apply_choi_to_dm(
+        choi=choi, dm=dm, choi_in_modes=[0], choi_out_modes=[0]
+    )
     assert dm_out.shape == (4, 5, 4, 5)
 
 
 def test_apply_choi_to_dm_2mode():
     """Test that choi operators are applied to a dm on the correct indices"""
     dm = np.random.normal(size=(4, 5, 4, 5))
-    choi = np.random.normal(size=(2, 3, 5, 2, 3, 5))  # [out_l_1,2, in_l_1, out_r_1,2, in_r_1]
+    choi = np.random.normal(
+        size=(2, 3, 5, 2, 3, 5)
+    )  # [out_l_1,2, in_l_1, out_r_1,2, in_r_1]
     dm_out = fock.apply_choi_to_dm(choi, dm, [1], [1, 2])
     assert dm_out.shape == (4, 2, 3, 4, 2, 3)
 
@@ -433,8 +455,12 @@ def test_number_means(x, y):
 
 @given(x=st.floats(-1, 1), y=st.floats(-1, 1))
 def test_number_variances_coh(x, y):
-    assert np.allclose(fock.number_variances(Coherent(x, y).ket([80]), False)[0], x * x + y * y)
-    assert np.allclose(fock.number_variances(Coherent(x, y).dm([80]), True)[0], x * x + y * y)
+    assert np.allclose(
+        fock.number_variances(Coherent(x, y).ket([80]), False)[0], x * x + y * y
+    )
+    assert np.allclose(
+        fock.number_variances(Coherent(x, y).dm([80]), True)[0], x * x + y * y
+    )
 
 
 def test_number_variances_fock():

--- a/tests/test_physics/test_fock/test_fock.py
+++ b/tests/test_physics/test_fock/test_fock.py
@@ -37,10 +37,6 @@ from mrmustard.lab import (
 from mrmustard.math.lattice.strategies import displacement, grad_displacement
 from mrmustard.physics import fock
 
-from mrmustard import settings
-
-settings.HBAR = 2
-
 # helper strategies
 st_angle = st.floats(min_value=0, max_value=2 * np.pi)
 

--- a/tests/test_physics/test_gaussian/test_symplectics.py
+++ b/tests/test_physics/test_gaussian/test_symplectics.py
@@ -15,7 +15,13 @@
 import numpy as np
 from hypothesis import given
 from hypothesis import strategies as st
-from thewalrus.symplectic import beam_splitter, expand, rotation, squeezing, two_mode_squeezing
+from thewalrus.symplectic import (
+    beam_splitter,
+    expand,
+    rotation,
+    squeezing,
+    two_mode_squeezing,
+)
 
 from mrmustard.lab import (
     Amplifier,
@@ -33,6 +39,10 @@ from mrmustard.lab import (
 )
 from mrmustard.lab.states import TMSV, Thermal, Vacuum
 from mrmustard.physics.gaussian import controlled_X, controlled_Z
+
+from mrmustard import settings
+
+settings.HBAR = 2
 
 
 @given(r=st.floats(0, 2))

--- a/tests/test_physics/test_gaussian/test_symplectics.py
+++ b/tests/test_physics/test_gaussian/test_symplectics.py
@@ -40,10 +40,6 @@ from mrmustard.lab import (
 from mrmustard.lab.states import TMSV, Thermal, Vacuum
 from mrmustard.physics.gaussian import controlled_X, controlled_Z
 
-from mrmustard import settings
-
-settings.HBAR = 2
-
 
 @given(r=st.floats(0, 2))
 def test_two_mode_squeezing(r):

--- a/tests/test_training/test_opt.py
+++ b/tests/test_training/test_opt.py
@@ -31,7 +31,13 @@ from mrmustard.lab.gates import (
     S2gate,
     Sgate,
 )
-from mrmustard.lab.states import DisplacedSqueezed, Fock, Gaussian, SqueezedVacuum, Vacuum
+from mrmustard.lab.states import (
+    DisplacedSqueezed,
+    Fock,
+    Gaussian,
+    SqueezedVacuum,
+    Vacuum,
+)
 from mrmustard.math import Math
 from mrmustard.physics import fidelity
 from mrmustard.physics.gaussian import trace, von_neumann_entropy
@@ -96,7 +102,10 @@ def test_hong_ou_mandel_optimizer(i, k):
     cutoff = 1 + i + k
 
     def cost_fn():
-        return math.abs((state_in >> circ).ket(cutoffs=[cutoff] * 4)[i, 1, i + k - 1, k]) ** 2
+        return (
+            math.abs((state_in >> circ).ket(cutoffs=[cutoff] * 4)[i, 1, i + k - 1, k])
+            ** 2
+        )
 
     opt = Optimizer(euclidean_lr=0.01)
     opt.minimize(
@@ -292,7 +301,9 @@ def test_learning_four_mode_RealInterferometer():
             r_trainable=True,
             phi_trainable=True,
         ),
-        RealInterferometer(orthogonal=perturbed_O, num_modes=4, orthogonal_trainable=True),
+        RealInterferometer(
+            orthogonal=perturbed_O, num_modes=4, orthogonal_trainable=True
+        ),
     ]
     circ = Circuit(ops)
 
@@ -315,7 +326,9 @@ def test_squeezing_hong_ou_mandel_optimizer():
 
     S_01 = S2gate(r=r, phi=0.0, phi_trainable=True)[0, 1]
     S_23 = S2gate(r=r, phi=0.0, phi_trainable=True)[2, 3]
-    S_12 = S2gate(r=1.0, phi=settings.rng.normal(), r_trainable=True, phi_trainable=True)[1, 2]
+    S_12 = S2gate(
+        r=1.0, phi=settings.rng.normal(), r_trainable=True, phi_trainable=True
+    )[1, 2]
 
     circ = Circuit([S_01, S_23, S_12])
 
@@ -368,7 +381,7 @@ def test_making_thermal_state_as_one_half_two_mode_squeezed_vacuum():
         cov1, _ = trace(state.cov, state.means, [0])
         mean1 = state.number_means[0]
         mean2 = state.number_means[1]
-        entropy = von_neumann_entropy(cov1, settings.HBAR)
+        entropy = von_neumann_entropy(cov1)
         S = thermal_entropy(nbar)
         return (mean1 - nbar) ** 2 + (entropy - S) ** 2 + (mean2 - nbar) ** 2
 
@@ -450,7 +463,9 @@ def test_bsgate_optimization():
     def cost_fn():
         state_out = G >> bsgate
 
-        return -math.abs(math.sum(math.conj(state_out.ket([40, 40])) * target_state)) ** 2
+        return (
+            -math.abs(math.sum(math.conj(state_out.ket([40, 40])) * target_state)) ** 2
+        )
 
     opt = Optimizer()
     opt.minimize(cost_fn, by_optimizing=[bsgate])

--- a/tests/test_training/test_opt.py
+++ b/tests/test_training/test_opt.py
@@ -102,10 +102,7 @@ def test_hong_ou_mandel_optimizer(i, k):
     cutoff = 1 + i + k
 
     def cost_fn():
-        return (
-            math.abs((state_in >> circ).ket(cutoffs=[cutoff] * 4)[i, 1, i + k - 1, k])
-            ** 2
-        )
+        return math.abs((state_in >> circ).ket(cutoffs=[cutoff] * 4)[i, 1, i + k - 1, k]) ** 2
 
     opt = Optimizer(euclidean_lr=0.01)
     opt.minimize(
@@ -301,9 +298,7 @@ def test_learning_four_mode_RealInterferometer():
             r_trainable=True,
             phi_trainable=True,
         ),
-        RealInterferometer(
-            orthogonal=perturbed_O, num_modes=4, orthogonal_trainable=True
-        ),
+        RealInterferometer(orthogonal=perturbed_O, num_modes=4, orthogonal_trainable=True),
     ]
     circ = Circuit(ops)
 
@@ -326,9 +321,7 @@ def test_squeezing_hong_ou_mandel_optimizer():
 
     S_01 = S2gate(r=r, phi=0.0, phi_trainable=True)[0, 1]
     S_23 = S2gate(r=r, phi=0.0, phi_trainable=True)[2, 3]
-    S_12 = S2gate(
-        r=1.0, phi=settings.rng.normal(), r_trainable=True, phi_trainable=True
-    )[1, 2]
+    S_12 = S2gate(r=1.0, phi=settings.rng.normal(), r_trainable=True, phi_trainable=True)[1, 2]
 
     circ = Circuit([S_01, S_23, S_12])
 
@@ -463,9 +456,7 @@ def test_bsgate_optimization():
     def cost_fn():
         state_out = G >> bsgate
 
-        return (
-            -math.abs(math.sum(math.conj(state_out.ket([40, 40])) * target_state)) ** 2
-        )
+        return -math.abs(math.sum(math.conj(state_out.ket([40, 40])) * target_state)) ** 2
 
     opt = Optimizer()
     opt.minimize(cost_fn, by_optimizing=[bsgate])


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Ensure that code and tests are properly formatted, by running `make format` or `black -l 100
      <filename>` on any relevant files. You will need to have the Black code format installed:
      `pip install black`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] The Mr Mustard source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/) except line length.
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint mrmustard/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
While the value of `hbar` is specified in `Settings`, some methods allow passing (potentially different) values of `hbar`. There is no mechanism to keep track of the different values of `hbar` employed in a simulation, nor to ensure consistency. This leaves room for unintended behaviors.
 
**Description of the Change:**
All methods retrieve the value of `hbar` from the `Settings`, instead of allowing users to specify it in the inputs.

**Benefits:**
The value of `hbar` is guaranteed to be consistent throughout the session, meaning that at any point, it is equal to the value that can be found in the `Settings`.

**Possible Drawbacks:**
Users may still change the `Settings` (and specifically, the value of `hbar`) at any point during the computation. This will be disallowed in a follow-up Pull Request.

**Related GitHub Issues:**
