### PR TITLE
New phase noise

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### New features
 
+* Added the `PhaseNoise(phase_stdev)` gate (non-Gaussian). Output is a mixed state in Fock representation.
+  It is not based on a choi operator, but on a nonlinear transformation of the density matrix.
+  [(#275)](https://github.com/XanaduAI/MrMustard/pull/275)
+
 ### Breaking changes
 
 ### Improvements

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -17,7 +17,7 @@
 ### Documentation
 
 ### Contributors
-[Yuan Yao](https://github.com/sylviemonet)
+[Filippo Miatto](https://github.com/ziofil), [Yuan Yao](https://github.com/sylviemonet)
 
 
 # Release 0.5.0 (current release)

--- a/mrmustard/lab/gates.py
+++ b/mrmustard/lab/gates.py
@@ -918,7 +918,7 @@ class PhaseNoise(Parametrized, Transformation):
         phase_stdev: Union[Optional[float], Optional[List[float]]] = 0.0,
         phase_stdev_trainable: bool = False,
         phase_stdev_bounds: Tuple[Optional[float], Optional[float]] = (0.0, None),
-        modes: Optional[List[int]] = [0],
+        modes: Optional[List[int]] = None,
     ):
         super().__init__(
             phase_stdev=phase_stdev,

--- a/mrmustard/lab/gates.py
+++ b/mrmustard/lab/gates.py
@@ -925,7 +925,7 @@ class PhaseNoise(Parametrized, Transformation):
             phase_stdev_trainable=phase_stdev_trainable,
             phase_stdev_bounds=phase_stdev_bounds,
         )
-        self._modes = modes
+        self._modes = modes or [0]
         self.is_unitary = False
         self.is_gaussian = False
         self.short_name = "P~"

--- a/mrmustard/lab/gates.py
+++ b/mrmustard/lab/gates.py
@@ -19,9 +19,9 @@ This module defines gates and operations that can be applied to quantum modes to
 """
 
 from typing import List, Optional, Sequence, Tuple, Union
-
+import numpy as np
 from mrmustard import settings
-from mrmustard.lab.abstract import Transformation
+from mrmustard.lab.abstract import State, Transformation
 from mrmustard.math import Math
 from mrmustard.physics import fock, gaussian
 from mrmustard.training import Parametrized

--- a/mrmustard/lab/gates.py
+++ b/mrmustard/lab/gates.py
@@ -45,6 +45,7 @@ __all__ = [
     "Attenuator",
     "Amplifier",
     "AdditiveNoise",
+    "PhaseNoise",
 ]
 
 
@@ -898,3 +899,69 @@ class AdditiveNoise(Parametrized, Transformation):
     @property
     def Y_matrix(self):
         return gaussian.noise_Y(self.noise.value, settings.HBAR)
+
+
+class PhaseNoise(Parametrized, Transformation):
+    r"""The phase noise channel.
+
+    The phase noise channel is a non-Gaussian transformation that is equivalent to
+    a random phase rotation.
+
+    Args:
+        phase_stdev (float or List[float]): the standard deviation of the (wrapped) normal
+            distribution for the angle of the rotation
+        modes (optional, list(int)): the single mode this gate is applied to (default [0])
+    """
+
+    def __init__(
+        self,
+        phase_stdev: Union[Optional[float], Optional[List[float]]] = 0.0,
+        phase_stdev_trainable: bool = False,
+        phase_stdev_bounds: Tuple[Optional[float], Optional[float]] = (0.0, None),
+        modes: Optional[List[int]] = [0],
+    ):
+        super().__init__(
+            phase_stdev=phase_stdev,
+            phase_stdev_trainable=phase_stdev_trainable,
+            phase_stdev_bounds=phase_stdev_bounds,
+        )
+        self._modes = modes
+        self.is_unitary = False
+        self.is_gaussian = False
+        self.short_name = "P~"
+
+    # need to override primal because of the unconventional way
+    # the channel is defined in Fock representation
+    def primal(self, state):
+        idx = state.modes.index(self.modes[0])
+        if state.is_pure:
+            ket = state.ket()
+            dm = fock.ket_to_dm(ket)
+        else:
+            dm = state.dm()
+
+        # transpose dm so that the modes of interest are at the end
+        M = state.num_modes
+        indices = list(range(2 * M))
+        indices.remove(idx)
+        indices.remove(idx + M)
+        indices += [idx, idx + M]
+        dm = math.transpose(dm, indices)
+
+        coeff = math.cast(
+            math.exp(
+                -0.5
+                * self.phase_stdev.value**2
+                * math.arange(-dm.shape[-2] + 1, dm.shape[-1]) ** 2
+            ),
+            dm.dtype,
+        )
+
+        for k in range(-dm.shape[-2] + 1, dm.shape[-1]):
+            diagonal = math.diag_part(dm, k=k)
+            diagonal *= coeff[k + dm.shape[-2] - 1]
+            dm = math.set_diag(dm, diagonal, k=k)
+
+        # transpose dm back to the original order
+
+        return State(dm=math.transpose(dm, np.argsort(indices)), modes=state.modes)

--- a/mrmustard/math/math_interface.py
+++ b/mrmustard/math/math_interface.py
@@ -297,11 +297,12 @@ class MathInterface(ABC):
         """
 
     @abstractmethod
-    def diag_part(self, array: Tensor) -> Tensor:
+    def diag_part(self, array: Tensor, k: int) -> Tensor:
         r"""Returns the array of the main diagonal of array.
 
         Args:
             array (array): array to extract the main diagonal of
+            k (int): diagonal to extract
 
         Returns:
             array: array of the main diagonal of array
@@ -666,6 +667,19 @@ class MathInterface(ABC):
 
         Returns:
             array: reshaped array
+        """
+
+    @abstractmethod
+    def set_diag(self, array: Tensor, diag: Tensor, k: int) -> Tensor:
+        r"""Returns the array with the diagonal set to ``diag``.
+
+        Args:
+            array (array): array to set the diagonal of
+            diag (array): diagonal to set
+            k (int): diagonal to set
+
+        Returns:
+            array: array with the diagonal set to ``diag``
         """
 
     @abstractmethod

--- a/mrmustard/math/tensorflow.py
+++ b/mrmustard/math/tensorflow.py
@@ -133,7 +133,7 @@ class TFMath(MathInterface):
     def diag(self, array: tf.Tensor, k: int = 0) -> tf.Tensor:
         return tf.linalg.diag(array, k=k)
 
-    def diag_part(self, array: tf.Tensor, k = 0: int) -> tf.Tensor:
+    def diag_part(self, array: tf.Tensor, k: int = 0) -> tf.Tensor:
         return tf.linalg.diag_part(array, k=k)
 
     def einsum(self, string: str, *tensors) -> tf.Tensor:

--- a/mrmustard/math/tensorflow.py
+++ b/mrmustard/math/tensorflow.py
@@ -133,8 +133,8 @@ class TFMath(MathInterface):
     def diag(self, array: tf.Tensor, k: int = 0) -> tf.Tensor:
         return tf.linalg.diag(array, k=k)
 
-    def diag_part(self, array: tf.Tensor) -> tf.Tensor:
-        return tf.linalg.diag_part(array)
+    def diag_part(self, array: tf.Tensor, k: int) -> tf.Tensor:
+        return tf.linalg.diag_part(array, k=k)
 
     def einsum(self, string: str, *tensors) -> tf.Tensor:
         if type(string) is str:
@@ -259,6 +259,9 @@ class TFMath(MathInterface):
 
     def reshape(self, array: tf.Tensor, shape: Sequence[int]) -> tf.Tensor:
         return tf.reshape(array, shape)
+
+    def set_diag(self, array: tf.Tensor, diag: tf.Tensor, k: int) -> tf.Tensor:
+        return tf.linalg.set_diag(array, diag, k=k)
 
     def sin(self, array: tf.Tensor) -> tf.Tensor:
         return tf.math.sin(array)

--- a/mrmustard/math/tensorflow.py
+++ b/mrmustard/math/tensorflow.py
@@ -133,7 +133,7 @@ class TFMath(MathInterface):
     def diag(self, array: tf.Tensor, k: int = 0) -> tf.Tensor:
         return tf.linalg.diag(array, k=k)
 
-    def diag_part(self, array: tf.Tensor, k: int) -> tf.Tensor:
+    def diag_part(self, array: tf.Tensor, k = 0: int) -> tf.Tensor:
         return tf.linalg.diag_part(array, k=k)
 
     def einsum(self, string: str, *tensors) -> tf.Tensor:

--- a/tests/test_lab/test_gates_fock.py
+++ b/tests/test_lab/test_gates_fock.py
@@ -341,6 +341,7 @@ def test_phasenoise_creates_dm(phase_stdev):
 
 @given(phase_stdev=medium_float.filter(lambda x: x > 0))
 def test_phasenoise_symmetry(phase_stdev):
+    "tests that symmetric states are not affected by phase noise"
     assert (Fock(1) >> PhaseNoise(phase_stdev)) == Fock(1)
     settings.AUTOCUTOFF_MIN_CUTOFF = 100
     assert (Thermal(1) >> PhaseNoise(phase_stdev)) == Thermal(1)
@@ -349,6 +350,7 @@ def test_phasenoise_symmetry(phase_stdev):
 
 @given(phase_stdev=medium_float.filter(lambda x: x > 0))
 def test_phasenoise_on_multimode(phase_stdev):
+    "tests that phase noise can be used on multimode states"
     G2 = Gaussian(2) >> Attenuator(0.1, modes=[0, 1])
     P = PhaseNoise(phase_stdev, modes=[1])
     settings.AUTOCUTOFF_MIN_CUTOFF = 20
@@ -358,12 +360,14 @@ def test_phasenoise_on_multimode(phase_stdev):
 
 
 def test_phasenoise_large_noise():
+    "tests that large phase noise kills the off-diagonal elements"
     G1 = Gaussian(1)
     P = PhaseNoise(1000)
     assert (G1 >> P) == State(dm=math.diag(math.diag_part(G1.dm())))
 
 
 def test_phasenoise_zero_noise():
+    "tests that zero phase noise is equal to the identity"
     G1 = Gaussian(1)
     P = PhaseNoise(0.0)
     assert (G1 >> P) == State(dm=G1.dm())

--- a/tests/test_lab/test_gates_fock.py
+++ b/tests/test_lab/test_gates_fock.py
@@ -332,6 +332,7 @@ def test_schwinger_bs_equals_vanilla_bs_for_small_cutoffs(theta, phi):
     assert np.allclose(U_vanilla, U_schwinger, atol=1e-6)
 
 
+# pylint: disable=protected-access
 @given(phase_stdev=medium_float.filter(lambda x: x > 0))
 def test_phasenoise_creates_dm(phase_stdev):
     """test that the phase noise gate is correctly applied"""


### PR DESCRIPTION
**Context:**
We add the phase noise gate. This will convert a state to the Fock representation, as the phase noise isn't a Gaussian operation. Note that this isn't an approximation of the channel: it's exact.

**Description of the Change:**
We add the `PhaseNoise` gate, available under `mrmustard.lab.gates`

**Benefits:**
It's now possible to implement a realistic phase noise :)

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None