### PR TITLE
fix the document about functions loss_XYd and amp_XYd

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -59,6 +59,8 @@ which uses the old Numba code. When setting to a higher value, the new Julia cod
 [(#291)](https://github.com/XanaduAI/MrMustard/pull/291)
 * Fixed inconsistent use of `atol` in purity evaluation for Gaussian states.
 [(#294)](https://github.com/XanaduAI/MrMustard/pull/294)
+* Fixed the documentations for loss_XYd and amp_XYd functions for Gaussian channels.
+[(#305)](https://github.com/XanaduAI/MrMustard/pull/305)
 
 ### Documentation
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -70,7 +70,8 @@ which uses the old Numba code. When setting to a higher value, the new Julia cod
 ### Contributors
 [Robbe De Prins](https://github.com/rdprins),
 [Samuele Ferracin](https://github.com/SamFerracin),
-[Jan Provaznik](https://github.com/jan-provaznik)
+[Jan Provaznik](https://github.com/jan-provaznik),
+[Yuan Yao](https://github.com/sylviemonet)
 
 # Release 0.6.0 (current release)
 

--- a/mrmustard/physics/gaussian.py
+++ b/mrmustard/physics/gaussian.py
@@ -442,8 +442,8 @@ def loss_XYd(
 
     .. math::
 
-        X = math.sqrt(gain)
-        Y = (gain - 1) * (2 * nbar + 1) * hbar / 2
+        X = math.sqrt(transmissivity)
+        Y = (1-transmissivity) * (2 * nbar + 1) * hbar / 2
 
     Reference: Alessio Serafini - Quantum Continuous Variables (5.77, p. 108)
 
@@ -466,6 +466,13 @@ def loss_XYd(
 
 def amp_XYd(gain: Union[Scalar, Vector], nbar: Union[Scalar, Vector]) -> Matrix:
     r"""Returns the ``X``, ``Y`` matrices and the d vector for the noisy amplifier channel.
+
+    .. math::
+
+        X = math.sqrt(gain)
+        Y = (gain-1) * (2 * nbar + 1) * hbar / 2
+
+    Reference: Alessio Serafini - Quantum Continuous Variables (5.77, p. 111)
 
     The quantum limited amplifier channel is recovered for ``nbar = 0.0``.
 


### PR DESCRIPTION
**Context:** The documentation of loss_XYd and amp_XYd is not correct, which are used to define two Gaussian channels: Attenuator and Amplifier.

**Description of the Change:** Change the wrong definition in the document part of both functions.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
