### PR TITLE
Fix the computation of symplectic eigenvalues

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -7,6 +7,8 @@
 * Added the function `phase_space(s)` for `State` class to take out the s-parametrized phase space representations' variables covariance matrix and means vector of the state. 
   [(#385)](https://github.com/XanaduAI/MrMustard/pull/385)
 
+* Added `sort` function to math backends.
+
 ### Breaking changes
 
 ### Improvements
@@ -23,6 +25,7 @@
 [Samuele Ferracin](https://github.com/SamFerracin)
 [Yuan Yao](https://github.com/sylviemonet)
 [Filippo Miatto](https://github.com/ziofil)
+[Austin Lund](https://github.com/aplund)
 
 
 ---

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -17,6 +17,8 @@
 * Fix the bug in the order of indices of the triples for DsMap CircuitComponent. 
   [(#385)](https://github.com/XanaduAI/MrMustard/pull/385)
 
+* Ensure all symplectic eigenvalues are returned by the `symplectic_eigenvals` function.
+
 ### Documentation
 
 ### Tests

--- a/mrmustard/math/backend_manager.py
+++ b/mrmustard/math/backend_manager.py
@@ -1031,6 +1031,18 @@ class BackendManager:  # pylint: disable=too-many-public-methods, fixme
         """
         return self._apply("solve", (matrix, rhs))
 
+    def sort(self, array: Tensor, axis: int = -1) -> Tensor:
+        r"""Sort the array along an axis.
+
+        Args:
+            array: The array to sort
+            axis: (optional) The axis to sort along. Defaults to last axis.
+
+        Returns:
+            A sorted version of the array in acending order.
+        """
+        return self._apply("sort", (array, axis))
+
     def sqrt(self, x: Tensor, dtype=None) -> Tensor:
         r"""The square root of ``x``.
 

--- a/mrmustard/math/backend_numpy.py
+++ b/mrmustard/math/backend_numpy.py
@@ -315,6 +315,9 @@ class BackendNumpy(BackendBase):  # pragma: no cover
             return np.linalg.solve(matrix, rhs)[..., 0]
         return np.linalg.solve(matrix, rhs)
 
+    def sort(self, array: np.ndarray, axis: int = -1) -> np.ndarray:
+        return np.sort(array, axis)
+
     def sqrt(self, x: np.ndarray, dtype=None) -> np.ndarray:
         return np.sqrt(self.cast(x, dtype))
 

--- a/mrmustard/math/backend_tensorflow.py
+++ b/mrmustard/math/backend_tensorflow.py
@@ -319,6 +319,9 @@ class BackendTensorflow(BackendBase):  # pragma: no cover
             return tf.linalg.solve(matrix, rhs)[..., 0]
         return tf.linalg.solve(matrix, rhs)
 
+    def sort(self, array: tf.Tensor, axis: int = -1) -> tf.Tensor:
+        return tf.sort(array, axis)
+
     def sqrt(self, x: tf.Tensor, dtype=None) -> tf.Tensor:
         return tf.sqrt(self.cast(x, dtype))
 

--- a/mrmustard/physics/gaussian.py
+++ b/mrmustard/physics/gaussian.py
@@ -745,8 +745,9 @@ def symplectic_eigenvals(cov: Matrix) -> Any:
     """
     J = math.J(cov.shape[-1] // 2)  # create a sympletic form
     M = math.matmul(1j * J, cov * (2 / settings.HBAR))
-    vals = math.eigvals(M)  # compute the eigenspectrum
-    return math.abs(vals[::2])  # return the even eigenvalues  # TODO: sort?
+    vals = math.abs(math.eigvals(M))  # compute the eigenspectrum
+    vals = math.sort(vals)
+    return vals[::2]  # return the even eigenvalues
 
 
 def von_neumann_entropy(cov: Matrix) -> float:


### PR DESCRIPTION
The failure listed below was due to the symplectic eigenvalue code randomly returning the same symplectic eigenvalue multiple times.  This occured because it was assumed that the computed eigenvalues of the operator |iΩΣ| were sorted.  This assumption is not true for all cases.

This fix ensures that the eigenvalues of the operator are sorted so that the assumption is true and the symplectic eigenvalues are indeed every second entry.  The test_random_state_is_entangled test always passes with this fix.

```
================================== FAILURES ===================================
_______________________ test_random_state_is_entangled ________________________

    def test_random_state_is_entangled():
        """Tests that a Gaussian state generated at random is entangled."""
        state = Vacuum(2) >> Ggate(num_modes=2)
        mat = state.cov
        assert np.allclose(gp.log_negativity(mat), 0.0)
        assert np.allclose(
            gp.log_negativity(gp.physical_partial_transpose(mat, [0, 1])), 0.0, atol=1e-7
        )
        N1 = gp.log_negativity(gp.physical_partial_transpose(mat, [0]))
        N2 = gp.log_negativity(gp.physical_partial_transpose(mat, [1]))

>       assert N1 > 0
E       assert 0 > 0

tests/test_lab/test_states.py:223: AssertionError
```

### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [ ] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [ ] Ensure that the test suite passes, by running `make test`.

- [ ] Ensure that code and tests are properly formatted, by running `make format` or `black -l 100
      <filename>` on any relevant files. You will need to have the Black code format installed:
      `pip install black`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [ ] The Mr Mustard source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/) except line length.
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint mrmustard/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
