### PR TITLE
include julia_pkg in python packaging

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -48,6 +48,9 @@ which uses the old Numba code. When setting to a higher value, the new Julia cod
 * Improved how states, transformations, and detectors deal with parameters by replacing the `Parametrized` class with `ParameterSet`.
   [(#298)](https://github.com/XanaduAI/MrMustard/pull/298)
 
+* Includes julia dependencies into the python packaging for downstream installation reproducibility.
+  [(#298)](https://github.com/XanaduAI/MrMustard/pull/303)
+
 ### Bug fixes
 
 * Added the missing `shape` input parameters to all methods `U` in the `gates.py` file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Differentiable quantum Gaussian circuits"
 authors = ["Xanadu <filippo@xanadu.ai>"]
 license = "Apache License 2.0"
 readme = "README.md"
-include = ["pyproject.toml"]
+include = ["julia_pkg/*"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Console",


### PR DESCRIPTION
**Context:**
Includes julia dependency files into the python packaging so that MM's downstreams can reproduce julia installation without cloning the repo.

**Description of the Change:**
- adds `julia_pkg` to the `include` in pyproject.toml, which acts like the old MANIFEST
- removes `pyproject.toml` from includes which is not needed and pollutes the site-packages in the installation.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
