### PR TITLE
Added attenuator kraus Abc triple

### DIFF
--- a/mrmustard/physics/triples.py
+++ b/mrmustard/physics/triples.py
@@ -33,7 +33,9 @@ def _X_matrix_for_unitary(n_modes: int) -> Matrix:
     r"""
     The X matrix for the order of unitaries.
     """
-    return math.cast(math.kron(math.astensor([[0, 1], [1, 0]]), math.eye(n_modes)), math.complex128)
+    return math.cast(
+        math.kron(math.astensor([[0, 1], [1, 0]]), math.eye(n_modes)), math.complex128
+    )
 
 
 def _vacuum_A_matrix(n_modes: int) -> Matrix:
@@ -220,7 +222,9 @@ def thermal_state_Abc(nbar: Union[int, Iterable[int]]) -> Union[Matrix, Vector, 
 # ~~~~~~~~~~~~~~~~~~~~~~~~
 
 
-def rotation_gate_Abc(theta: Union[float, Iterable[float]]) -> Union[Matrix, Vector, Scalar]:
+def rotation_gate_Abc(
+    theta: Union[float, Iterable[float]],
+) -> Union[Matrix, Vector, Scalar]:
     r"""
     The ``(A, b, c)`` triple of of a tensor product of rotation gates.
 
@@ -297,7 +301,9 @@ def squeezing_gate_Abc(
     tanhr = math.diag(math.sinh(r) / math.cosh(r))
     sechr = math.diag(1 / math.cosh(r))
 
-    A = math.block([[-math.exp(1j * delta) * tanhr, sechr], [sechr, math.exp(-1j * delta) * tanhr]])
+    A = math.block(
+        [[-math.exp(1j * delta) * tanhr, sechr], [sechr, math.exp(-1j * delta) * tanhr]]
+    )
     b = _vacuum_B_vector(n_modes * 2)
     c = math.prod(1 / math.sqrt(math.cosh(r)))
 
@@ -330,7 +336,10 @@ def beamsplitter_gate_Abc(
     costheta = math.diag(math.cos(theta))
     sintheta = math.diag(math.sin(theta))
     V = math.block(
-        [[costheta, -math.exp(-1j * phi) * sintheta], [math.exp(1j * phi) * sintheta, costheta]]
+        [
+            [costheta, -math.exp(-1j * phi) * sintheta],
+            [math.exp(1j * phi) * sintheta, costheta],
+        ]
     )
 
     A = math.block([[O_n, V], [math.transpose(V), O_n]])
@@ -369,7 +378,11 @@ def attenuator_Abc(eta: Union[float, Iterable[float]]) -> Union[Matrix, Vector, 
             raise ValueError(msg)
 
     O_n = math.zeros((n_modes, n_modes), math.complex128)
-    eta1 = math.diag(math.sqrt(eta)).reshape((n_modes, n_modes)).reshape((n_modes, n_modes))
+    eta1 = (
+        math.diag(math.sqrt(eta))
+        .reshape((n_modes, n_modes))
+        .reshape((n_modes, n_modes))
+    )
     eta2 = math.eye(n_modes) - math.diag(eta).reshape((n_modes, n_modes))
 
     A = math.block(
@@ -456,7 +469,7 @@ def fock_damping_Abc(n_modes: int) -> Union[Matrix, Vector, Scalar]:
 
 def displacement_map_s_parametrized_Abc(s: int) -> Union[Matrix, Vector, Scalar]:
     r"""
-    The ``(A, b, c)`` triple of a single-mode ``s``\-parametrized dispalcement map :math:`D(\gamma)`.
+    The ``(A, b, c)`` triple of a single-mode ``s``\-parametrized displacement map :math:`D(\gamma)`.
     Given the complex variables for this single-mode is :math:`(z^*, z)` corresponding to [out_ket, in_ket] unitary ordering,
     the indices of the final triple correspond to the variables :math:`(\gamma^*, z^*, \gamma, z)` of the Bargmann function of the s-parametrized displacement map, and correspond to ``out_bra, in_bra, out_ket, in_ket`` wires.
 
@@ -477,4 +490,32 @@ def displacement_map_s_parametrized_Abc(s: int) -> Union[Matrix, Vector, Scalar]
     ]  # Change the order of this map into the normal ordering as a single mode channel
     b = _vacuum_B_vector(4)
     c = 1.0 + 0j
+    return A, b, c
+
+
+# ~~~~~~~~~~~~~~~~
+# Kraus operators
+# ~~~~~~~~~~~~~~~~
+
+
+def attenuator_kraus_Abc(eta: float) -> Union[Matrix, Vector, Scalar]:
+    r"""
+    The entire family of Kraus operators of the attenuator (loss) channel as a single ``(A, b, c)`` triple.
+    The last index is the "bond" index which should be summed/integrated over.
+
+    Args:
+        eta: The value of the transmissivity.
+
+    Returns:
+        The ``(A, b, c)`` triple of the kraus operators of the attenuator (loss) channel.
+    """
+    costheta = math.sqrt(eta)
+    sintheta = math.sqrt(1 - eta)
+
+    A = math.astensor(
+        [[0, costheta, 0], [costheta, 0, -sintheta], [0, -sintheta, 0]], math.complex128
+    )
+    b = _vacuum_B_vector(3)
+    c = 1.0 + 0j
+
     return A, b, c

--- a/mrmustard/physics/triples.py
+++ b/mrmustard/physics/triples.py
@@ -33,9 +33,7 @@ def _X_matrix_for_unitary(n_modes: int) -> Matrix:
     r"""
     The X matrix for the order of unitaries.
     """
-    return math.cast(
-        math.kron(math.astensor([[0, 1], [1, 0]]), math.eye(n_modes)), math.complex128
-    )
+    return math.cast(math.kron(math.astensor([[0, 1], [1, 0]]), math.eye(n_modes)), math.complex128)
 
 
 def _vacuum_A_matrix(n_modes: int) -> Matrix:
@@ -301,9 +299,7 @@ def squeezing_gate_Abc(
     tanhr = math.diag(math.sinh(r) / math.cosh(r))
     sechr = math.diag(1 / math.cosh(r))
 
-    A = math.block(
-        [[-math.exp(1j * delta) * tanhr, sechr], [sechr, math.exp(-1j * delta) * tanhr]]
-    )
+    A = math.block([[-math.exp(1j * delta) * tanhr, sechr], [sechr, math.exp(-1j * delta) * tanhr]])
     b = _vacuum_B_vector(n_modes * 2)
     c = math.prod(1 / math.sqrt(math.cosh(r)))
 
@@ -378,11 +374,7 @@ def attenuator_Abc(eta: Union[float, Iterable[float]]) -> Union[Matrix, Vector, 
             raise ValueError(msg)
 
     O_n = math.zeros((n_modes, n_modes), math.complex128)
-    eta1 = (
-        math.diag(math.sqrt(eta))
-        .reshape((n_modes, n_modes))
-        .reshape((n_modes, n_modes))
-    )
+    eta1 = math.diag(math.sqrt(eta)).reshape((n_modes, n_modes)).reshape((n_modes, n_modes))
     eta2 = math.eye(n_modes) - math.diag(eta).reshape((n_modes, n_modes))
 
     A = math.block(

--- a/tests/test_physics/test_triples.py
+++ b/tests/test_physics/test_triples.py
@@ -74,9 +74,7 @@ class TestTriples:
         assert math.allclose(c1, 0.9975072676192522)
 
         A2, b2, c2 = triples.squeezed_vacuum_state_Abc(0.1, [0.2, 0.3])
-        assert math.allclose(
-            A2, [[-0.09768127 - 0.01980097j, 0], [0, -0.09521647 - 0.02945391j]]
-        )
+        assert math.allclose(A2, [[-0.09768127 - 0.01980097j, 0], [0, -0.09521647 - 0.02945391j]])
         assert math.allclose(b2, np.zeros(2))
         assert math.allclose(c2, 0.9950207489532265)
 
@@ -91,12 +89,8 @@ class TestTriples:
         assert math.allclose(b1, [0.14952016 + 0.15768091j])
         assert math.allclose(c1, 0.95557745 + 0.00675411j)
 
-        A2, b2, c2 = triples.displaced_squeezed_vacuum_state_Abc(
-            0.1, 0.2, 0.3, [0.4, 0.5]
-        )
-        assert math.allclose(
-            A2, [[-0.26831668 - 0.11344247j, 0], [0, -0.25565087 - 0.13966271j]]
-        )
+        A2, b2, c2 = triples.displaced_squeezed_vacuum_state_Abc(0.1, 0.2, 0.3, [0.4, 0.5])
+        assert math.allclose(A2, [[-0.26831668 - 0.11344247j, 0], [0, -0.25565087 - 0.13966271j]])
         assert math.allclose(b2, [0.14952016 + 0.15768091j, 0.15349763 + 0.1628361j])
         assert math.allclose(c2, 0.912428762764038 + 0.013026652993991094j)
 
@@ -127,18 +121,14 @@ class TestTriples:
 
     def test_rotation_gate_Abc(self):
         A1, b1, c1 = triples.rotation_gate_Abc(0.1)
-        assert math.allclose(
-            A1, [[0, 0.99500417 + 0.09983342j], [0.99500417 + 0.09983342j, 0]]
-        )
+        assert math.allclose(A1, [[0, 0.99500417 + 0.09983342j], [0.99500417 + 0.09983342j, 0]])
         assert math.allclose(b1, np.zeros(2))
         assert math.allclose(c1, 1.0)
 
         A2, b2, c2 = triples.rotation_gate_Abc([0.1, 0.2])
         g1 = 0.99500417 + 0.09983342j
         g2 = 0.98006658 + 0.19866933j
-        assert math.allclose(
-            A2, [[0, 0, g1, 0], [0, 0, 0, g2], [g1, 0, 0, 0], [0, g2, 0, 0]]
-        )
+        assert math.allclose(A2, [[0, 0, g1, 0], [0, 0, 0, g2], [g1, 0, 0, 0], [0, g2, 0, 0]])
         assert math.allclose(b2, np.zeros(4))
         assert math.allclose(c2, 1.0)
 
@@ -149,16 +139,12 @@ class TestTriples:
         assert math.allclose(c1, 0.990049833749168)
 
         A2, b2, c2 = triples.displacement_gate_Abc([0.1, 0.2], 0.1)
-        assert math.allclose(
-            A2, [[0, 0, 1, 0], [0, 0, 0, 1], [1, 0, 0, 0], [0, 1, 0, 0]]
-        )
+        assert math.allclose(A2, [[0, 0, 1, 0], [0, 0, 0, 1], [1, 0, 0, 0], [0, 1, 0, 0]])
         assert math.allclose(b2, [0.1 + 0.1j, 0.2 + 0.1j, -0.1 + 0.1j, -0.2 + 0.1j])
         assert math.allclose(c2, 0.9656054162575665)
 
         A3, b3, c3 = triples.displacement_gate_Abc(x=[0.1, 0.2])
-        assert math.allclose(
-            A3, [[0, 0, 1, 0], [0, 0, 0, 1], [1, 0, 0, 0], [0, 1, 0, 0]]
-        )
+        assert math.allclose(A3, [[0, 0, 1, 0], [0, 0, 0, 1], [1, 0, 0, 0], [0, 1, 0, 0]])
         assert math.allclose(b3, [0.1, 0.2, -0.1, -0.2])
         assert math.allclose(c3, 0.9753099120283327)
 
@@ -239,9 +225,7 @@ class TestTriples:
     def test_attenuator_Abc(self):
         A1, b1, c1 = triples.attenuator_Abc(0.1)
         e = 0.31622777
-        assert math.allclose(
-            A1, [[0, e, 0, 0], [e, 0, 0, 0.9], [0, 0, 0, e], [0, 0.9, e, 0]]
-        )
+        assert math.allclose(A1, [[0, e, 0, 0], [e, 0, 0, 0.9], [0, 0, 0, e], [0, 0.9, e, 0]])
         assert math.allclose(b1, np.zeros((4)))
         assert math.allclose(c1, 1.0)
 
@@ -308,34 +292,26 @@ class TestTriples:
     @pytest.mark.parametrize("n_modes", [1, 2, 3])
     def test_fock_damping_Abc(self, n_modes):
         A1, b1, c1 = triples.fock_damping_Abc(n_modes)
-        assert math.allclose(
-            A1, np.kron(math.astensor([[0, 1], [1, 0]]), math.eye(2 * n_modes))
-        )
+        assert math.allclose(A1, np.kron(math.astensor([[0, 1], [1, 0]]), math.eye(2 * n_modes)))
         assert math.allclose(b1, np.zeros((4 * n_modes)))
         assert math.allclose(c1, 1)
 
     def test_displacement_gate_s_parametrized_Abc(self):
         A1, b1, c1 = triples.displacement_map_s_parametrized_Abc(0)
-        A1_correct = np.array(
-            [[0, -0.5, -1, 0], [-0.5, 0, 0, 1], [-1, 0, 0, 1], [0, 1, 1, 0]]
-        )
+        A1_correct = np.array([[0, -0.5, -1, 0], [-0.5, 0, 0, 1], [-1, 0, 0, 1], [0, 1, 1, 0]])
         assert math.allclose(A1, A1_correct[[0, 2, 1, 3], :][:, [0, 2, 1, 3]])
         print(b1.shape)
         assert math.allclose(b1, np.zeros(4))
         assert math.allclose(c1, 1)
 
         A2, b2, c2 = triples.displacement_map_s_parametrized_Abc(1)
-        A2_correct = np.array(
-            [[0, 0, -1, 0], [0, 0, 0, 1], [-1, 0, 0, 1], [0, 1, 1, 0]]
-        )
+        A2_correct = np.array([[0, 0, -1, 0], [0, 0, 0, 1], [-1, 0, 0, 1], [0, 1, 1, 0]])
         assert math.allclose(A2, A2_correct[[0, 2, 1, 3], :][:, [0, 2, 1, 3]])
         assert math.allclose(b2, np.zeros(4))
         assert math.allclose(c2, 1)
 
         A3, b3, c3 = triples.displacement_map_s_parametrized_Abc(-1)
-        A3_correct = np.array(
-            [[0, -1, -1, 0], [-1, 0, 0, 1], [-1, 0, 0, 1], [0, 1, 1, 0]]
-        )
+        A3_correct = np.array([[0, -1, -1, 0], [-1, 0, 0, 1], [-1, 0, 0, 1], [0, 1, 1, 0]])
         assert math.allclose(A3, A3_correct[[0, 2, 1, 3], :][:, [0, 2, 1, 3]])
         assert math.allclose(b3, np.zeros(4))
         assert math.allclose(c3, 1)

--- a/tests/test_physics/test_triples.py
+++ b/tests/test_physics/test_triples.py
@@ -14,12 +14,12 @@
 
 """Tests the Bargmann triples."""
 
-
 import numpy as np
 import pytest
 
 from mrmustard import math
 from mrmustard.physics import triples
+from mrmustard.physics.representations import Bargmann
 
 
 # pylint: disable = missing-function-docstring
@@ -74,7 +74,9 @@ class TestTriples:
         assert math.allclose(c1, 0.9975072676192522)
 
         A2, b2, c2 = triples.squeezed_vacuum_state_Abc(0.1, [0.2, 0.3])
-        assert math.allclose(A2, [[-0.09768127 - 0.01980097j, 0], [0, -0.09521647 - 0.02945391j]])
+        assert math.allclose(
+            A2, [[-0.09768127 - 0.01980097j, 0], [0, -0.09521647 - 0.02945391j]]
+        )
         assert math.allclose(b2, np.zeros(2))
         assert math.allclose(c2, 0.9950207489532265)
 
@@ -89,8 +91,12 @@ class TestTriples:
         assert math.allclose(b1, [0.14952016 + 0.15768091j])
         assert math.allclose(c1, 0.95557745 + 0.00675411j)
 
-        A2, b2, c2 = triples.displaced_squeezed_vacuum_state_Abc(0.1, 0.2, 0.3, [0.4, 0.5])
-        assert math.allclose(A2, [[-0.26831668 - 0.11344247j, 0], [0, -0.25565087 - 0.13966271j]])
+        A2, b2, c2 = triples.displaced_squeezed_vacuum_state_Abc(
+            0.1, 0.2, 0.3, [0.4, 0.5]
+        )
+        assert math.allclose(
+            A2, [[-0.26831668 - 0.11344247j, 0], [0, -0.25565087 - 0.13966271j]]
+        )
         assert math.allclose(b2, [0.14952016 + 0.15768091j, 0.15349763 + 0.1628361j])
         assert math.allclose(c2, 0.912428762764038 + 0.013026652993991094j)
 
@@ -121,14 +127,18 @@ class TestTriples:
 
     def test_rotation_gate_Abc(self):
         A1, b1, c1 = triples.rotation_gate_Abc(0.1)
-        assert math.allclose(A1, [[0, 0.99500417 + 0.09983342j], [0.99500417 + 0.09983342j, 0]])
+        assert math.allclose(
+            A1, [[0, 0.99500417 + 0.09983342j], [0.99500417 + 0.09983342j, 0]]
+        )
         assert math.allclose(b1, np.zeros(2))
         assert math.allclose(c1, 1.0)
 
         A2, b2, c2 = triples.rotation_gate_Abc([0.1, 0.2])
         g1 = 0.99500417 + 0.09983342j
         g2 = 0.98006658 + 0.19866933j
-        assert math.allclose(A2, [[0, 0, g1, 0], [0, 0, 0, g2], [g1, 0, 0, 0], [0, g2, 0, 0]])
+        assert math.allclose(
+            A2, [[0, 0, g1, 0], [0, 0, 0, g2], [g1, 0, 0, 0], [0, g2, 0, 0]]
+        )
         assert math.allclose(b2, np.zeros(4))
         assert math.allclose(c2, 1.0)
 
@@ -139,12 +149,16 @@ class TestTriples:
         assert math.allclose(c1, 0.990049833749168)
 
         A2, b2, c2 = triples.displacement_gate_Abc([0.1, 0.2], 0.1)
-        assert math.allclose(A2, [[0, 0, 1, 0], [0, 0, 0, 1], [1, 0, 0, 0], [0, 1, 0, 0]])
+        assert math.allclose(
+            A2, [[0, 0, 1, 0], [0, 0, 0, 1], [1, 0, 0, 0], [0, 1, 0, 0]]
+        )
         assert math.allclose(b2, [0.1 + 0.1j, 0.2 + 0.1j, -0.1 + 0.1j, -0.2 + 0.1j])
         assert math.allclose(c2, 0.9656054162575665)
 
         A3, b3, c3 = triples.displacement_gate_Abc(x=[0.1, 0.2])
-        assert math.allclose(A3, [[0, 0, 1, 0], [0, 0, 0, 1], [1, 0, 0, 0], [0, 1, 0, 0]])
+        assert math.allclose(
+            A3, [[0, 0, 1, 0], [0, 0, 0, 1], [1, 0, 0, 0], [0, 1, 0, 0]]
+        )
         assert math.allclose(b3, [0.1, 0.2, -0.1, -0.2])
         assert math.allclose(c3, 0.9753099120283327)
 
@@ -152,7 +166,10 @@ class TestTriples:
         A1, b1, c1 = triples.squeezing_gate_Abc(0.1, 0.2)
         assert math.allclose(
             A1,
-            [[-0.09768127 - 1.98009738e-02j, 0.99502075], [0.99502075, 0.09768127 - 0.01980097j]],
+            [
+                [-0.09768127 - 1.98009738e-02j, 0.99502075],
+                [0.99502075, 0.09768127 - 0.01980097j],
+            ],
         )
         assert math.allclose(b1, np.zeros(2))
         assert math.allclose(c1, 0.9975072676192522)
@@ -172,7 +189,11 @@ class TestTriples:
 
         A3, b3, c3 = triples.squeezing_gate_Abc(0.1)
         assert math.allclose(
-            A3, [[-0.09966799 + 0.0j, 0.99502075 + 0.0j], [0.99502075 + 0.0j, 0.09966799 + 0.0j]]
+            A3,
+            [
+                [-0.09966799 + 0.0j, 0.99502075 + 0.0j],
+                [0.99502075 + 0.0j, 0.09966799 + 0.0j],
+            ],
         )
         assert math.allclose(b3, np.zeros(2))
         assert math.allclose(c3, 0.9975072676192522)
@@ -218,7 +239,9 @@ class TestTriples:
     def test_attenuator_Abc(self):
         A1, b1, c1 = triples.attenuator_Abc(0.1)
         e = 0.31622777
-        assert math.allclose(A1, [[0, e, 0, 0], [e, 0, 0, 0.9], [0, 0, 0, e], [0, 0.9, e, 0]])
+        assert math.allclose(
+            A1, [[0, e, 0, 0], [e, 0, 0, 0.9], [0, 0, 0, e], [0, 0.9, e, 0]]
+        )
         assert math.allclose(b1, np.zeros((4)))
         assert math.allclose(c1, 1.0)
 
@@ -285,26 +308,40 @@ class TestTriples:
     @pytest.mark.parametrize("n_modes", [1, 2, 3])
     def test_fock_damping_Abc(self, n_modes):
         A1, b1, c1 = triples.fock_damping_Abc(n_modes)
-        assert math.allclose(A1, np.kron(math.astensor([[0, 1], [1, 0]]), math.eye(2 * n_modes)))
+        assert math.allclose(
+            A1, np.kron(math.astensor([[0, 1], [1, 0]]), math.eye(2 * n_modes))
+        )
         assert math.allclose(b1, np.zeros((4 * n_modes)))
         assert math.allclose(c1, 1)
 
     def test_displacement_gate_s_parametrized_Abc(self):
         A1, b1, c1 = triples.displacement_map_s_parametrized_Abc(0)
-        A1_correct = np.array([[0, -0.5, -1, 0], [-0.5, 0, 0, 1], [-1, 0, 0, 1], [0, 1, 1, 0]])
+        A1_correct = np.array(
+            [[0, -0.5, -1, 0], [-0.5, 0, 0, 1], [-1, 0, 0, 1], [0, 1, 1, 0]]
+        )
         assert math.allclose(A1, A1_correct[[0, 2, 1, 3], :][:, [0, 2, 1, 3]])
         print(b1.shape)
         assert math.allclose(b1, np.zeros(4))
         assert math.allclose(c1, 1)
 
         A2, b2, c2 = triples.displacement_map_s_parametrized_Abc(1)
-        A2_correct = np.array([[0, 0, -1, 0], [0, 0, 0, 1], [-1, 0, 0, 1], [0, 1, 1, 0]])
+        A2_correct = np.array(
+            [[0, 0, -1, 0], [0, 0, 0, 1], [-1, 0, 0, 1], [0, 1, 1, 0]]
+        )
         assert math.allclose(A2, A2_correct[[0, 2, 1, 3], :][:, [0, 2, 1, 3]])
         assert math.allclose(b2, np.zeros(4))
         assert math.allclose(c2, 1)
 
         A3, b3, c3 = triples.displacement_map_s_parametrized_Abc(-1)
-        A3_correct = np.array([[0, -1, -1, 0], [-1, 0, 0, 1], [-1, 0, 0, 1], [0, 1, 1, 0]])
+        A3_correct = np.array(
+            [[0, -1, -1, 0], [-1, 0, 0, 1], [-1, 0, 0, 1], [0, 1, 1, 0]]
+        )
         assert math.allclose(A3, A3_correct[[0, 2, 1, 3], :][:, [0, 2, 1, 3]])
         assert math.allclose(b3, np.zeros(4))
         assert math.allclose(c3, 1)
+
+    @pytest.mark.parametrize("eta", [0.0, 0.1, 0.5, 0.9, 1.0])
+    def test_attenuator_kraus_Abc(self, eta):
+        B = Bargmann(*triples.attenuator_kraus_Abc(eta))
+        Att = Bargmann(*triples.attenuator_Abc(eta))
+        assert B[2] @ B[2] == Att


### PR DESCRIPTION
**Context:**
One more useful triple

**Description of the Change:**
A new function in physics/triples.py and a test

**Benefits:**
Can break down the 4-wired attenuator into two 3-wired tensors

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None