### PR TITLE
Fix adjoint dual bug

### DIFF
--- a/mrmustard/lab_dev/circuit_components.py
+++ b/mrmustard/lab_dev/circuit_components.py
@@ -361,7 +361,9 @@ class AdjointView(CircuitComponent):
         r"""
         A representation of this circuit component.
         """
-        return self._component.representation.conj()
+        bras = self._component.wires.bra.indices
+        kets = self._component.wires.ket.indices
+        return self._component.representation.reorder(kets+bras).conj()
 
     @property
     def wires(self):
@@ -398,7 +400,9 @@ class DualView(CircuitComponent):
         r"""
         A representation of this circuit component.
         """
-        return self._component.representation.conj()
+        outs = self._component.wires.output.indices
+        ins = self._component.wires.input.indices
+        return self._component.representation.reorder(ins+outs).conj()
 
     @property
     def wires(self):

--- a/mrmustard/lab_dev/circuit_components.py
+++ b/mrmustard/lab_dev/circuit_components.py
@@ -363,7 +363,7 @@ class AdjointView(CircuitComponent):
         """
         bras = self._component.wires.bra.indices
         kets = self._component.wires.ket.indices
-        return self._component.representation.reorder(kets+bras).conj()
+        return self._component.representation.reorder(kets + bras).conj()
 
     @property
     def wires(self):
@@ -402,7 +402,7 @@ class DualView(CircuitComponent):
         """
         outs = self._component.wires.output.indices
         ins = self._component.wires.input.indices
-        return self._component.representation.reorder(ins+outs).conj()
+        return self._component.representation.reorder(ins + outs).conj()
 
     @property
     def wires(self):

--- a/mrmustard/physics/ansatze.py
+++ b/mrmustard/physics/ansatze.py
@@ -99,6 +99,12 @@ class Ansatz(ABC):
         Multiplies this ansatz by another ansatz.
         """
 
+    @abstractmethod
+    def __and__(self, other: Ansatz) -> Ansatz:
+        r"""
+        Tensor product of this ansatz with another ansatz.
+        """
+
     def __rmul__(self, other: Scalar) -> Ansatz:
         r"""
         Multiplies this ansatz by a scalar.

--- a/mrmustard/physics/representations.py
+++ b/mrmustard/physics/representations.py
@@ -57,6 +57,12 @@ class Representation(ABC):
         """
 
     @abstractmethod
+    def reorder(self, order: tuple[int, ...] | list[int]) -> Representation:
+        r"""
+        Reorders the representation indices.
+        """
+
+    @abstractmethod
     def from_ansatz(cls, ansatz: Ansatz) -> Representation:  # pragma: no cover
         r"""
         Returns a representation from an ansatz.

--- a/tests/test_lab_dev/test_circuit_components.py
+++ b/tests/test_lab_dev/test_circuit_components.py
@@ -91,7 +91,7 @@ class TestCircuitComponent:
         assert isinstance(d1_adj, AdjointView)
         assert d1_adj.name == d1.name
         assert d1_adj.wires == d1.wires.adjoint
-        assert d1_adj.representation == d1.representation.conj()
+        assert d1_adj.representation == d1.representation.conj()  # this holds for the Dgate but not in general
 
         d1_adj_adj = d1_adj.adjoint
         assert isinstance(d1_adj_adj, CircuitComponent)
@@ -101,11 +101,13 @@ class TestCircuitComponent:
     def test_dual(self):
         d1 = Dgate([1, 8], x=0.1, y=0.2)
         d1_dual = d1.dual
+        vac = Vacuum([1,8])
 
         assert isinstance(d1_dual, DualView)
         assert d1_dual.name == d1.name
         assert d1_dual.wires == d1.wires.dual
-        assert d1_dual.representation == d1.representation.conj()
+        assert (vac >> d1 >> d1_dual).representation == vac.representation
+        assert (vac >> d1_dual >> d1).representation == vac.representation
 
         d1_dual_dual = d1_dual.dual
         assert isinstance(d1_dual_dual, CircuitComponent)
@@ -407,10 +409,11 @@ class TestDualView:
         """
         d1 = Dgate([1], x=0.1, y=0.1)
         d1_dual = DualView(d1)
+        vac = Vacuum([1])
 
         assert d1_dual.name == d1.name
         assert d1_dual.wires == d1.wires.dual
-        assert d1_dual.representation == d1.representation.conj()
+        assert (vac >> d1 >> d1_dual).representation == vac.representation
 
         d1_dual_dual = DualView(d1_dual)
         assert d1_dual_dual.wires == d1.wires
@@ -429,8 +432,8 @@ class TestDualView:
         """
         d1 = Dgate(modes=[0], x=0.1, y=0.2, x_trainable=True)
         d1_dual = DualView(d1)
-
+        vac = Vacuum([0])
         d1.x.value = 0.8
 
         assert d1_dual.x.value == 0.8
-        assert d1_dual.representation == d1.representation.conj()
+        assert (vac >> d1 >> d1_dual).representation == vac.representation


### PR DESCRIPTION
**Context:**
There was a bug whereby e.g.
```python
G = Bargmann(*Ggate(2).bargmann())
U = CircuitComponent(representation=G, modes_in_ket=[0,1], modes_out_ket=[0,1])
assert (U >> U.dual).representation == Dgate([0,1], x=0).representation  # fails
```

**Description of the Change:**
Added missing reordering of the representation

**Benefits:**
Correct now

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None