### PR TITLE
Removing TF warnings on import with `os` instead of `logging`

### DIFF
--- a/mrmustard/math/backend_tensorflow.py
+++ b/mrmustard/math/backend_tensorflow.py
@@ -18,14 +18,14 @@
 
 from typing import Callable, List, Optional, Sequence, Tuple, Union
 
-import logging
 import numpy as np
-
-logging.getLogger("tensorflow").setLevel(logging.ERROR)
-import tensorflow as tf
+import os
 import tensorflow_probability as tfp
 
-logging.getLogger("tensorflow").setLevel(logging.INFO)
+os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
+import tensorflow as tf
+
+os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"
 
 
 from mrmustard.math.lattice.strategies.compactFock.inputValidation import (

--- a/mrmustard/math/backend_tensorflow.py
+++ b/mrmustard/math/backend_tensorflow.py
@@ -18,8 +18,8 @@
 
 from typing import Callable, List, Optional, Sequence, Tuple, Union
 
-import numpy as np
 import os
+import numpy as np
 import tensorflow_probability as tfp
 
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"

--- a/mrmustard/training/callbacks.py
+++ b/mrmustard/training/callbacks.py
@@ -76,13 +76,13 @@ import hashlib
 from pathlib import Path
 from typing import Callable, Optional, Mapping, Sequence, Union
 
-import logging
 import numpy as np
+import os
 
-logging.getLogger("tensorflow").setLevel(logging.ERROR)
+os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
 import tensorflow as tf
 
-logging.getLogger("tensorflow").setLevel(logging.INFO)
+os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"
 
 
 @dataclass

--- a/mrmustard/training/callbacks.py
+++ b/mrmustard/training/callbacks.py
@@ -76,8 +76,8 @@ import hashlib
 from pathlib import Path
 from typing import Callable, Optional, Mapping, Sequence, Union
 
-import numpy as np
 import os
+import numpy as np
 
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
 import tensorflow as tf


### PR DESCRIPTION
**Context:**
The previous solution based on `logging` does not appear to work on every OS
