### PR TITLE
generaldyne pdf

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -65,6 +65,10 @@ which uses the old Numba code. When setting to a higher value, the new Julia cod
 * Changed the ``cast`` functions in the numpy and tensorflow backends to avoid ``ComplexWarning``s.
   [(#307)](https://github.com/XanaduAI/MrMustard/pull/307)
 
+* `mrmustard.physics.gaussian.general_dyne()` now returns also the pdf of the measurement outcome. This is useful for
+  further processing (e.g. entropy of the pdf, mean, sampling) and for inclusion in cost functions.
+  [(#317)](https://github.com/XanaduAI/MrMustard/pull/317)
+
 
 ### Bug fixes
 

--- a/mrmustard/lab/abstract/measurement.py
+++ b/mrmustard/lab/abstract/measurement.py
@@ -23,6 +23,7 @@ from mrmustard import math, settings
 from mrmustard.math.parameter_set import ParameterSet
 from mrmustard.math.parameters import Constant, Variable
 from mrmustard.utils.typing import Tensor
+
 from .state import State
 
 

--- a/mrmustard/lab/abstract/state.py
+++ b/mrmustard/lab/abstract/state.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import warnings
 from typing import (
     TYPE_CHECKING,
     Iterable,
@@ -25,14 +26,15 @@ from typing import (
     Tuple,
     Union,
 )
-import warnings
-import numpy as np
+
 import matplotlib.pyplot as plt
+import numpy as np
 from matplotlib import cm
 
 from mrmustard import math, settings
 from mrmustard.math.parameters import Constant, Variable
 from mrmustard.physics import bargmann, fock, gaussian
+from mrmustard.physics.wigner import wigner_discretized
 from mrmustard.utils.typing import (
     ComplexMatrix,
     ComplexTensor,
@@ -41,8 +43,6 @@ from mrmustard.utils.typing import (
     RealTensor,
     RealVector,
 )
-from mrmustard.physics.wigner import wigner_discretized
-
 
 if TYPE_CHECKING:
     from .transformation import Transformation
@@ -476,7 +476,7 @@ class State:  # pylint: disable=too-many-public-methods
         # being projected onto the measurement state
         remaining_modes = list(set(other.modes) - set(self.modes))
 
-        _, probability, new_cov, new_means = gaussian.general_dyne(
+        _, probability, new_cov, new_means, _ = gaussian.general_dyne(
             other.cov,
             other.means,
             self.cov,

--- a/mrmustard/lab/detectors.py
+++ b/mrmustard/lab/detectors.py
@@ -270,7 +270,7 @@ class Generaldyne(Measurement):
     def _measure_gaussian(self, other) -> Union[State, float]:
         remaining_modes = list(set(other.modes) - set(self.modes))
 
-        outcome, prob, new_cov, new_means, pdf = gaussian.general_dyne(
+        outcome, prob, new_cov, new_means, _ = gaussian.general_dyne(
             other.cov, other.means, self.state.cov, None, modes=self.modes
         )
         self.state = State(cov=self.state.cov, means=outcome)

--- a/mrmustard/lab/detectors.py
+++ b/mrmustard/lab/detectors.py
@@ -18,11 +18,10 @@ This module implements the set of detector classes that perform measurements on 
 
 from typing import Iterable, List, Optional, Tuple, Union
 
-from mrmustard import settings
+from mrmustard import math, settings
 from mrmustard.physics import fock, gaussian
 from mrmustard.utils.typing import RealMatrix, RealVector
 
-from mrmustard import math
 from .abstract import FockMeasurement, Measurement, State
 from .gates import Rgate
 from .states import Coherent, DisplacedSqueezed
@@ -271,7 +270,7 @@ class Generaldyne(Measurement):
     def _measure_gaussian(self, other) -> Union[State, float]:
         remaining_modes = list(set(other.modes) - set(self.modes))
 
-        outcome, prob, new_cov, new_means = gaussian.general_dyne(
+        outcome, prob, new_cov, new_means, pdf = gaussian.general_dyne(
             other.cov, other.means, self.state.cov, None, modes=self.modes
         )
         self.state = State(cov=self.state.cov, means=outcome)

--- a/mrmustard/physics/gaussian.py
+++ b/mrmustard/physics/gaussian.py
@@ -595,7 +595,7 @@ def general_dyne(
     # calculate conditional output state of unmeasured modes
     num_remaining_modes = N - M
     if num_remaining_modes == 0:
-        return outcome, prob, None, None
+        return outcome, prob, None, None, pdf
 
     AB_inv = math.matmul(AB, math.inv(reduced_cov))
     new_cov = A - math.matmul(AB_inv, math.transpose(AB))


### PR DESCRIPTION
`physics.gaussian.general_dyne()` now returns the pdf for further use (e.g. sampling)