### PR TITLE
Add batch in recursive relation

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -72,11 +72,11 @@ which uses the old Numba code. When setting to a higher value, the new Julia cod
 * Added tests for calculating Fock amplitudes with a higher precision than `complex128`.
 
 ### Contributors
-[Eli Bourassa](https://github.com/elib20)
+[Eli Bourassa](https://github.com/elib20),
 [Robbe De Prins](https://github.com/rdprins),
 [Samuele Ferracin](https://github.com/SamFerracin),
 [Jan Provaznik](https://github.com/jan-provaznik),
-[Yuan Yao](https://github.com/sylviemonet),
+[Yuan Yao](https://github.com/sylviemonet)
 
 # Release 0.6.0 (current release)
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -53,7 +53,8 @@ which uses the old Numba code. When setting to a higher value, the new Julia cod
   [(#303)](https://github.com/XanaduAI/MrMustard/pull/303)
   [(#304)](https://github.com/XanaduAI/MrMustard/pull/304)
 
-* Adds functions `hermite_renormalized_batch` and `hermite_renormalized_diagonal_batch` to speed up calculating Hermite polynomials.
+* Adds functions `hermite_renormalized_batch` and `hermite_renormalized_diagonal_batch` to speed up calculating 
+  Hermite polynomials over a batch of B vectors.
   [(#308)](https://github.com/XanaduAI/MrMustard/pull/308)
 
 ### Bug fixes
@@ -71,10 +72,11 @@ which uses the old Numba code. When setting to a higher value, the new Julia cod
 * Added tests for calculating Fock amplitudes with a higher precision than `complex128`.
 
 ### Contributors
+[Eli Bourassa](https://github.com/elib20)
 [Robbe De Prins](https://github.com/rdprins),
 [Samuele Ferracin](https://github.com/SamFerracin),
 [Jan Provaznik](https://github.com/jan-provaznik),
-[Yuan Yao](https://github.com/sylviemonet)
+[Yuan Yao](https://github.com/sylviemonet),
 
 # Release 0.6.0 (current release)
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -58,6 +58,7 @@ which uses the old Numba code. When setting to a higher value, the new Julia cod
   [(#308)](https://github.com/XanaduAI/MrMustard/pull/308)
 
 * Changed the ``cast`` functions in the numpy and tensorflow backends to avoid ``ComplexWarning``s.
+  [(#307)](https://github.com/XanaduAI/MrMustard/pull/307)
 
 
 ### Bug fixes

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -53,6 +53,9 @@ which uses the old Numba code. When setting to a higher value, the new Julia cod
   [(#303)](https://github.com/XanaduAI/MrMustard/pull/303)
   [(#304)](https://github.com/XanaduAI/MrMustard/pull/304)
 
+* Adds functions `hermite_renormalized_batch` and `hermite_renormalized_diagonal_batch` to speed up calculating Hermite polynomials.
+  [(#308)](https://github.com/XanaduAI/MrMustard/pull/308)
+
 ### Bug fixes
 
 * Added the missing `shape` input parameters to all methods `U` in the `gates.py` file.

--- a/mrmustard/math/backend_manager.py
+++ b/mrmustard/math/backend_manager.py
@@ -574,6 +574,12 @@ class BackendManager:  # pylint: disable=too-many-public-methods, fixme
         """
         return self._apply("hermite_renormalized_diagonal", (A, B, C, cutoffs))
 
+    def hermite_renormalized_diagonal_batch(
+        self, A: Tensor, B: Tensor, C: Tensor, cutoffs: Tuple[int]
+    ) -> Tensor:
+        r"""Same as hermite_renormalized_diagonal but works for a batch of different B's."""
+        return self._apply("hermite_renormalized_diagonal_batch", (A, B, C, cutoffs))
+
     def hermite_renormalized_1leftoverMode(
         self, A: Tensor, B: Tensor, C: Tensor, cutoffs: Tuple[int]
     ) -> Tensor:

--- a/mrmustard/math/backend_manager.py
+++ b/mrmustard/math/backend_manager.py
@@ -596,7 +596,7 @@ class BackendManager:  # pylint: disable=too-many-public-methods, fixme
     def hermite_renormalized_diagonal_batch(
         self, A: Tensor, B: Tensor, C: Tensor, cutoffs: Tuple[int]
     ) -> Tensor:
-        r"""Firsts, reorder A and B parameters of Bargmann representation to match conventions in mrmustard.math.compactFock~
+        r"""First, reorder A and B parameters of Bargmann representation to match conventions in mrmustard.math.compactFock~
         Then, calculates the required renormalized multidimensional Hermite polynomial.
         Same as hermite_renormalized_diagonal but works for a batch of different B's."""
         return self._apply("hermite_renormalized_diagonal_batch", (A, B, C, cutoffs))

--- a/mrmustard/math/backend_manager.py
+++ b/mrmustard/math/backend_manager.py
@@ -115,7 +115,7 @@ class BackendManager:  # pylint: disable=too-many-public-methods, fixme
             "complex64",
             "complex128",
             "hermite_renormalized",
-            # "hermite_renormalized_batch",
+            "hermite_renormalized_batch",
             "hermite_renormalized_binomial",
             "hermite_renormalized_diagonal_reorderedAB",
             "hermite_renormalized_1leftoverMode_reorderedAB",

--- a/mrmustard/math/backend_manager.py
+++ b/mrmustard/math/backend_manager.py
@@ -577,7 +577,9 @@ class BackendManager:  # pylint: disable=too-many-public-methods, fixme
     def hermite_renormalized_diagonal_batch(
         self, A: Tensor, B: Tensor, C: Tensor, cutoffs: Tuple[int]
     ) -> Tensor:
-        r"""Same as hermite_renormalized_diagonal but works for a batch of different B's."""
+        r"""Firsts, reorder A and B parameters of Bargmann representation to match conventions in mrmustard.math.compactFock~
+        Then, calculates the required renormalized multidimensional Hermite polynomial.
+        Same as hermite_renormalized_diagonal but works for a batch of different B's."""
         return self._apply("hermite_renormalized_diagonal_batch", (A, B, C, cutoffs))
 
     def hermite_renormalized_1leftoverMode(

--- a/mrmustard/math/backend_manager.py
+++ b/mrmustard/math/backend_manager.py
@@ -115,7 +115,6 @@ class BackendManager:  # pylint: disable=too-many-public-methods, fixme
             "complex64",
             "complex128",
             "hermite_renormalized",
-            "hermite_renormalized_batch",
             "hermite_renormalized_binomial",
             "hermite_renormalized_diagonal_reorderedAB",
             "hermite_renormalized_1leftoverMode_reorderedAB",
@@ -565,6 +564,26 @@ class BackendManager:  # pylint: disable=too-many-public-methods, fixme
                 axis,
             ),
         )
+
+    def hermite_renormalized_batch(
+        self, A: Tensor, B: Tensor, C: Tensor, shape: Tuple[int]
+    ) -> Tensor:
+        r"""Renormalized multidimensional Hermite polynomial given by the "exponential" Taylor
+        series of :math:`exp(C + Bx + 1/2*Ax^2)` at zero, where the series has :math:`sqrt(n!)`
+        at the denominator rather than :math:`n!`. It computes all the amplitudes within the
+        tensor of given shape in case of B is a batched vector with a batched diemnsion on the
+        last index.
+
+        Args:
+            A: The A matrix.
+            B: The batched B vector with its batch dimension on the last index.
+            C: The C scalar.
+            shape: The shape of the final tensor.
+
+        Returns:
+            The batched Hermite polynomial of given shape.
+        """
+        return self._apply("hermite_renormalized_batch", (A, B, C, shape))
 
     def hermite_renormalized_diagonal(
         self, A: Tensor, B: Tensor, C: Tensor, cutoffs: Tuple[int]

--- a/mrmustard/math/backend_manager.py
+++ b/mrmustard/math/backend_manager.py
@@ -565,7 +565,7 @@ class BackendManager:  # pylint: disable=too-many-public-methods, fixme
                 axis,
             ),
         )
-    
+
     def hermite_renormalized_diagonal(
         self, A: Tensor, B: Tensor, C: Tensor, cutoffs: Tuple[int]
     ) -> Tensor:

--- a/mrmustard/math/backend_manager.py
+++ b/mrmustard/math/backend_manager.py
@@ -115,6 +115,7 @@ class BackendManager:  # pylint: disable=too-many-public-methods, fixme
             "complex64",
             "complex128",
             "hermite_renormalized",
+            # "hermite_renormalized_batch",
             "hermite_renormalized_binomial",
             "hermite_renormalized_diagonal_reorderedAB",
             "hermite_renormalized_1leftoverMode_reorderedAB",
@@ -564,7 +565,7 @@ class BackendManager:  # pylint: disable=too-many-public-methods, fixme
                 axis,
             ),
         )
-
+    
     def hermite_renormalized_diagonal(
         self, A: Tensor, B: Tensor, C: Tensor, cutoffs: Tuple[int]
     ) -> Tensor:

--- a/mrmustard/math/backend_numpy.py
+++ b/mrmustard/math/backend_numpy.py
@@ -446,21 +446,6 @@ class BackendNumpy(BackendBase):  # pragma: no cover
     def hermite_renormalized_batch(
         self, A: np.array, B: np.array, C: np.array, shape: Tuple[int]
     ) -> np.array:
-        r"""Renormalized multidimensional Hermite polynomial given by the "exponential" Taylor
-        series of :math:`exp(C + Bx + 1/2*Ax^2)` at zero, where the series has :math:`sqrt(n!)`
-        at the denominator rather than :math:`n!`. It computes all the amplitudes within the
-        tensor of given shape in case of B is a batched vector with a batched diemnsion on the
-        last index.
-
-        Args:
-            A: The A matrix.
-            B: The batched B vector with its batch dimension on the last index.
-            C: The C scalar.
-            shape: The shape of the final tensor.
-
-        Returns:
-            The batched Hermite polynomial of given shape.
-        """
         G = vanilla_batch(tuple(shape), A, B, C)
         return G
 

--- a/mrmustard/math/backend_numpy.py
+++ b/mrmustard/math/backend_numpy.py
@@ -29,7 +29,7 @@ import numpy as np
 from .autocast import Autocast
 from .backend_base import BackendBase
 from ..utils.settings import settings
-from .lattice.strategies import binomial, vanilla
+from .lattice.strategies import binomial, vanilla, vanilla_batch
 from .lattice.strategies.compactFock.inputValidation import (
     hermite_multidimensional_1leftoverMode,
     hermite_multidimensional_diagonal,
@@ -438,6 +438,24 @@ class BackendNumpy(BackendBase):  # pragma: no cover
                 _A, _B, _C.item(), np.array(shape, dtype=np.int64), precision_bits
             )
 
+        return G
+    
+    def hermite_renormalized_batch(self, A: np.array, B: np.array, C: np.array, shape: Tuple[int]) -> np.array:
+        r"""multidimensional Hermite polynomial given by the "exponential" Taylor
+        series of :math:`exp(C + Bx + 1/2*Ax^2)` at zero, where the series has :math:`sqrt(n!)`
+        at the denominator rather than :math:`n!`. It computes all the amplitudes within the
+        tensor of given shape.
+
+        Args:
+            A: The A matrix.
+            B: The B vector.
+            C: The C scalar.
+            shape: The shape of the final tensor.
+
+        Returns:
+            The Hermite polynomial of given shape.
+        """
+        G = vanilla_batch(tuple(shape), A, B, C)
         return G
 
     def hermite_renormalized_binomial(

--- a/mrmustard/math/backend_numpy.py
+++ b/mrmustard/math/backend_numpy.py
@@ -439,8 +439,10 @@ class BackendNumpy(BackendBase):  # pragma: no cover
             )
 
         return G
-    
-    def hermite_renormalized_batch(self, A: np.array, B: np.array, C: np.array, shape: Tuple[int]) -> np.array:
+
+    def hermite_renormalized_batch(
+        self, A: np.array, B: np.array, C: np.array, shape: Tuple[int]
+    ) -> np.array:
         r"""multidimensional Hermite polynomial given by the "exponential" Taylor
         series of :math:`exp(C + Bx + 1/2*Ax^2)` at zero, where the series has :math:`sqrt(n!)`
         at the denominator rather than :math:`n!`. It computes all the amplitudes within the

--- a/mrmustard/math/backend_numpy.py
+++ b/mrmustard/math/backend_numpy.py
@@ -443,19 +443,20 @@ class BackendNumpy(BackendBase):  # pragma: no cover
     def hermite_renormalized_batch(
         self, A: np.array, B: np.array, C: np.array, shape: Tuple[int]
     ) -> np.array:
-        r"""multidimensional Hermite polynomial given by the "exponential" Taylor
+        r"""Renormalized multidimensional Hermite polynomial given by the "exponential" Taylor
         series of :math:`exp(C + Bx + 1/2*Ax^2)` at zero, where the series has :math:`sqrt(n!)`
         at the denominator rather than :math:`n!`. It computes all the amplitudes within the
-        tensor of given shape.
+        tensor of given shape in case of B is a batched vector with a batched diemnsion on the
+        last index.
 
         Args:
             A: The A matrix.
-            B: The B vector.
+            B: The batched B vector with its batch dimension on the last index.
             C: The C scalar.
             shape: The shape of the final tensor.
 
         Returns:
-            The Hermite polynomial of given shape.
+            The batched Hermite polynomial of given shape.
         """
         G = vanilla_batch(tuple(shape), A, B, C)
         return G

--- a/mrmustard/math/backend_numpy.py
+++ b/mrmustard/math/backend_numpy.py
@@ -33,6 +33,7 @@ from .lattice.strategies import binomial, vanilla, vanilla_batch
 from .lattice.strategies.compactFock.inputValidation import (
     hermite_multidimensional_1leftoverMode,
     hermite_multidimensional_diagonal,
+    hermite_multidimensional_diagonal_batch,
 )
 
 
@@ -505,7 +506,7 @@ class BackendNumpy(BackendBase):  # pragma: no cover
         ordering = np.arange(2 * A.shape[0] // 2).reshape(2, -1).T.flatten()
         A = self.gather(A, ordering, axis=1)
         A = self.gather(A, ordering)
-        B = self.gather(B, ordering)
+        B = self.gather(B, ordering, axis=0)
         return A, B
 
     def hermite_renormalized_diagonal(
@@ -537,6 +538,31 @@ class BackendNumpy(BackendBase):  # pragma: no cover
             The renormalized Hermite polynomial.
         """
         poly0, _, _, _, _ = hermite_multidimensional_diagonal(A, B, C, cutoffs)
+
+        return poly0
+
+    def hermite_renormalized_diagonal_batch(
+        self, A: np.array, B: np.array, C: np.array, cutoffs: Tuple[int]
+    ) -> np.array:
+        r"""Same as hermite_renormalized_diagonal but works for a batch of different B's."""
+        A, B = self.reorder_AB_bargmann(A, B)
+        return self.hermite_renormalized_diagonal_reorderedAB_batch(A, B, C, cutoffs=cutoffs)
+
+    def hermite_renormalized_diagonal_reorderedAB_batch(
+        self, A: np.array, B: np.array, C: np.array, cutoffs: Tuple[int]
+    ) -> np.array:
+        r"""Same as hermite_renormalized_diagonal_reorderedAB but works for a batch of different B's.
+
+        Args:
+            A: The A matrix.
+            B: The B vectors.
+            C: The C scalar.
+            cutoffs: upper boundary of photon numbers in each mode
+
+        Returns:
+            The renormalized Hermite polynomial from different B values.
+        """
+        poly0, _, _, _, _ = hermite_multidimensional_diagonal_batch(A, B, C, cutoffs)
 
         return poly0
 

--- a/mrmustard/math/backend_numpy.py
+++ b/mrmustard/math/backend_numpy.py
@@ -499,9 +499,6 @@ class BackendNumpy(BackendBase):  # pragma: no cover
     def hermite_renormalized_diagonal(
         self, A: np.array, B: np.array, C: np.array, cutoffs: Tuple[int]
     ) -> np.array:
-        r"""First, reorder A and B parameters of Bargmann representation to match conventions in mrmustard.math.numba.compactFock~
-        Then, calculate the required renormalized multidimensional Hermite polynomial.
-        """
         A, B = self.reorder_AB_bargmann(A, B)
         return self.hermite_renormalized_diagonal_reorderedAB(A, B, C, cutoffs=cutoffs)
 

--- a/mrmustard/math/backend_tensorflow.py
+++ b/mrmustard/math/backend_tensorflow.py
@@ -435,7 +435,9 @@ class BackendTensorflow(BackendBase):  # pragma: no cover
         Returns:
             The Hermite polynomial of given shape.
         """
-        G = strategies.vanilla_batch(tuple(shape), A, B, C)
+        _A, _B, _C = self.asnumpy(A), self.asnumpy(B), self.asnumpy(C)
+
+        G = strategies.vanilla_batch(tuple(shape), _A, _B, _C)
         return G
 
     @tf.custom_gradient

--- a/mrmustard/math/backend_tensorflow.py
+++ b/mrmustard/math/backend_tensorflow.py
@@ -419,6 +419,24 @@ class BackendTensorflow(BackendBase):  # pragma: no cover
             return self.conj(dLdA), self.conj(dLdB), self.conj(dLdC)
 
         return G, grad
+    
+    def hermite_renormalized_batch(self, A: tf.Tensor, B: tf.Tensor, C: tf.Tensor, shape: Tuple[int]) -> tf.Tensor:
+        r"""multidimensional Hermite polynomial given by the "exponential" Taylor
+        series of :math:`exp(C + Bx + 1/2*Ax^2)` at zero, where the series has :math:`sqrt(n!)`
+        at the denominator rather than :math:`n!`. It computes all the amplitudes within the
+        tensor of given shape.
+
+        Args:
+            A: The A matrix.
+            B: The B vector.
+            C: The C scalar.
+            shape: The shape of the final tensor.
+
+        Returns:
+            The Hermite polynomial of given shape.
+        """
+        G = strategies.vanilla_batch(tuple(shape), A, B, C)
+        return G
 
     @tf.custom_gradient
     def hermite_renormalized_binomial(

--- a/mrmustard/math/backend_tensorflow.py
+++ b/mrmustard/math/backend_tensorflow.py
@@ -427,23 +427,6 @@ class BackendTensorflow(BackendBase):  # pragma: no cover
     def hermite_renormalized_batch(
         self, A: tf.Tensor, B: tf.Tensor, C: tf.Tensor, shape: Tuple[int]
     ) -> tf.Tensor:
-        r"""Renormalized multidimensional Hermite polynomial given by the "exponential" Taylor
-        series of :math:`exp(C + Bx + 1/2*Ax^2)` at zero, where the series has :math:`sqrt(n!)`
-        at the denominator rather than :math:`n!`. It computes all the amplitudes within the
-        tensor of given shape in case of B is a batched vector with a batched diemnsion on the
-        last index.
-
-        Note that this function is only available for the forward pass, not with the gradient.
-
-        Args:
-            A: The A matrix.
-            B: The batched B vector with its batch dimension on the last index.
-            C: The C scalar.
-            shape: The shape of the final tensor.
-
-        Returns:
-            The batched Hermite polynomial of given shape.
-        """
         _A, _B, _C = self.asnumpy(A), self.asnumpy(B), self.asnumpy(C)
 
         G = strategies.vanilla_batch(tuple(shape), _A, _B, _C)

--- a/mrmustard/math/backend_tensorflow.py
+++ b/mrmustard/math/backend_tensorflow.py
@@ -419,8 +419,10 @@ class BackendTensorflow(BackendBase):  # pragma: no cover
             return self.conj(dLdA), self.conj(dLdB), self.conj(dLdC)
 
         return G, grad
-    
-    def hermite_renormalized_batch(self, A: tf.Tensor, B: tf.Tensor, C: tf.Tensor, shape: Tuple[int]) -> tf.Tensor:
+
+    def hermite_renormalized_batch(
+        self, A: tf.Tensor, B: tf.Tensor, C: tf.Tensor, shape: Tuple[int]
+    ) -> tf.Tensor:
         r"""multidimensional Hermite polynomial given by the "exponential" Taylor
         series of :math:`exp(C + Bx + 1/2*Ax^2)` at zero, where the series has :math:`sqrt(n!)`
         at the denominator rather than :math:`n!`. It computes all the amplitudes within the

--- a/mrmustard/math/backend_tensorflow.py
+++ b/mrmustard/math/backend_tensorflow.py
@@ -490,9 +490,6 @@ class BackendTensorflow(BackendBase):  # pragma: no cover
     def hermite_renormalized_diagonal(
         self, A: tf.Tensor, B: tf.Tensor, C: tf.Tensor, cutoffs: Tuple[int]
     ) -> tf.Tensor:
-        r"""First, reorder A and B parameters of Bargmann representation to match conventions in mrmustard.math.compactFock.compactFock~
-        Then, calculate the required renormalized multidimensional Hermite polynomial.
-        """
         A, B = self.reorder_AB_bargmann(A, B)
         return self.hermite_renormalized_diagonal_reorderedAB(A, B, C, cutoffs=cutoffs)
 

--- a/mrmustard/math/backend_tensorflow.py
+++ b/mrmustard/math/backend_tensorflow.py
@@ -429,6 +429,8 @@ class BackendTensorflow(BackendBase):  # pragma: no cover
         tensor of given shape in case of B is a batched vector with a batched diemnsion on the
         last index.
 
+        Note that this function is only available for the forward pass, not with the gradient.
+
         Args:
             A: The A matrix.
             B: The batched B vector with its batch dimension on the last index.

--- a/mrmustard/math/backend_tensorflow.py
+++ b/mrmustard/math/backend_tensorflow.py
@@ -423,19 +423,20 @@ class BackendTensorflow(BackendBase):  # pragma: no cover
     def hermite_renormalized_batch(
         self, A: tf.Tensor, B: tf.Tensor, C: tf.Tensor, shape: Tuple[int]
     ) -> tf.Tensor:
-        r"""multidimensional Hermite polynomial given by the "exponential" Taylor
+        r"""Renormalized multidimensional Hermite polynomial given by the "exponential" Taylor
         series of :math:`exp(C + Bx + 1/2*Ax^2)` at zero, where the series has :math:`sqrt(n!)`
         at the denominator rather than :math:`n!`. It computes all the amplitudes within the
-        tensor of given shape.
+        tensor of given shape in case of B is a batched vector with a batched diemnsion on the
+        last index.
 
         Args:
             A: The A matrix.
-            B: The B vector.
+            B: The batched B vector with its batch dimension on the last index.
             C: The C scalar.
             shape: The shape of the final tensor.
 
         Returns:
-            The Hermite polynomial of given shape.
+            The batched Hermite polynomial of given shape.
         """
         _A, _B, _C = self.asnumpy(A), self.asnumpy(B), self.asnumpy(C)
 

--- a/mrmustard/math/lattice/steps.py
+++ b/mrmustard/math/lattice/steps.py
@@ -69,11 +69,11 @@ def vanilla_step(
 
 @njit
 def vanilla_step_batch(
-    G: np.array,
-    A: np.array,
-    b: np.array,
+    G: ComplexTensor,
+    A: ComplexMatrix,
+    b: ComplexTensor,
     index: tuple[int, ...],
-) -> np.array:
+) -> complex:
     r"""Fock-Bargmann recurrence relation step, vanilla version.
     This function returns the amplitude of the Gaussian tensor G
     at G[index]. It does not modify G.
@@ -92,12 +92,11 @@ def vanilla_step_batch(
     i, pivot = first_available_pivot(index)
 
     # pivot contribution
-
     value_at_index = b[:, i] * G[pivot]
 
     # neighbors contribution
     for j, neighbor in lower_neighbors(pivot):
-            value_at_index += A[i, j] * SQRT[pivot[j]] * G[neighbor]
+        value_at_index += A[i, j] * SQRT[pivot[j]] * G[neighbor]
 
     return value_at_index / SQRT[index[i]]
 

--- a/mrmustard/math/lattice/steps.py
+++ b/mrmustard/math/lattice/steps.py
@@ -69,11 +69,11 @@ def vanilla_step(
 
 @njit
 def vanilla_step_batch(
-    G: ComplexTensor,
-    A: ComplexMatrix,
-    b: ComplexVector,
+    G: np.array,
+    A: np.array,
+    b: np.array,
     index: tuple[int, ...],
-) -> complex:
+) -> np.array:
     r"""Fock-Bargmann recurrence relation step, vanilla version.
     This function returns the amplitude of the Gaussian tensor G
     at G[index]. It does not modify G.
@@ -93,11 +93,11 @@ def vanilla_step_batch(
 
     # pivot contribution
 
-    value_at_index = b[:, i] * G[(...,*pivot)]
+    value_at_index = b[:, i] * G[pivot]
 
     # neighbors contribution
     for j, neighbor in lower_neighbors(pivot):
-            value_at_index += A[i, j] * SQRT[pivot[j]] * G[(..., *neighbor)]
+            value_at_index += A[i, j] * SQRT[pivot[j]] * G[neighbor]
 
     return value_at_index / SQRT[index[i]]
 

--- a/mrmustard/math/lattice/steps.py
+++ b/mrmustard/math/lattice/steps.py
@@ -74,19 +74,21 @@ def vanilla_step_batch(
     b: ComplexTensor,
     index: tuple[int, ...],
 ) -> complex:
-    r"""Fock-Bargmann recurrence relation step, vanilla version.
+    r"""Fock-Bargmann recurrence relation step, vanilla batched version.
     This function returns the amplitude of the Gaussian tensor G
     at G[index]. It does not modify G.
     The necessary pivot and neighbours must have already been computed,
     as this step will read those values from G.
+    Note that this function is different from vanilla_step with b is no longer a vector,
+    it becomes a bathced vector with the batch dimension on the last index.
 
     Args:
         G (array or dict): fock amplitudes data store that supports getitem[tuple[int, ...]]
         A (array): A matrix of the Fock-Bargmann representation
-        b (array): B vector of the Fock-Bargmann representation
+        b (array): batched B vector of the Fock-Bargmann representation, the batch dimension is on the last index
         index (Sequence): index of the amplitude to calculate
     Returns:
-        complex: the value of the amplitude at the given index
+        array: the value of the amplitude at the given index according to each batch on the last index
     """
     # get pivot
     i, pivot = first_available_pivot(index)

--- a/mrmustard/math/lattice/steps.py
+++ b/mrmustard/math/lattice/steps.py
@@ -73,7 +73,7 @@ def vanilla_step_batch(
     A: ComplexMatrix,
     b: ComplexTensor,
     index: tuple[int, ...],
-) -> complex:
+) -> complex:  # pragma: no cover
     r"""Fock-Bargmann recurrence relation step, vanilla batched version.
     This function returns the amplitude of the Gaussian tensor G
     at G[index]. It does not modify G.

--- a/mrmustard/math/lattice/steps.py
+++ b/mrmustard/math/lattice/steps.py
@@ -92,7 +92,7 @@ def vanilla_step_batch(
     i, pivot = first_available_pivot(index)
 
     # pivot contribution
-    value_at_index = b[:, i] * G[pivot]
+    value_at_index = b[i] * G[pivot]
 
     # neighbors contribution
     for j, neighbor in lower_neighbors(pivot):

--- a/mrmustard/math/lattice/steps.py
+++ b/mrmustard/math/lattice/steps.py
@@ -68,6 +68,41 @@ def vanilla_step(
 
 
 @njit
+def vanilla_step_batch(
+    G: ComplexTensor,
+    A: ComplexMatrix,
+    b: ComplexVector,
+    index: tuple[int, ...],
+) -> complex:
+    r"""Fock-Bargmann recurrence relation step, vanilla version.
+    This function returns the amplitude of the Gaussian tensor G
+    at G[index]. It does not modify G.
+    The necessary pivot and neighbours must have already been computed,
+    as this step will read those values from G.
+
+    Args:
+        G (array or dict): fock amplitudes data store that supports getitem[tuple[int, ...]]
+        A (array): A matrix of the Fock-Bargmann representation
+        b (array): B vector of the Fock-Bargmann representation
+        index (Sequence): index of the amplitude to calculate
+    Returns:
+        complex: the value of the amplitude at the given index
+    """
+    # get pivot
+    i, pivot = first_available_pivot(index)
+
+    # pivot contribution
+
+    value_at_index = b[:, i] * G[(...,*pivot)]
+
+    # neighbors contribution
+    for j, neighbor in lower_neighbors(pivot):
+            value_at_index += A[i, j] * SQRT[pivot[j]] * G[(..., *neighbor)]
+
+    return value_at_index / SQRT[index[i]]
+
+
+@njit
 def vanilla_step_jacobian(
     G: ComplexTensor,
     A: ComplexMatrix,

--- a/mrmustard/math/lattice/strategies/compactFock/diagonal_amps.py
+++ b/mrmustard/math/lattice/strategies/compactFock/diagonal_amps.py
@@ -15,7 +15,7 @@ from mrmustard.math.lattice.strategies.compactFock.helperFunctions import (
 
 
 @njit
-def use_offDiag_pivot(A, B, M, cutoffs, params, d, arr0, arr2, arr1010, arr1001, arr1):
+def use_offDiag_pivot(A, B, M, cutoffs, params, d, arr0, arr2, arr1010, arr1001, arr1):  # pragma: no cover
     """
     Apply recurrence relation for pivot of type [a+1,a,b,b,c,c,...] / [a,a,b+1,b,c,c,...] / [a,a,b,b,c+1,c,...]
     Args:
@@ -82,7 +82,7 @@ def use_offDiag_pivot(A, B, M, cutoffs, params, d, arr0, arr2, arr1010, arr1001,
 
 
 @njit
-def use_diag_pivot(A, B, M, cutoffs, params, arr0, arr1):
+def use_diag_pivot(A, B, M, cutoffs, params, arr0, arr1):  # pragma: no cover
     """
     Apply recurrence relation for pivot of type [a,a,b,b,c,c...]
     Args:
@@ -132,7 +132,7 @@ def use_diag_pivot(A, B, M, cutoffs, params, arr0, arr1):
 @njit
 def fock_representation_diagonal_amps_NUMBA(
     A, B, M, cutoffs, arr0, arr2, arr1010, arr1001, arr1, tuple_type, list_type
-):
+):  # pragma: no cover
     """
     Returns the PNR probabilities of a mixed state according to algorithm 1 of:
     https://doi.org/10.22331/q-2023-08-29-1097

--- a/mrmustard/math/lattice/strategies/compactFock/diagonal_amps.py
+++ b/mrmustard/math/lattice/strategies/compactFock/diagonal_amps.py
@@ -15,7 +15,9 @@ from mrmustard.math.lattice.strategies.compactFock.helperFunctions import (
 
 
 @njit
-def use_offDiag_pivot(A, B, M, cutoffs, params, d, arr0, arr2, arr1010, arr1001, arr1):  # pragma: no cover
+def use_offDiag_pivot(
+    A, B, M, cutoffs, params, d, arr0, arr2, arr1010, arr1001, arr1
+):  # pragma: no cover
     """
     Apply recurrence relation for pivot of type [a+1,a,b,b,c,c,...] / [a,a,b+1,b,c,c,...] / [a,a,b,b,c+1,c,...]
     Args:

--- a/mrmustard/math/lattice/strategies/compactFock/inputValidation.py
+++ b/mrmustard/math/lattice/strategies/compactFock/inputValidation.py
@@ -85,3 +85,22 @@ def grad_hermite_multidimensional_1leftoverMode(A, B, G0, arr0, arr2, arr1010, a
     )
     arr0_dG0 = np.array(arr0 / G0).astype(np.complex128)
     return arr0_dG0, arr0_dA, arr0_dB
+
+
+def hermite_multidimensional_diagonal_batch(A, B, G0, cutoffs, rtol=1e-05, atol=1e-08):
+    """
+    Validation of user input for mrmustard.math.backend_tensorflow.hermite_renormalized_diagonal_batch
+    """
+    input_validation(A, atol=atol, rtol=rtol)
+    if len(B.shape) != 2:
+        raise ValueError("B should be two dimensional (vector and batch dimension)")
+    if A.shape[0] != B.shape[0]:
+        raise ValueError("The matrix A and vector B have incompatible dimensions")
+    if isinstance(cutoffs, Iterable):
+        cutoffs = tuple(cutoffs)
+    else:
+        raise ValueError("cutoffs should be array like of length M")
+    M = len(cutoffs)
+    if A.shape[0] // 2 != M:
+        raise ValueError("The matrix A and cutoffs have incompatible dimensions")
+    return fock_representation_diagonal_amps(A, B, G0, M, cutoffs)

--- a/mrmustard/math/lattice/strategies/vanilla.py
+++ b/mrmustard/math/lattice/strategies/vanilla.py
@@ -72,7 +72,7 @@ def vanilla_batch(shape: tuple[int, ...], A, b, c) -> ComplexTensor:  # pragma: 
     G = np.zeros(shape, dtype=np.complex128)
 
     # initialize path iterator
-    path = np.ndindex(shape[:-1]) # We know the last dimension is the batch one
+    path = np.ndindex(shape[:-1])  # We know the last dimension is the batch one
 
     # write vacuum amplitude
     G[next(path)] = c
@@ -80,7 +80,7 @@ def vanilla_batch(shape: tuple[int, ...], A, b, c) -> ComplexTensor:  # pragma: 
     # iterate over the rest of the indices
     for index in path:
         G[index] = steps.vanilla_step_batch(G, A, b, index)
-    
+
     return G
 
 

--- a/mrmustard/math/lattice/strategies/vanilla.py
+++ b/mrmustard/math/lattice/strategies/vanilla.py
@@ -72,14 +72,14 @@ def vanilla_batch(shape: tuple[int, ...], A, b, c) -> ComplexTensor:  # pragma: 
     G = np.zeros(shape, dtype=np.complex128)
 
     # initialize path iterator
-    path = np.ndindex(shape[1:]) # We know the fist dimension is the batch one
+    path = np.ndindex(shape[:-1]) # We know the last dimension is the batch one
 
     # write vacuum amplitude
-    G[(...,*next(path))] = c
+    G[next(path)] = c
 
     # iterate over the rest of the indices
     for index in path:
-        G[(...,*index)] = steps.vanilla_step_batch(G, A, b, index)
+        G[index] = steps.vanilla_step_batch(G, A, b, index)
     
     return G
 

--- a/mrmustard/math/lattice/strategies/vanilla.py
+++ b/mrmustard/math/lattice/strategies/vanilla.py
@@ -55,13 +55,15 @@ def vanilla(shape: tuple[int, ...], A, b, c) -> ComplexTensor:  # pragma: no cov
 
 @njit
 def vanilla_batch(shape: tuple[int, ...], A, b, c) -> ComplexTensor:  # pragma: no cover
-    r"""Vanilla Fock-Bargmann strategy. Fills the tensor by iterating over all indices
+    r"""Vanilla batched Fock-Bargmann strategy. Fills the tensor by iterating over all indices
     in ndindex order.
+    Note that this function is different from vanilla with b is no longer a vector,
+    it becomes a bathced vector with the batch dimension on the last index.
 
     Args:
-        shape (tuple[int, ...]): shape of the output tensor
+        shape (tuple[int, ...]): shape of the output tensor with the batch dimension on the last term
         A (np.ndarray): A matrix of the Fock-Bargmann representation
-        b (np.ndarray): B vector of the Fock-Bargmann representation
+        b (np.ndarray): batched B vector of the Fock-Bargmann representation, the batch dimension is on the last index
         c (complex): vacuum amplitude
 
     Returns:

--- a/mrmustard/math/lattice/strategies/vanilla.py
+++ b/mrmustard/math/lattice/strategies/vanilla.py
@@ -20,7 +20,7 @@ from mrmustard.utils.typing import ComplexMatrix, ComplexTensor, ComplexVector
 
 SQRT = np.sqrt(np.arange(100000))
 
-__all__ = ["vanilla", "vanilla_jacobian", "vanilla_vjp"]
+__all__ = ["vanilla", "vanilla_batch", "vanilla_jacobian", "vanilla_vjp"]
 
 
 @njit
@@ -50,6 +50,37 @@ def vanilla(shape: tuple[int, ...], A, b, c) -> ComplexTensor:  # pragma: no cov
     # iterate over the rest of the indices
     for index in path:
         G[index] = steps.vanilla_step(G, A, b, index)
+    return G
+
+
+@njit
+def vanilla_batch(shape: tuple[int, ...], A, b, c) -> ComplexTensor:  # pragma: no cover
+    r"""Vanilla Fock-Bargmann strategy. Fills the tensor by iterating over all indices
+    in ndindex order.
+
+    Args:
+        shape (tuple[int, ...]): shape of the output tensor
+        A (np.ndarray): A matrix of the Fock-Bargmann representation
+        b (np.ndarray): B vector of the Fock-Bargmann representation
+        c (complex): vacuum amplitude
+
+    Returns:
+        np.ndarray: Fock representation of the Gaussian tensor with shape ``shape``
+    """
+
+    # init output tensor
+    G = np.zeros(shape, dtype=np.complex128)
+
+    # initialize path iterator
+    path = np.ndindex(shape[1:]) # We know the fist dimension is the batch one
+
+    # write vacuum amplitude
+    G[(...,*next(path))] = c
+
+    # iterate over the rest of the indices
+    for index in path:
+        G[(...,*index)] = steps.vanilla_step_batch(G, A, b, index)
+    
     return G
 
 

--- a/tests/test_math/test_lattice.py
+++ b/tests/test_math/test_lattice.py
@@ -74,7 +74,7 @@ def test_vanillabatchNumba_vs_vanillaNumba():
     )  # Create random state (M mode Gaussian state with displacement)
 
     batch = 3
-    cutoffs = (60, 60, 60, 60, batch)
+    cutoffs = (20, 20, 20, 20, batch)
 
     # Vanilla MM
     G_ref = math.hermite_renormalized(A, B, C, shape=cutoffs[:-1])

--- a/tests/test_math/test_lattice.py
+++ b/tests/test_math/test_lattice.py
@@ -77,14 +77,14 @@ def test_vanillabatchNumba_vs_vanillaNumba():
 
     # Vanilla MM
     G_ref = math.hermite_renormalized(
-        A, B, C, shape=cutoffs
+        A, B, C, shape=cutoffs[:-1]
     )
 
     # replicate the B
-    B_batched = np.tile(B, (len(B),1))
-    
+    B_batched = np.stack((B,)*batch,axis=1)
+
     G_batched = math.hermite_renormalized_batch(A, B_batched, C, shape=cutoffs)
 
-    assert np.allclose(G_ref, G_batched[0])
-    assert np.allclose(G_ref, G_batched[1])
-    assert np.allclose(G_ref, G_batched[2])
+    assert np.allclose(G_ref, G_batched[:,:,:,:,0])
+    assert np.allclose(G_ref, G_batched[:,:,:,:,1])
+    assert np.allclose(G_ref, G_batched[:,:,:,:,2])

--- a/tests/test_math/test_lattice.py
+++ b/tests/test_math/test_lattice.py
@@ -66,25 +66,24 @@ def test_binomial_vs_binomialDict():
         assert np.isclose(D[idx], G[idx])
 
 
-
 def test_vanillabatchNumba_vs_vanillaNumba():
     """Test the batch version works versus the normal vanilla version."""
     state = Gaussian(3)
-    A, B, C = wigner_to_bargmann_rho(state.cov, state.means)  # Create random state (M mode Gaussian state with displacement)
+    A, B, C = wigner_to_bargmann_rho(
+        state.cov, state.means
+    )  # Create random state (M mode Gaussian state with displacement)
 
     batch = 3
-    cutoffs = (60,60,60,60,batch)
+    cutoffs = (60, 60, 60, 60, batch)
 
     # Vanilla MM
-    G_ref = math.hermite_renormalized(
-        A, B, C, shape=cutoffs[:-1]
-    )
+    G_ref = math.hermite_renormalized(A, B, C, shape=cutoffs[:-1])
 
     # replicate the B
-    B_batched = np.stack((B,)*batch,axis=1)
+    B_batched = np.stack((B,) * batch, axis=1)
 
     G_batched = math.hermite_renormalized_batch(A, B_batched, C, shape=cutoffs)
 
-    assert np.allclose(G_ref, G_batched[:,:,:,:,0])
-    assert np.allclose(G_ref, G_batched[:,:,:,:,1])
-    assert np.allclose(G_ref, G_batched[:,:,:,:,2])
+    assert np.allclose(G_ref, G_batched[:, :, :, :, 0])
+    assert np.allclose(G_ref, G_batched[:, :, :, :, 1])
+    assert np.allclose(G_ref, G_batched[:, :, :, :, 2])

--- a/tests/test_math/test_lattice.py
+++ b/tests/test_math/test_lattice.py
@@ -87,3 +87,26 @@ def test_vanillabatchNumba_vs_vanillaNumba():
     assert np.allclose(G_ref, G_batched[:, :, :, :, 0])
     assert np.allclose(G_ref, G_batched[:, :, :, :, 1])
     assert np.allclose(G_ref, G_batched[:, :, :, :, 2])
+
+
+def test_diagonalbatchNumba_vs_diagonalNumba():
+    """Test the batch version works versus the normal diagonal version."""
+    state = Gaussian(3)
+    A, B, C = wigner_to_bargmann_rho(
+        state.cov, state.means
+    )  # Create random state (M mode Gaussian state with displacement)
+
+    batch = 3
+    cutoffs = (18, 19, 20, batch)
+
+    # Diagonal MM
+    G_ref = math.hermite_renormalized_diagonal(A, B, C, cutoffs=cutoffs[:-1])
+
+    # replicate the B
+    B_batched = np.stack((B,) * batch, axis=1)
+
+    G_batched = math.hermite_renormalized_diagonal_batch(A, B_batched, C, cutoffs=cutoffs[:-1])
+
+    assert np.allclose(G_ref, G_batched[:, :, :, 0])
+    assert np.allclose(G_ref, G_batched[:, :, :, 1])
+    assert np.allclose(G_ref, G_batched[:, :, :, 2])

--- a/tests/test_math/test_lattice.py
+++ b/tests/test_math/test_lattice.py
@@ -19,7 +19,7 @@ import pytest
 import numpy as np
 
 from mrmustard.lab import Gaussian
-from mrmustard import settings
+from mrmustard import settings, math
 from mrmustard.physics.bargmann import wigner_to_bargmann_rho
 from mrmustard.math.lattice.strategies.binomial import binomial, binomial_dict
 


### PR DESCRIPTION
**Context:** Add multiple functions to make recursive functions work with batch dimension.

**Description of the Change:** We add batch with hermite_renormalized vanilla version and hermite_renormalized_diagonal version in Numba.

**Benefits:** Gain speed when we have a batch in b of the triple(A,b,c).

**Possible Drawbacks:**

**Related GitHub Issues:**
