### PR TITLE
Speeding up `vanilla_vjp`

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -53,10 +53,10 @@ which uses the old Numba code. When setting to a higher value, the new Julia cod
   [(#303)](https://github.com/XanaduAI/MrMustard/pull/303)
   [(#304)](https://github.com/XanaduAI/MrMustard/pull/304)
 
-* Improves the algorithm implemented in `vanilla` to achieve a speedup. Specifically, the improved
-  algorithm works on a flattened array (which is reshaped before returning) as opposed to a
-  multi-dimensional array.
+* Improves the algorithms implemented in `vanilla` and `vanilla_vjp` to achieve a speedup.
+  Specifically, the improved algorithms work on flattened arrays (which are reshaped before being returned) as opposed to multi-dimensional array.
   [(#312)](https://github.com/XanaduAI/MrMustard/pull/312)
+  [(#318)](https://github.com/XanaduAI/MrMustard/pull/318)
 
 * Adds functions `hermite_renormalized_batch` and `hermite_renormalized_diagonal_batch` to speed up calculating 
   Hermite polynomials over a batch of B vectors.

--- a/mrmustard/math/lattice/strategies/vanilla.py
+++ b/mrmustard/math/lattice/strategies/vanilla.py
@@ -151,7 +151,6 @@ def vanilla_vjp(G, c, dLdG) -> tuple[ComplexMatrix, ComplexVector, complex]:  # 
 
     # calculate the strides
     strides = shape_to_strides(np.array(shape))
-    print(shape, strides)
 
     # linearize G
     G_lin = G.flatten()
@@ -187,42 +186,6 @@ def vanilla_vjp(G, c, dLdG) -> tuple[ComplexMatrix, ComplexVector, complex]:  # 
         dLdb += db * dLdG[index_u]
 
     dLdc = np.sum(G_lin.reshape(shape) * dLdG) / c
-
-    return dLdA, dLdb, dLdc
-
-@njit
-def vanilla_vjp2(G, c, dLdG) -> tuple[ComplexMatrix, ComplexVector, complex]:  # pragma: no cover
-    r"""Vanilla Fock-Bargmann strategy gradient. Returns dL/dA, dL/db, dL/dc.
-
-    Args:
-        G (np.ndarray): Tensor result of the forward pass
-        c (complex): vacuum amplitude
-        dLdG (np.ndarray): gradient of the loss with respect to the output tensor
-
-    Returns:
-        tuple[np.ndarray, np.ndarray, complex]: dL/dA, dL/db, dL/dc
-    """
-    D = G.ndim
-
-    # init gradients
-    dA = np.zeros((D, D), dtype=np.complex128)  # component of dL/dA
-    db = np.zeros(D, dtype=np.complex128)  # component of dL/db
-    dLdA = np.zeros_like(dA)
-    dLdb = np.zeros_like(db)
-
-    # initialize path iterator
-    path = np.ndindex(G.shape)
-
-    # skip first index
-    next(path)
-
-    # iterate over the rest of the indices
-    for index in path:
-        dA, db = steps.vanilla_step_grad(G, index, dA, db)
-        dLdA += dA * dLdG[index]
-        dLdb += db * dLdG[index]
-
-    dLdc = np.sum(G * dLdG) / c
 
     return dLdA, dLdb, dLdc
 

--- a/mrmustard/math/lattice/strategies/vanilla.py
+++ b/mrmustard/math/lattice/strategies/vanilla.py
@@ -151,9 +151,10 @@ def vanilla_vjp(G, c, dLdG) -> tuple[ComplexMatrix, ComplexVector, complex]:  # 
 
     # calculate the strides
     strides = shape_to_strides(np.array(shape))
+    print(shape, strides)
 
     # linearize G
-    G_lin = G.reshape((np.prod(np.array(shape)),))
+    G_lin = G.flatten()
 
     # init gradients
     D = G.ndim
@@ -180,7 +181,7 @@ def vanilla_vjp(G, c, dLdG) -> tuple[ComplexMatrix, ComplexVector, complex]:  # 
             db[i] = np.sqrt(index_u[i]) * G_lin[n]
             dA[i, i] = 0.5 * np.sqrt(index_u[i] * (index_u[i] - 1)) * G_lin[n-strides[i]]
             for j in range(i + 1, len(db)):
-                dA[i, j] = np.sqrt(index_u[i] * (index_u[i] - 1)) * G_lin[n-strides[j]]
+                dA[i, j] = np.sqrt(index_u[i] * index_u[j]) * G_lin[n-strides[j]]
         
         dLdA += dA * dLdG[index_u]
         dLdb += db * dLdG[index_u]

--- a/mrmustard/math/lattice/strategies/vanilla.py
+++ b/mrmustard/math/lattice/strategies/vanilla.py
@@ -174,14 +174,54 @@ def vanilla_vjp(G, c, dLdG) -> tuple[ComplexMatrix, ComplexVector, complex]:  # 
         index += 1
 
         ns = lower_neighbors(index, strides, 0)
-        # (i0, n0) = next(ns)
 
-        for (i, n) in ns:  # pylint: disable=consider-using-enumerate
+        for i in range(len(db)):
+            _, n = next(ns)
             db[i] = np.sqrt(index_u[i]) * G_lin[n]
-            dA[i, i] = 0.5 * np.sqrt(index_u[i] * n[i]) * G_lin[n-strides[i]]
-            for j in range(i + 1, len(strides)):
-                dA[i, j] = np.sqrt(index_u[i] * n[j]) * G_lin[n-strides[j]]
+            dA[i, i] = 0.5 * np.sqrt(index_u[i] * (index_u[i] - 1)) * G_lin[n-strides[i]]
+            for j in range(i + 1, len(db)):
+                dA[i, j] = np.sqrt(index_u[i] * (index_u[i] - 1)) * G_lin[n-strides[j]]
+        
+        dLdA += dA * dLdG[index_u]
+        dLdb += db * dLdG[index_u]
 
     dLdc = np.sum(G_lin.reshape(shape) * dLdG) / c
 
     return dLdA, dLdb, dLdc
+
+@njit
+def vanilla_vjp2(G, c, dLdG) -> tuple[ComplexMatrix, ComplexVector, complex]:  # pragma: no cover
+    r"""Vanilla Fock-Bargmann strategy gradient. Returns dL/dA, dL/db, dL/dc.
+
+    Args:
+        G (np.ndarray): Tensor result of the forward pass
+        c (complex): vacuum amplitude
+        dLdG (np.ndarray): gradient of the loss with respect to the output tensor
+
+    Returns:
+        tuple[np.ndarray, np.ndarray, complex]: dL/dA, dL/db, dL/dc
+    """
+    D = G.ndim
+
+    # init gradients
+    dA = np.zeros((D, D), dtype=np.complex128)  # component of dL/dA
+    db = np.zeros(D, dtype=np.complex128)  # component of dL/db
+    dLdA = np.zeros_like(dA)
+    dLdb = np.zeros_like(db)
+
+    # initialize path iterator
+    path = np.ndindex(G.shape)
+
+    # skip first index
+    next(path)
+
+    # iterate over the rest of the indices
+    for index in path:
+        dA, db = steps.vanilla_step_grad(G, index, dA, db)
+        dLdA += dA * dLdG[index]
+        dLdb += db * dLdG[index]
+
+    dLdc = np.sum(G * dLdG) / c
+
+    return dLdA, dLdb, dLdc
+

--- a/mrmustard/math/lattice/strategies/vanilla.py
+++ b/mrmustard/math/lattice/strategies/vanilla.py
@@ -162,7 +162,7 @@ def vanilla_vjp(G, c, dLdG) -> tuple[ComplexMatrix, ComplexVector, complex]:  # 
     dLdA = np.zeros_like(dA)
     dLdb = np.zeros_like(db)
 
-    # initialize the indeces.
+    # initialize the indices.
     # ``index`` is the index of the flattened output tensor, while
     # ``index_u_iter`` iterates through the unravelled counterparts of
     # ``index``.

--- a/mrmustard/math/lattice/strategies/vanilla.py
+++ b/mrmustard/math/lattice/strategies/vanilla.py
@@ -174,22 +174,14 @@ def vanilla_vjp(G, c, dLdG) -> tuple[ComplexMatrix, ComplexVector, complex]:  # 
         index += 1
 
         ns = lower_neighbors(index, strides, 0)
-        (j0, n0) = next(ns)
+        # (i0, n0) = next(ns)
 
-        for (j, n) in ns:  # pylint: disable=consider-using-enumerate
-            db[j] = np.sqrt[index_u[j]] * G[n]
-            dA[j, j] = 0.5 * np.sqrt[index_u[i] * n[j]] * G[tuple_setitem(pivot_i, i, pivot_i[i] - 1)]
-            for j in range(i + 1, len(db)):
-                dA[i, j] = np.sqrt[index[i] * pivot_i[j]] * G[tuple_setitem(pivot_i, j, pivot_i[j] - 1)]
+        for (i, n) in ns:  # pylint: disable=consider-using-enumerate
+            db[i] = np.sqrt(index_u[i]) * G_lin[n]
+            dA[i, i] = 0.5 * np.sqrt(index_u[i] * n[i]) * G_lin[n-strides[i]]
+            for j in range(i + 1, len(strides)):
+                dA[i, j] = np.sqrt(index_u[i] * n[j]) * G_lin[n-strides[j]]
 
-    return dA, db
-
-    # iterate over the rest of the indices
-    for index in path:
-        dA, db = steps.vanilla_step_grad(G, index, dA, db)
-        dLdA += dA * dLdG[index]
-        dLdb += db * dLdG[index]
-
-    dLdc = np.sum(G * dLdG) / c
+    dLdc = np.sum(G_lin.reshape(shape) * dLdG) / c
 
     return dLdA, dLdb, dLdc

--- a/mrmustard/math/lattice/strategies/vanilla.py
+++ b/mrmustard/math/lattice/strategies/vanilla.py
@@ -175,17 +175,16 @@ def vanilla_vjp(G, c, dLdG) -> tuple[ComplexMatrix, ComplexVector, complex]:  # 
 
         ns = lower_neighbors(index, strides, 0)
 
-        for i in range(len(db)):
+        for i, _ in enumerate(db):
             _, n = next(ns)
             db[i] = np.sqrt(index_u[i]) * G_lin[n]
-            dA[i, i] = 0.5 * np.sqrt(index_u[i] * (index_u[i] - 1)) * G_lin[n-strides[i]]
+            dA[i, i] = 0.5 * np.sqrt(index_u[i] * (index_u[i] - 1)) * G_lin[n - strides[i]]
             for j in range(i + 1, len(db)):
-                dA[i, j] = np.sqrt(index_u[i] * index_u[j]) * G_lin[n-strides[j]]
-        
+                dA[i, j] = np.sqrt(index_u[i] * index_u[j]) * G_lin[n - strides[j]]
+
         dLdA += dA * dLdG[index_u]
         dLdb += db * dLdG[index_u]
 
     dLdc = np.sum(G_lin.reshape(shape) * dLdG) / c
 
     return dLdA, dLdb, dLdc
-


### PR DESCRIPTION
**Description of the Change:**
Same change as for `vanilla()`: The returned nD tensor is flattened, manipulated as a 1D tensor, and finally reshaped
