### PR TITLE
Simplifying tests for compact fock file

### DIFF
--- a/tests/test_math/test_compactFock.py
+++ b/tests/test_math/test_compactFock.py
@@ -42,7 +42,9 @@ def random_ABC(draw, M):
 @given(random_ABC(M=3))
 @pytest.mark.parametrize("precision", precisions)
 def test_compactFock_diagonal(precision, A_B_G0):
-    """Test getting Fock amplitudes if all modes are detected (math.hermite_renormalized_diagonal)"""
+    r"""Test getting Fock amplitudes if all modes are
+    detected (math.hermite_renormalized_diagonal)
+    """
     settings.PRECISION_BITS_HERMITE_POLY = precision
     cutoffs = (7, 7, 7)
 
@@ -72,7 +74,10 @@ def test_compactFock_diagonal(precision, A_B_G0):
 @given(random_ABC(M=3))
 @pytest.mark.parametrize("precision", precisions)
 def test_compactFock_1leftover(precision, A_B_G0):
-    """Test getting Fock amplitudes if all but the first mode are detected (math.hermite_renormalized_1leftoverMode)"""
+    r"""
+    Test getting Fock amplitudes if all but the first mode
+    are detected (math.hermite_renormalized_1leftoverMode).
+    """
     skip_np()
 
     settings.PRECISION_BITS_HERMITE_POLY = precision
@@ -104,20 +109,23 @@ def test_compactFock_1leftover(precision, A_B_G0):
 
 @pytest.mark.parametrize("precision", precisions)
 def test_compactFock_diagonal_gradients(precision):
-    """Test getting Fock amplitudes AND GRADIENTS if all modes are detected (math.hermite_renormalized_diagonal)"""
+    r"""
+    Test getting Fock amplitudes and gradients if all modes
+    are detected (math.hermite_renormalized_diagonal).
+    """
     skip_np()
 
     settings.PRECISION_BITS_HERMITE_POLY = precision
-    G = Ggate(num_modes=3, symplectic_trainable=True)
+    G = Ggate(num_modes=2, symplectic_trainable=True)
 
     def cost_fn():
-        n1, n2, n3 = 2, 2, 4  # number of detected photons
-        state_opt = Vacuum(3) >> G
+        n1, n2 = 2, 4  # number of detected photons
+        state_opt = Vacuum(2) >> G
         A, B, G0 = wigner_to_bargmann_rho(state_opt.cov, state_opt.means)
         probs = math.hermite_renormalized_diagonal(
-            math.conj(-A), math.conj(B), math.conj(G0), cutoffs=[n1 + 1, n2 + 1, n3 + 1]
+            math.conj(-A), math.conj(B), math.conj(G0), cutoffs=[n1 + 1, n2 + 1]
         )
-        p = probs[n1, n2, n3]
+        p = probs[n1, n2]
         return -math.real(p)
 
     opt = Optimizer(symplectic_lr=0.5)
@@ -130,20 +138,23 @@ def test_compactFock_diagonal_gradients(precision):
 
 @pytest.mark.parametrize("precision", precisions)
 def test_compactFock_1leftover_gradients(precision):
-    """Test getting Fock amplitudes AND GRADIENTS if all but the first mode are detected (math.hermite_renormalized_1leftoverMode)"""
+    r"""
+    Test getting Fock amplitudes and if all but the first
+    mode are detected (math.hermite_renormalized_1leftoverMode).
+    """
     skip_np()
 
     settings.PRECISION_BITS_HERMITE_POLY = precision
-    G = Ggate(num_modes=3, symplectic_trainable=True)
+    G = Ggate(num_modes=2, symplectic_trainable=True)
 
     def cost_fn():
-        n2, n3 = 1, 3  # number of detected photons
-        state_opt = Vacuum(3) >> G
+        n2 = 3  # number of detected photons
+        state_opt = Vacuum(2) >> G
         A, B, G0 = wigner_to_bargmann_rho(state_opt.cov, state_opt.means)
         marginal = math.hermite_renormalized_1leftoverMode(
-            math.conj(-A), math.conj(B), math.conj(G0), cutoffs=[8, n2 + 1, n3 + 1]
+            math.conj(-A), math.conj(B), math.conj(G0), cutoffs=[8, n2 + 1]
         )
-        conditional_state = normalize(State(dm=marginal[..., n2, n3]))
+        conditional_state = normalize(State(dm=marginal[..., n2]))
         return -fidelity(conditional_state, SqueezedVacuum(r=1))
 
     opt = Optimizer(symplectic_lr=0.1)

--- a/tests/test_math/test_compactFock.py
+++ b/tests/test_math/test_compactFock.py
@@ -46,7 +46,7 @@ def test_compactFock_diagonal(precision, A_B_G0):
     detected (math.hermite_renormalized_diagonal)
     """
     settings.PRECISION_BITS_HERMITE_POLY = precision
-    cutoffs = (7, 7, 7)
+    cutoffs = (5, 5, 5)
 
     A, B, G0 = A_B_G0  # Create random state (M mode Gaussian state with displacement)
 
@@ -81,7 +81,7 @@ def test_compactFock_1leftover(precision, A_B_G0):
     skip_np()
 
     settings.PRECISION_BITS_HERMITE_POLY = precision
-    cutoffs = (7, 7, 7)
+    cutoffs = (5, 5, 5)
 
     A, B, G0 = A_B_G0  # Create random state (M mode Gaussian state with displacement)
 

--- a/tests/test_math/test_compactFock.py
+++ b/tests/test_math/test_compactFock.py
@@ -63,9 +63,7 @@ def test_compactFock_diagonal(precision, A_B_G0):
         ref_diag[inds] = G_ref[tuple(inds_expanded)]
 
     # New MM
-    G_diag = math.hermite_renormalized_diagonal(
-        math.conj(-A), math.conj(B), math.conj(G0), cutoffs
-    )
+    G_diag = math.hermite_renormalized_diagonal(math.conj(-A), math.conj(B), math.conj(G0), cutoffs)
     assert np.allclose(ref_diag, G_diag)
 
     settings.PRECISION_BITS_HERMITE_POLY = original_precision


### PR DESCRIPTION
**Context:**
The tests in `tests/test_math/test_compactFock.py` take a long time to run (over 5mins with the tensorflow backend) and are very intensive in terms of memory. They often crash on GitHub, making our entire workflow unstable.

**Description of the Change:**
This PR simplifies `tests/test_math/test_compactFock.py` so that the tests in it are less intensive in time (1min50s) and memory, but still test all that they were originally testing.