### PR TITLE
Fix `math.Categorical`

### DIFF
--- a/mrmustard/math/backend_manager.py
+++ b/mrmustard/math/backend_manager.py
@@ -1187,9 +1187,8 @@ class BackendManager:  # pylint: disable=too-many-public-methods, fixme
         """Categorical distribution over integers.
 
         Args:
-            probs (Tensor): tensor representing the probabilities of a set of Categorical
-                distributions.
-            name (str): name prefixed to operations created by this class
+            probs: The unnormalized probabilities of a set of Categorical distributions.
+            name: The name prefixed to operations created by this class.
 
         Returns:
             tfp.distributions.Categorical: instance of ``tfp.distributions.Categorical`` class

--- a/mrmustard/math/backend_numpy.py
+++ b/mrmustard/math/backend_numpy.py
@@ -367,7 +367,7 @@ class BackendNumpy(BackendBase):  # pragma: no cover
                 self._probs = probs
 
             def sample(self):
-                array = np.random.multinomial(1, pvals=probs)
+                array = np.random.multinomial(1, pvals=probs/sum(probs))
                 return np.where(array == 1)[0][0]
 
         return Generator(probs)

--- a/mrmustard/math/backend_numpy.py
+++ b/mrmustard/math/backend_numpy.py
@@ -367,7 +367,7 @@ class BackendNumpy(BackendBase):  # pragma: no cover
                 self._probs = probs
 
             def sample(self):
-                array = np.random.multinomial(1, pvals=probs/sum(probs))
+                array = np.random.multinomial(1, pvals=probs / sum(probs))
                 return np.where(array == 1)[0][0]
 
         return Generator(probs)

--- a/mrmustard/math/backend_numpy.py
+++ b/mrmustard/math/backend_numpy.py
@@ -368,7 +368,7 @@ class BackendNumpy(BackendBase):  # pragma: no cover
 
             def sample(self):
                 idx = [i for i, _ in enumerate(probs)]
-                return np.random.choice(1, p=probs / sum(probs))
+                return np.random.choice(idx, p=probs / sum(probs))
 
         return Generator(probs)
 

--- a/mrmustard/math/backend_numpy.py
+++ b/mrmustard/math/backend_numpy.py
@@ -367,8 +367,8 @@ class BackendNumpy(BackendBase):  # pragma: no cover
                 self._probs = probs
 
             def sample(self):
-                array = np.random.multinomial(1, pvals=probs / sum(probs))
-                return np.where(array == 1)[0][0]
+                idx = [i for i, _ in enumerate(probs)]
+                return np.random.choice(1, p=probs / sum(probs))
 
         return Generator(probs)
 

--- a/tests/test_lab/test_detectors.py
+++ b/tests/test_lab/test_detectors.py
@@ -331,7 +331,7 @@ class TestHomodyneDetector:
         self, state, kwargs, mean_expected, var_expected
     ):
         """Tests that the mean and variance estimates of many homodyne
-        measurements are in agreement with the expected values for the states"""
+        measurements are in agreement with the expected values for the given (unnormalized) states"""
         state = state(**kwargs)
         state = State(dm=state.dm(cutoffs=[10])/3)
 

--- a/tests/test_lab/test_detectors.py
+++ b/tests/test_lab/test_detectors.py
@@ -331,9 +331,10 @@ class TestHomodyneDetector:
         self, state, kwargs, mean_expected, var_expected
     ):
         """Tests that the mean and variance estimates of many homodyne
-        measurements are in agreement with the expected values for the given (unnormalized) states"""
+        measurements are in agreement with the expected values for the given (unnormalized) states
+        """
         state = state(**kwargs)
-        state = State(dm=state.dm(cutoffs=[10])/3)
+        state = State(dm=state.dm(cutoffs=[10]) / 3)
 
         detector = Homodyne(0.0)
 

--- a/tests/test_lab/test_detectors.py
+++ b/tests/test_lab/test_detectors.py
@@ -296,7 +296,7 @@ class TestHomodyneDetector:
         ],
     )
     @pytest.mark.parametrize("gaussian_state", [True, False])
-    @pytest.mark.parametrize("normalization", [1, 1/3])
+    @pytest.mark.parametrize("normalization", [1, 1 / 3])
     def test_sampling_mean_and_var(
         self, state, kwargs, mean_expected, var_expected, gaussian_state, normalization
     ):
@@ -305,7 +305,7 @@ class TestHomodyneDetector:
         state = state(**kwargs)
 
         if not gaussian_state:
-            state = State(dm=state.dm(cutoffs=[40])*normalization)
+            state = State(dm=state.dm(cutoffs=[40]) * normalization)
         detector = Homodyne(0.0)
 
         results = np.zeros((self.N_MEAS, 2))

--- a/tests/test_math/test_backend_manager.py
+++ b/tests/test_math/test_backend_manager.py
@@ -590,9 +590,8 @@ class TestBackendManager:
 
     def test_categorical(self):
         r"""
-        Tests the ``Categorical`` method. 
+        Tests the ``Categorical`` method.
         """
         probs = np.array([1e-6 for _ in range(300)])
         results = [math.Categorical(probs, "") for _ in range(100)]
         assert len(set(results)) > 1
-

--- a/tests/test_math/test_backend_manager.py
+++ b/tests/test_math/test_backend_manager.py
@@ -587,3 +587,12 @@ class TestBackendManager:
         arr = 4 * np.eye(3)
         res = math.asnumpy(math.sum(arr))
         assert np.allclose(res, 12)
+
+    def test_categorical(self):
+        r"""
+        Tests the ``Categorical`` method. 
+        """
+        probs = np.array([1e-6 for _ in range(300)])
+        results = [math.Categorical(probs, "") for _ in range(100)]
+        assert len(set(results)) > 1
+


### PR DESCRIPTION
**Context:**
```
probs = np.array([1e-6 for _ in range(300)])
results = [math.Categorical(probs, "") for _ in range(100)]
assert len(set(results)) > 1
```
When using the numpy backend, the code above fails: `results` contains 100 identical values.
This is because `math.Categorical` uses `np.random.multinomial`, which assumes that the probabilities sum up to `1` (if not, the last probability is increased such that the resulting probabilities sum up to `1`)
