### PR TITLE
Use importlib for version

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -49,7 +49,9 @@ which uses the old Numba code. When setting to a higher value, the new Julia cod
   [(#298)](https://github.com/XanaduAI/MrMustard/pull/298)
 
 * Includes julia dependencies into the python packaging for downstream installation reproducibility.
-  [(#298)](https://github.com/XanaduAI/MrMustard/pull/303)
+  Removes dependency on tomli to load pyproject.toml for version info, uses importlib instead.
+  [(#303)](https://github.com/XanaduAI/MrMustard/pull/303)
+  [(#304)](https://github.com/XanaduAI/MrMustard/pull/304)
 
 ### Bug fixes
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -48,6 +48,9 @@ which uses the old Numba code. When setting to a higher value, the new Julia cod
 * Improved how states, transformations, and detectors deal with parameters by replacing the `Parametrized` class with `ParameterSet`.
   [(#298)](https://github.com/XanaduAI/MrMustard/pull/298)
 
+* Includes julia dependencies into the python packaging for downstream installation reproducibility.
+  [(#298)](https://github.com/XanaduAI/MrMustard/pull/303)
+
 ### Bug fixes
 
 * Added the missing `shape` input parameters to all methods `U` in the `gates.py` file.

--- a/mrmustard/_version.py
+++ b/mrmustard/_version.py
@@ -16,19 +16,7 @@
 
 Version number retrieved from pyproject.toml file
 """
-from pathlib import Path
-import tomli
 
+from importlib.metadata import version
 
-def _get_project_root():
-    """Compute and return root dir"""
-    return Path(__file__).parent.parent
-
-
-def _get_project_version():
-    """Parse 'pyproject.toml' and return current version"""
-    with open(f"{_get_project_root()}/pyproject.toml", mode="rb") as pyproject:
-        return tomli.load(pyproject)["tool"]["poetry"]["version"]
-
-
-__version__ = str(_get_project_version())
+__version__ = version("mrmustard")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Differentiable quantum Gaussian circuits"
 authors = ["Xanadu <filippo@xanadu.ai>"]
 license = "Apache License 2.0"
 readme = "README.md"
-include = ["pyproject.toml"]
+include = ["julia_pkg/*"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Console",


### PR DESCRIPTION
**Context:**
Currently MM's `__version__` depends on loading (and thus the existence of) the pyproject.toml file, but the version info is already present in the python package.

Exclusion of pyproject.toml in #303 is causing the __version__ to break in downstream installations. Instead of reverting back to including the pyproject toml, this PR addresses the issue by fundamentally fixing it.

**Description of the Change:**
Switches from tomli loading of pyproject toml to get version to using importlib.metadata.

**Benefits:**
the pyproject.toml is no longer thrown into the `site-packages` folder when installing MM.

**Possible Drawbacks:**

**Related GitHub Issues:**
