### PR TITLE
Fix the small bugs

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -119,7 +119,6 @@ which uses the old Numba code. When setting to a higher value, the new Julia cod
 * Fixing a bug where `scipy.linalg.sqrtm` returns an unsupported type.
 [(#337)](https://github.com/XanaduAI/MrMustard/pull/337)
 
-
 ### Documentation
 
 ### Tests

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -114,6 +114,10 @@ which uses the old Numba code. When setting to a higher value, the new Julia cod
 [(#309)](https://github.com/XanaduAI/MrMustard/pull/309)
 * Fixing a bug where `scipy.linalg.sqrtm` returns an unsupported type.
 [(#337)](https://github.com/XanaduAI/MrMustard/pull/337)
+* Fixing a bug in `_transform_gaussian` in transformation.py that modifies the input state's cov and means.
+[(#349)](https://github.com/XanaduAI/MrMustard/pull/349)
+* Fixing a bug in `general_dyne` in physics/gaussian.py that returns the wrong probability and outcomes with given projection.
+[(#349)](https://github.com/XanaduAI/MrMustard/pull/349)
 
 ### Documentation
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -9,6 +9,10 @@
 ### Improvements
 
 ### Bug fixes
+* Fixing a bug in `_transform_gaussian` in transformation.py that modifies the input state's cov and means.
+[(#349)](https://github.com/XanaduAI/MrMustard/pull/349)
+* Fixing a bug in `general_dyne` in physics/gaussian.py that returns the wrong probability and outcomes with given projection.
+[(#349)](https://github.com/XanaduAI/MrMustard/pull/349)
 
 ### Documentation
 
@@ -114,10 +118,7 @@ which uses the old Numba code. When setting to a higher value, the new Julia cod
 [(#309)](https://github.com/XanaduAI/MrMustard/pull/309)
 * Fixing a bug where `scipy.linalg.sqrtm` returns an unsupported type.
 [(#337)](https://github.com/XanaduAI/MrMustard/pull/337)
-* Fixing a bug in `_transform_gaussian` in transformation.py that modifies the input state's cov and means.
-[(#349)](https://github.com/XanaduAI/MrMustard/pull/349)
-* Fixing a bug in `general_dyne` in physics/gaussian.py that returns the wrong probability and outcomes with given projection.
-[(#349)](https://github.com/XanaduAI/MrMustard/pull/349)
+
 
 ### Documentation
 

--- a/mrmustard/lab/abstract/transformation.py
+++ b/mrmustard/lab/abstract/transformation.py
@@ -113,7 +113,9 @@ class Transformation(Tensor):
             State: the transformed state
         """
         X, Y, d = self.XYd(allow_none=False) if not dual else self.XYd_dual(allow_none=False)
-        cov, means = gaussian.CPTP(state.cov, state.means, X, Y, d, state.modes, self.modes)
+        cov, means = gaussian.CPTP(
+            math.astensor(state.cov), math.astensor(state.means), X, Y, d, state.modes, self.modes
+        )
         new_state = State(
             cov=cov, means=means, modes=state.modes, _norm=state.norm
         )  # NOTE: assumes modes don't change

--- a/mrmustard/physics/bargmann.py
+++ b/mrmustard/physics/bargmann.py
@@ -126,6 +126,11 @@ def complex_gaussian_integral(
 
     :math: `dmu(z) = \textrm{exp}(m * |z|^2) \frac{d^{2n}z}{\pi^n} = \frac{1}{\pi^n}\textrm{exp}(m * |z|^2) d\textrm{Re}(z) d\textrm{Im}(z)`
 
+    Note that the indices must be a complex variable pairs with each other (idx_z, idx_zconj) to make this contraction meaningful.
+    Please make sure the corresponding complex variable with respect to your Abc triples.
+    For examples, if the indices of Abc denotes the variables ``(\alpha, \beta, \alpha^*, \beta^*, \gamma, \eta)``, the contraction only works
+    with the indices between ``(\alpha, \alpha^*)`` pairs and ``(\beta, \beta^*)`` pairs.
+
     Arguments:
         A,b,c: the ``(A,b,c)`` triple
         idx_z: the tuple of indices of the z variables
@@ -158,13 +163,12 @@ def complex_gaussian_integral(
         D = math.gather(math.gather(A, idx, axis=-1), not_idx, axis=-2)
         R = math.gather(math.gather(A, not_idx, axis=-1), not_idx, axis=-2)
         bR = math.gather(b, not_idx, axis=-1)
+        A_post = R - math.matmul(D, math.inv(M), math.transpose(D))
+        b_post = bR - math.matvec(D, math.solve(M, bM))
     else:
-        D = math.zeros_like(math.gather(A, idx, axis=-1))
-        R = math.zeros_like(A)
-        bR = math.zeros_like(b)
+        A_post = math.astensor([])
+        b_post = math.astensor([])
 
-    A_post = R - math.matmul(D, math.inv(M), math.transpose(D))
-    b_post = bR - math.matvec(D, math.solve(M, bM))
     c_post = (
         c * math.sqrt((-1) ** n / math.det(M)) * math.exp(-0.5 * math.sum(bM * math.solve(M, bM)))
     )
@@ -217,7 +221,12 @@ def contract_two_Abc(
     idx2: Sequence[int],
 ):
     r"""
-    Returns the contraction of two ``(A,b,c)`` triples.
+    Returns the contraction of two ``(A,b,c)`` triples with given indices.
+
+    Note that the indices must be a complex variable pairs with each other to make this contraction meaningful. Please make sure
+    the corresponding complex variable with respect to your Abc triples.
+    For examples, if the indices of Abc1 denotes the variables ``(\alpha, \beta)``, the indices of Abc2 denotes the variables
+    ``(\alpha^*,\gamma)``, the contraction only works with ``idx1 = [0], idx2 = [0]``.
 
     Arguments:
         Abc1: the first ``(A,b,c)`` triple

--- a/mrmustard/physics/gaussian.py
+++ b/mrmustard/physics/gaussian.py
@@ -594,7 +594,7 @@ def general_dyne(
     else:
         # If the projector is already given: proj_means
         # use the formula 5.139 in Serafini - Quantum Continuous Variables
-        # fixed by -0.5 on the exponential, hbar and pi with adaptation changes
+        # fixed by -0.5 on the exponential, added hbar and removed pi due to different convention
         outcome = proj_means
         prob = (
             settings.HBAR**M

--- a/tests/test_lab/test_detectors.py
+++ b/tests/test_lab/test_detectors.py
@@ -418,3 +418,13 @@ class TestNormalization:
         """Checks that after projection the norm of the leftover state is as expected."""
         leftover = Coherent(x=[2.0, 2.0]) << Coherent(x=1.0, normalize=True)[0]
         assert np.isclose(1.0, physics.norm(leftover), atol=1e-5)
+
+
+class TestProjectionOnState:
+    r"""Tests the cases that the projection state is given."""
+
+    def test_vacuum_project_on_vacuum(self):
+        """Tests that the probability of Vacuum that projects on Vacuum is 1.0."""
+        assert np.allclose(Vacuum(3) << Vacuum(3), 1.0)
+        assert np.allclose(Vacuum(3) << Coherent([0, 0, 0]), 1.0)
+        assert np.allclose(Vacuum(3) << Fock([0, 0, 0]), 1.0)

--- a/tests/test_lab/test_state.py
+++ b/tests/test_lab/test_state.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from mrmustard import math
-from mrmustard.lab import Attenuator, Coherent, Gaussian
+from mrmustard.lab import Attenuator, Coherent, Gaussian, Vacuum, Dgate
 from mrmustard.lab.abstract.state import mikkel_plot
 
 
@@ -58,3 +58,14 @@ def test_mikkel_plot():
 
     assert fig is not None
     assert axs is not None
+
+
+def test_rshit():
+    """Tests that right shifr of the state will not change the state object. This was a bug (PR349)."""
+    vac0 = Vacuum(1)
+    vac0_cov_original = vac0.cov
+    vac0_means_original = vac0.means
+    d1 = Dgate(0.1, 0.1)
+    _ = vac0 >> d1
+    assert np.all(vac0_cov_original == vac0.cov)
+    assert np.all(vac0_means_original == vac0.means)

--- a/tests/test_lab/test_state.py
+++ b/tests/test_lab/test_state.py
@@ -60,7 +60,7 @@ def test_mikkel_plot():
     assert axs is not None
 
 
-def test_rshit():
+def test_rshift():
     """Tests that right shifr of the state will not change the state object. This was a bug (PR349)."""
     vac0 = Vacuum(1)
     vac0_cov_original = vac0.cov


### PR DESCRIPTION
**Context:** There are three bugs fixed in this PR.

1. the projection onto the Vacuum state will use the generaldyne where the projection function is not correct.
For example,
`from mrmustard.lab import *;Vacuum(3) << Vacuum(3)`
The projection in the example above is not 1.0, which should be 1.0.
This has been fixed by changing the functions inside generaldyne.
3. add more text to explain about complex_gaussian_integral and other function in bargmann.py.
4. fix the problems that the state will be reassigned during the running of the circuit.
For example,
`from mrmustard.lab import *;
vac0 = Vacuum(1);
d1 = Dgate(0.1, 0.1);
vac0 >> d1;
vac0.bargmann()`

the state `vac0` state will be modified after going through the first Dgate, which is not the behaviour we want.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
