### PR TITLE
Remove warnings

### DIFF
--- a/mrmustard/math/backend_tensorflow.py
+++ b/mrmustard/math/backend_tensorflow.py
@@ -467,7 +467,7 @@ class BackendTensorflow(BackendBase):  # pragma: no cover
         r"""In mrmustard.math.compactFock.compactFock~ dimensions of the Fock representation are ordered like [mode0,mode0,mode1,mode1,...]
         while in mrmustard.physics.bargmann the ordering is [mode0,mode1,...,mode0,mode1,...]. Here we reorder A and B.
         """
-        ordering = np.arange(2 * A.shape[0] // 2).reshape(2, -1).T.flatten()
+        ordering = np.arange(2 * A.shape[0] // 2).reshape(2, -1).T.flatten()  # ordering is [0,2,4,...,1,3,5,...]
         A = tf.gather(A, ordering, axis=1)
         A = tf.gather(A, ordering)
         B = tf.gather(B, ordering)

--- a/mrmustard/physics/fock.py
+++ b/mrmustard/physics/fock.py
@@ -713,7 +713,7 @@ def oscillator_eigenstate(q: Vector, cutoff: int) -> Tensor:
         poly = math.hermite_renormalized(
             R, 2 * math.astensor([xi], "complex128"), 1 + 0j, (cutoff,)
         )
-        return math.cast(poly, "float64")
+        return math.real(poly)
 
     hermite_polys = math.map_fn(f_hermite_polys, x_tensor)
 
@@ -844,7 +844,7 @@ def quadrature_distribution(
         else math.abs(math.einsum("n,nj->j", state, psi_x)) ** 2
     )
 
-    return x, math.cast(pdf, "float64")
+    return x, math.real(pdf)
 
 
 def sample_homodyne(state: Tensor, quadrature_angle: float = 0.0) -> Tuple[float, float]:


### PR DESCRIPTION
Removes complex to real warnings when making the mikkel_plot, due to casting in the oscillator_eigenstate function.
We just take the real part now.