### PR TITLE
Changing ordering convention of `ids` in wires

### DIFF
--- a/mrmustard/lab/circuit_drawer.py
+++ b/mrmustard/lab/circuit_drawer.py
@@ -61,8 +61,7 @@ def _add_op(op, layer_str, decimals):
     control = []
     if op.__class__.__qualname__ in ["BSgate", "MZgate", "CZgate", "CXgate"]:
         control = [op.modes[0]]
-    # label = op.short_name
-    label = op.__class__.__qualname__
+    label = op.short_name
     if decimals is not None:
         param_string = op.parameter_set.to_string(decimals)
         if param_string == "":


### PR DESCRIPTION
**Context:**
So that it matches the indices convention of representation

**Description of the Change:**
`wires.ids` returns:
`[out_bra(0), ... out_bra(N), in_bra(0), ..., in_bra(N), ...]`
With this change, it will return:
`[out_bra(m), in_bra(m), out_ket(m), in_ket(m)] for m in modes`