### PR TITLE
fix inheritance diagrams and make install

### DIFF
--- a/.github/workflows/tests_numpy.yml
+++ b/.github/workflows/tests_numpy.yml
@@ -4,14 +4,6 @@ on:
     branches:
       - develop
   pull_request:
-    paths:
-      - '.github/workflows/tests.yml'
-      - 'doc/**'
-      - 'mrmustard/**'
-      - 'tests/**'
-      - 'pyproject.toml'
-      - 'poetry.lock'
-      - 'pytest.ini'
 
 jobs:
   pytest:

--- a/.github/workflows/tests_tensorflow.yml
+++ b/.github/workflows/tests_tensorflow.yml
@@ -4,14 +4,6 @@ on:
     branches:
       - develop
   pull_request:
-    paths:
-      - '.github/workflows/tests.yml'
-      - 'doc/**'
-      - 'mrmustard/**'
-      - 'tests/**'
-      - 'pyproject.toml'
-      - 'poetry.lock'
-      - 'pytest.ini'
 
 jobs:
   pytest:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,6 +6,8 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+  apt_packages:
+    - graphviz
   jobs:
     post_install:
       - "curl -fsSL https://install.julialang.org | sh -s -- --yes"

--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,8 @@ ifndef JULIA
 	@echo "To use Mr Mustard with higher precision than complex128, it is required to have Julia installed"
 	poetry install
 else
-    julia --project="julia_pkg" -e "using Pkg; Pkg.instantiate()"
-    poetry install
+	julia --project="julia_pkg" -e "using Pkg; Pkg.instantiate()"
+	poetry install
 endif
 
 


### PR DESCRIPTION
- `Makefile` syntax requires tabs, not spaces, so this `make` target didn't work
- Sphinx inheritance diagrams require the RTD builder machine to have `graphviz` installed. Otherwise, [it doesn't work](https://mrmustard.readthedocs.io/en/stable/code/training.html#class-inheritance-diagram)
  - it's [fixed](https://mrmustard--387.org.readthedocs.build/en/387/code/training.html#class-inheritance-diagram) by this PR
- run numpy and tensorflow tests unconditionally