### PR TITLE
To phase space for states

### DIFF
--- a/mrmustard/physics/converters.py
+++ b/mrmustard/physics/converters.py
@@ -18,6 +18,10 @@ This module contains the functions to convert between different representations.
 from typing import Iterable, Union, Optional
 from mrmustard.physics.representations import Representation, Bargmann, Fock
 from mrmustard import math, settings
+from mrmustard.utils.typing import Matrix, Vector
+from mrmustard.physics.triples import displacement_map_s_parametrized_Abc
+from mrmustard.physics.bargmann import complex_gaussian_integral, join_Abc
+from mrmustard.lab_dev.states import State
 
 
 def to_fock(rep: Representation, shape: Optional[Union[int, Iterable[int]]] = None) -> Fock:
@@ -59,3 +63,40 @@ def to_fock(rep: Representation, shape: Optional[Union[int, Iterable[int]]] = No
         array = [math.hermite_renormalized(A, b, c, shape) for A, b, c in zip(rep.A, rep.b, rep.c)]
         return Fock(math.astensor(array), batched=True)
     return rep
+
+
+def to_phase_space(state: State, modes: Union[int, Iterable[int]], s: int = None) -> Union[Matrix, Vector]:
+    r"""A function to map states from Bargamann representations to s-parametrized ``phase-space`` representations.
+
+    This function supports only from Bargmann to phase space representation for states.
+
+    Args:
+        state: The orginal state object.
+        modes: the modes of the state that needs to be transformed into phase space.
+        s: the parametrization related to the ordering of creation and annihilation operators in the expression of any operator. :math:`s=0` is the "symmetric" ordering, which is symmetric under the exchange of creation and annihilation operators, :math:`s=-1` is the "normal" ordering, where all the creation operators are on the left and all the annihilation operators are on the right, and :math:`s=1` is the "anti-normal" ordering, which is the vice versa of the normal ordering. By using s-parametrized displacement map to generate the s-parametrized characteristic function :math:`\chi_s = Tr[\rho D_s]`, and then by doing the complex fourier transform, we get the s-parametrized quasi-probaility distribution: :math:`s=0` is the Wigner distribution, :math:`s=-1` is the Husimi Q distribution, and :math:`s=1` is the Glauber P distribution.
+
+    Returns:
+        The covariance matrix and means vector in phase space.
+
+    .. code-block::
+
+        >>> from mrmustard.physics.converters import to_phase_space
+        >>> from mrmustard.physics.representations import Bargmann
+        >>> from mrmustard.physics.triples import displacement_gate_Abc
+
+        >>> bargmann = Bargmann(*displacement_gate_Abc(x=0.1, y=[0.2, 0.3]))
+        >>> cov, means = to_phase_space(bargmann)
+        >>> assert 1.0 #TODO
+
+    """
+    if not isinstance(rep, Bargmann):
+        raise ValueError("This converter only works for Bargamnn representation.")
+
+    D_s_map_A, D_s_map_b, D_s_map_c = displacement_map_s_parametrized_Abc(s)
+    A,b,c = rep.ansatz.A, rep.ansatz.b, rep.ansatz.c
+    new_A, new_b, new_c = complex_gaussian_integral(
+        join_Abc((D_s_map_A, D_s_map_b, D_s_map_c), (A, b, c)),
+        idx_z=[3, 4],
+        idx_zconj=index_pair,
+    )
+


### PR DESCRIPTION
------------------------------------------------------------------------------------------------------------

**Context:** Add the to_phase_space function for states.

Note that this is branched out from PR368 to use the D_s_map.

**Description of the Change:** This function receives the state and changes the representation of a given mode.

Questions left:
- [ ]  What would be the best returns? If this is a N-mode state, the state has been transformed totally into phase space, would it be stored in the phase space representation somehow? If the state is just partially transformed into another representation, how to label it?

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
