### PR TITLE
enable new TF and pip installation

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -22,6 +22,9 @@
 
 * Ensure all symplectic eigenvalues are returned by the `symplectic_eigenvals` function.
 
+* Ensured support for TensorFlow 2.16+, which would be chosen when installing with `pip`.
+  [(#406)](https://github.com/XanaduAI/MrMustard/pull/406)
+
 
 ### Documentation
 

--- a/mrmustard/math/backend_tensorflow.py
+++ b/mrmustard/math/backend_tensorflow.py
@@ -408,7 +408,6 @@ class BackendTensorflow(BackendBase):  # pragma: no cover
     # ~~~~~~~~~~~~~~~~~
 
     def DefaultEuclideanOptimizer(self) -> tf.keras.optimizers.legacy.Optimizer:
-        print(f"{distribution('tensorflow').version}\n{platform.system()}\n{platform.processor()}")
         use_legacy = Version(distribution("tensorflow").version) < Version("2.16.0")
         AdamOpt = tf.keras.optimizers.legacy.Adam if use_legacy else tf.keras.optimizers.Adam
         if not use_legacy and platform.system() == "Darwin" and platform.processor() == "arm":

--- a/mrmustard/math/backend_tensorflow.py
+++ b/mrmustard/math/backend_tensorflow.py
@@ -18,7 +18,7 @@
 
 from typing import Callable, List, Optional, Sequence, Tuple, Union
 
-from importlib.metadata import distribution
+from importlib import metadata
 import os
 import platform
 from warnings import warn
@@ -408,7 +408,7 @@ class BackendTensorflow(BackendBase):  # pragma: no cover
     # ~~~~~~~~~~~~~~~~~
 
     def DefaultEuclideanOptimizer(self) -> tf.keras.optimizers.legacy.Optimizer:
-        use_legacy = Version(distribution("tensorflow").version) < Version("2.16.0")
+        use_legacy = Version(metadata.distribution("tensorflow").version) < Version("2.16.0")
         AdamOpt = tf.keras.optimizers.legacy.Adam if use_legacy else tf.keras.optimizers.Adam
         if not use_legacy and platform.system() == "Darwin" and platform.processor() == "arm":
             warn(

--- a/mrmustard/math/backend_tensorflow.py
+++ b/mrmustard/math/backend_tensorflow.py
@@ -20,6 +20,9 @@ from typing import Callable, List, Optional, Sequence, Tuple, Union
 
 from importlib.metadata import distribution
 import os
+import platform
+from warnings import warn
+
 import numpy as np
 from semantic_version import Version
 import tensorflow_probability as tfp
@@ -405,8 +408,15 @@ class BackendTensorflow(BackendBase):  # pragma: no cover
     # ~~~~~~~~~~~~~~~~~
 
     def DefaultEuclideanOptimizer(self) -> tf.keras.optimizers.legacy.Optimizer:
+        print(f"{distribution('tensorflow').version}\n{platform.system()}\n{platform.processor()}")
         use_legacy = Version(distribution("tensorflow").version) < Version("2.16.0")
         AdamOpt = tf.keras.optimizers.legacy.Adam if use_legacy else tf.keras.optimizers.Adam
+        if not use_legacy and platform.system() == "Darwin" and platform.processor() == "arm":
+            warn(
+                "Mac ARM processor detected - MrMustard always trains using the latest Keras Adam "
+                "optimizer with TensorFlow 2.16+, but it is known to be slow on Mac+ARM. To use "
+                "the legacy optimizer, please downgrade TensorFlow to 2.15."
+            )
         return AdamOpt(learning_rate=0.001)
 
     def value_and_gradients(

--- a/mrmustard/math/backend_tensorflow.py
+++ b/mrmustard/math/backend_tensorflow.py
@@ -403,7 +403,14 @@ class BackendTensorflow(BackendBase):  # pragma: no cover
     # ~~~~~~~~~~~~~~~~~
 
     def DefaultEuclideanOptimizer(self) -> tf.keras.optimizers.legacy.Optimizer:
-        return tf.keras.optimizers.legacy.Adam(learning_rate=0.001)
+        try:
+            return tf.keras.optimizers.legacy.Adam(learning_rate=0.001)
+        except ImportError as e:  # pragma: no cover
+            raise ImportError(
+                "Importing the legacy Adam optimizer failed. If you are using TensorFlow 2.16+ "
+                "(perhaps due to installing MrMustard with pip), you need to set an environment "
+                "variable before using this optimizer:\n\texport TF_USE_LEGACY_KERAS=True"
+            ) from e
 
     def value_and_gradients(
         self, cost_fn: Callable, parameters: List[Trainable]

--- a/poetry.lock
+++ b/poetry.lock
@@ -3950,4 +3950,4 @@ ray = ["ray", "scikit-optimize"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.12"
-content-hash = "142dc82b0236a8c3675520518e2829b72d738f7f64d5590430bc4ad02ffb351b"
+content-hash = "b13dc2dc4d291a6f7a542e55f3f9ea174a2d0ae03a1ee058022a342779f4e713"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3950,4 +3950,4 @@ ray = ["ray", "scikit-optimize"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.12"
-content-hash = "9c43fec0bd367fcc2a77c66b1c3dfa37e18de243ec6ccf32a299b45f3eb746d5"
+content-hash = "142dc82b0236a8c3675520518e2829b72d738f7f64d5590430bc4ad02ffb351b"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2725,13 +2725,13 @@ rpds-py = ">=0.7.0"
 
 [[package]]
 name = "requests"
-version = "2.31.0"
+version = "2.32.3"
 description = "Python HTTP for Humans."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "requests-2.31.0-py3-none-any.whl", hash = "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f"},
-    {file = "requests-2.31.0.tar.gz", hash = "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"},
+    {file = "requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"},
+    {file = "requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ tensorflow-io-gcs-filesystem = [
     { version = ">= 0.23.1", markers = "platform_machine!='arm64' or platform_system!='Darwin'" },
     { version = "< 0.32.0", markers = "platform_system == 'Windows'" }
 ]
-tensorflow-probability = "^0.22.0"
+tensorflow-probability = { version = ">=0.22.0,<1.0", extras = ["tf"] }
 
 [tool.poetry.extras]
 ray = ["ray", "scikit-optimize"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ tensorflow-io-gcs-filesystem = [
     { version = "< 0.32.0", markers = "platform_system == 'Windows'" }
 ]
 tensorflow-probability = { version = ">=0.22.0,<1.0", extras = ["tf"] }
+semantic-version = "^2.10.0"
 
 [tool.poetry.extras]
 ray = ["ray", "scikit-optimize"]

--- a/tests/test_math/test_backend_manager.py
+++ b/tests/test_math/test_backend_manager.py
@@ -16,7 +16,7 @@
 Unit tests for the :class:`BackendManager`.
 """
 import math
-from unittest.mock import patch, PropertyMock, MagicMock
+from unittest.mock import patch, MagicMock
 
 import numpy as np
 import pytest
@@ -650,6 +650,9 @@ class TestBackendManager:
         mock_version.return_value = MagicMock(version="2.16.0")
 
         math._euclidean_opt = None  # just in case another test set it
-        with pytest.warns(UserWarning, match=r"Mac.*please downgrade TensorFlow to 2.15"):
-            opt = math.euclidean_opt
-        assert isinstance(opt, tf.keras.optimizers.Adam)
+        try:
+            with pytest.warns(UserWarning, match=r"Mac.*please downgrade TensorFlow to 2.15"):
+                opt = math.euclidean_opt
+            assert isinstance(opt, tf.keras.optimizers.Adam)
+        finally:
+            math._euclidean_opt = None  # reset after test passes

--- a/tests/test_math/test_backend_manager.py
+++ b/tests/test_math/test_backend_manager.py
@@ -16,8 +16,7 @@
 Unit tests for the :class:`BackendManager`.
 """
 import math
-from importlib.metadata import Distribution
-from unittest.mock import patch
+from unittest.mock import patch, PropertyMock, MagicMock
 
 import numpy as np
 import pytest
@@ -640,18 +639,17 @@ class TestBackendManager:
         results = [math.Categorical(probs, "") for _ in range(100)]
         assert len(set(results)) > 1
 
+    @patch("importlib.metadata.distribution")
     @patch("platform.processor")
     @patch("platform.system")
-    def test_euclidean_opt_warning(self, mock_system, mock_processor):
+    def test_euclidean_opt_warning(self, mock_system, mock_processor, mock_version):
         """Test that a warning is raised for M1/M2 Mac users with TF 2.16+."""
-        pytest.xfail(reason="no warnings filter applied")
         skip_np()
         mock_system.return_value = "Darwin"
         mock_processor.return_value = "arm"
+        mock_version.return_value = MagicMock(version="2.16.0")
 
         math._euclidean_opt = None  # just in case another test set it
-        with pytest.warns(
-            UserWarning, match=r"Mac.*please downgrade TensorFlow to 2.15"
-        ), patch.object(Distribution, "version", "2.16.0"):
+        with pytest.warns(UserWarning, match=r"Mac.*please downgrade TensorFlow to 2.15"):
             opt = math.euclidean_opt
         assert isinstance(opt, tf.keras.optimizers.Adam)

--- a/tests/test_math/test_backend_manager.py
+++ b/tests/test_math/test_backend_manager.py
@@ -17,13 +17,14 @@ Unit tests for the :class:`BackendManager`.
 """
 import math
 from importlib.metadata import Distribution
+from unittest.mock import patch
 
 import numpy as np
 import pytest
 import tensorflow as tf
-from unittest.mock import patch, MagicMock
 
 from mrmustard import math
+from ..conftest import skip_np
 
 
 # pylint: disable=protected-access, too-many-public-methods
@@ -643,6 +644,7 @@ class TestBackendManager:
     @patch("platform.system")
     def test_euclidean_opt_warning(self, mock_system, mock_processor):
         """Test that a warning is raised for M1/M2 Mac users with TF 2.16+."""
+        skip_np()
         mock_system.return_value = "Darwin"
         mock_processor.return_value = "arm"
 

--- a/tests/test_math/test_backend_manager.py
+++ b/tests/test_math/test_backend_manager.py
@@ -644,6 +644,7 @@ class TestBackendManager:
     @patch("platform.system")
     def test_euclidean_opt_warning(self, mock_system, mock_processor):
         """Test that a warning is raised for M1/M2 Mac users with TF 2.16+."""
+        pytest.xfail(reason="no warnings filter applied")
         skip_np()
         mock_system.return_value = "Darwin"
         mock_processor.return_value = "arm"


### PR DESCRIPTION
**Context:**
If you install MrMustard with `pip`, it will install the latest tensorflow, but that does not allow the use of `tf.keras.optimizers.legacy.Adam`. We need the non-legacy version, but it's [slow on M1/M2 Macs](https://stackoverflow.com/questions/77222463/is-there-a-way-to-change-adam-to-legacy-when-using-mac-m1-m2-in-tensorflow). Some manual effort is required to support the legacy optimizer with TF 2.16+, and it seems out of the door anyway. I'd advise Mac M1/M2 users to install TF 2.15 in advance if they want the better optimizer for them (until TF fixes it, at least).

**Description of the Change:**
- Add the `tf` extra to `tensorflow-probability`. This one's a bit hacky, because that extra doesn't exist until 0.24+, but if you are using 0.24+ (which you would be with a `pip install`), you need it to use Keras optimizers. The good news is that `poetry` doesn't seem to mind, and totally ignores it for our lockfile (which has it pinned to 0.22)
- Use the non-legacy optimizer for TF 2.16+ since it will work out of the box
- Raise a warning to advise M1/M2 Mac users to downgrade to TF 2.15 (if they're on 2.16+)

**Benefits:**
If users pip-install MrMustard, it will still work (even with TF 2.16)

**Possible Drawbacks:**
Mac M1/M2 users will have slow optimizations if they get a fresh environment and `pip install mrmustard`. They can avoid this by pre-installing TF 2.15 to their environment. I've added a warning to tell them clearly what to do.

**Related GitHub Issues:**
Fixes #381 by adding 2.16 support