### PR TITLE
QtoB and other improvements

### DIFF
--- a/mrmustard/lab_dev/circuit_components.py
+++ b/mrmustard/lab_dev/circuit_components.py
@@ -77,12 +77,7 @@ class CircuitComponent:
         ib = tuple(sorted(modes_in_bra))
         ok = tuple(sorted(modes_out_ket))
         ik = tuple(sorted(modes_in_ket))
-        if (
-            ob != modes_out_bra
-            or ib != modes_in_bra
-            or ok != modes_out_ket
-            or ik != modes_in_ket
-        ):
+        if ob != modes_out_bra or ib != modes_in_bra or ok != modes_out_ket or ik != modes_in_ket:
             offsets = [len(ob), len(ob) + len(ib), len(ob) + len(ib) + len(ok)]
             perm = (
                 tuple(np.argsort(modes_out_bra))
@@ -177,11 +172,7 @@ class CircuitComponent:
         # Here for a CircuitComponent, we need to add this map four times: BtoQ on out_ket
         # wires, BtoQ.dual on in_ket wires, BtoQ.adjoint on out_bra wires and BtoQ.adjoint.dual
         # on in_bra wires.
-        kets_done = (
-            BtoQ(self.wires.input.ket.modes).dual
-            @ self
-            @ BtoQ(self.wires.output.ket.modes)
-        )
+        kets_done = BtoQ(self.wires.input.ket.modes).dual @ self @ BtoQ(self.wires.output.ket.modes)
         all_done = (
             BtoQ(self.wires.input.bra.modes).adjoint.dual
             @ kets_done
@@ -290,9 +281,7 @@ class CircuitComponent:
 
         return ret
 
-    def to_fock(
-        self, shape: Optional[Union[int, Iterable[int]]] = None
-    ) -> CircuitComponent:
+    def to_fock(self, shape: Optional[Union[int, Iterable[int]]] = None) -> CircuitComponent:
         r"""
         Returns a circuit component with the same attributes as this component, but
         with ``Fock`` representation.
@@ -371,9 +360,7 @@ class CircuitComponent:
         """
         return self.representation == other.representation and self.wires == other.wires
 
-    def _matmul_indices(
-        self, other: CircuitComponent
-    ) -> tuple[tuple[int, ...], tuple[int, ...]]:
+    def _matmul_indices(self, other: CircuitComponent) -> tuple[tuple[int, ...], tuple[int, ...]]:
         r"""
         Finds the indices of the wires being contracted on the bra and ket sides of the components.
         """
@@ -439,9 +426,7 @@ class CircuitComponent:
         wires_temp = Template(filename=os.path.dirname(__file__) + "/assets/wires.txt")  # nosec
         wires_temp_uni = wires_temp.render_unicode(wires=self.wires)
         wires_temp_uni = (
-            wires_temp_uni.replace("<body>", "")
-            .replace("</body>", "")
-            .replace("h1", "h3")
+            wires_temp_uni.replace("<body>", "").replace("</body>", "").replace("h1", "h3")
         )
 
         rep_temp = (
@@ -452,11 +437,7 @@ class CircuitComponent:
             )  # nosec
         )
         rep_temp_uni = rep_temp.render_unicode(rep=self.representation)
-        rep_temp_uni = (
-            rep_temp_uni.replace("<body>", "")
-            .replace("</body>", "")
-            .replace("h1", "h3")
-        )
+        rep_temp_uni = rep_temp_uni.replace("<body>", "").replace("</body>", "").replace("h1", "h3")
 
         display(HTML(temp.render(comp=self, wires=wires_temp_uni, rep=rep_temp_uni)))
 

--- a/mrmustard/lab_dev/circuit_components.py
+++ b/mrmustard/lab_dev/circuit_components.py
@@ -121,7 +121,7 @@ class CircuitComponent:
         Returns:
             A circuit component of type ``cls`` with the given attributes.
         """
-        types = {"Ket", "DM", "Unitary", "Channel"}
+        types = {"Ket", "DM", "Unitary", "Operator", "Channel", "Map"}
         for tp in cls.mro():
             if tp.__name__ in types:
                 ret = tp()
@@ -185,7 +185,6 @@ class CircuitComponent:
             modes_out_ket: The output modes on the ket side of this component.
             modes_in_ket: The input modes on the ket side of this component.
             name: The name of this component.
-            kwargs: keyword arguments like modes_in, modes_out and modes.
 
         Returns:
             A circuit component with the given quadrature representation.
@@ -202,14 +201,14 @@ class CircuitComponent:
             Bargmann(*triple), wires
         )  # this is actually in quadrature
         kets_done = (
-            BtoQ(wires.input.ket.modes).inverse().dual
+            BtoQ(wires.output.ket.modes).inverse()
             @ Q
-            @ BtoQ(wires.output.ket.modes).inverse()
+            @ BtoQ(wires.input.ket.modes).inverse().dual
         )
         all_done = (
-            BtoQ(wires.input.bra.modes).inverse().adjoint.dual
+            BtoQ(wires.output.bra.modes).inverse().adjoint
             @ kets_done
-            @ BtoQ(wires.output.bra.modes).inverse().adjoint
+            @ BtoQ(wires.input.bra.modes).inverse().adjoint.dual
         )
         return cls._from_attributes(all_done.representation, wires, name)
 
@@ -226,14 +225,14 @@ class CircuitComponent:
         # wires, BtoQ.dual on in_ket wires, BtoQ.adjoint on out_bra wires and BtoQ.adjoint.dual
         # on in_bra wires.
         kets_done = (
-            BtoQ(self.wires.input.ket.modes).dual
+            BtoQ(self.wires.output.ket.modes)
             @ self
-            @ BtoQ(self.wires.output.ket.modes)
+            @ BtoQ(self.wires.input.ket.modes).dual
         )
         all_done = (
-            BtoQ(self.wires.input.bra.modes).adjoint.dual
+            BtoQ(self.wires.output.bra.modes).adjoint
             @ kets_done
-            @ BtoQ(self.wires.output.bra.modes).adjoint
+            @ BtoQ(self.wires.input.bra.modes).adjoint.dual
         )
         return all_done.representation.data
 

--- a/mrmustard/lab_dev/circuit_components.py
+++ b/mrmustard/lab_dev/circuit_components.py
@@ -43,22 +43,22 @@ class CircuitComponent:
     unphysical ``wired'' objects) that can be placed in Mr Mustard's quantum circuits.
 
     Args:
-        name: The name of this component.
         representation: A representation for this circuit component.
         modes_out_bra: The output modes on the bra side of this component.
         modes_in_bra: The input modes on the bra side of this component.
         modes_out_ket: The output modes on the ket side of this component.
         modes_in_ket: The input modes on the ket side of this component.
+        name: The name of this component.
     """
 
     def __init__(
         self,
-        name: Optional[str] = None,
         representation: Optional[Bargmann | Fock] = None,
         modes_out_bra: Optional[Sequence[int]] = None,
         modes_in_bra: Optional[Sequence[int]] = None,
         modes_out_ket: Optional[Sequence[int]] = None,
         modes_in_ket: Optional[Sequence[int]] = None,
+        name: Optional[str] = None,
     ) -> None:
         modes_out_bra = modes_out_bra or ()
         modes_in_bra = modes_in_bra or ()
@@ -77,7 +77,12 @@ class CircuitComponent:
         ib = tuple(sorted(modes_in_bra))
         ok = tuple(sorted(modes_out_ket))
         ik = tuple(sorted(modes_in_ket))
-        if ob != modes_out_bra or ib != modes_in_bra or ok != modes_out_ket or ik != modes_in_ket:
+        if (
+            ob != modes_out_bra
+            or ib != modes_in_bra
+            or ok != modes_out_ket
+            or ik != modes_in_ket
+        ):
             offsets = [len(ob), len(ob) + len(ib), len(ob) + len(ib) + len(ok)]
             perm = (
                 tuple(np.argsort(modes_out_bra))
@@ -90,7 +95,10 @@ class CircuitComponent:
 
     @classmethod
     def _from_attributes(
-        cls, name: str, representation: Representation, wires: Wires
+        cls,
+        representation: Representation,
+        wires: Wires,
+        name: Optional[str] = None,
     ) -> CircuitComponent:
         r"""
         Initializes a circuit component from its attributes (a name, a ``Wires``,
@@ -106,9 +114,9 @@ class CircuitComponent:
         wires on the bra side.
 
         Args:
-            name: The name of this component.
             representation: A representation for this circuit component.
             wires: The wires of this component.
+            name: The name of this component.
 
         Returns:
             A circuit component of type ``cls`` with the given attributes.
@@ -121,7 +129,7 @@ class CircuitComponent:
         else:
             ret = CircuitComponent()
 
-        ret._name = name
+        ret._name = name or tp.__name__ + "".join(str(m) for m in sorted(wires.modes))
         ret._representation = representation
         ret._wires = wires
 
@@ -162,20 +170,22 @@ class CircuitComponent:
         The quadrature representation of this circuit component.
         """
         from mrmustard.lab_dev.circuit_components_utils import (  # pylint: disable=import-outside-toplevel
-            BtoQMap,
+            BtoQ,
         )
 
-        # The representation change from Bargmann into quadrature is to use the BtoQMap.
-        # Here for a CircuitComponent, we need to add this map four times: BtoQMap on out_ket
-        # wires, BtoQMap.dual on in_ket wires, BtoQMap.adjoint on out_bra wires and BtoQMap.adjoint.dual
+        # The representation change from Bargmann into quadrature is to use the BtoQ.
+        # Here for a CircuitComponent, we need to add this map four times: BtoQ on out_ket
+        # wires, BtoQ.dual on in_ket wires, BtoQ.adjoint on out_bra wires and BtoQ.adjoint.dual
         # on in_bra wires.
         kets_done = (
-            BtoQMap(self.wires.input.ket.modes).dual @ self @ BtoQMap(self.wires.output.ket.modes)
+            BtoQ(self.wires.input.ket.modes).dual
+            @ self
+            @ BtoQ(self.wires.output.ket.modes)
         )
         all_done = (
-            BtoQMap(self.wires.input.bra.modes).adjoint.dual
+            BtoQ(self.wires.input.bra.modes).adjoint.dual
             @ kets_done
-            @ BtoQMap(self.wires.output.bra.modes).adjoint
+            @ BtoQ(self.wires.output.bra.modes).adjoint
         )
         return all_done.representation.data
 
@@ -280,7 +290,9 @@ class CircuitComponent:
 
         return ret
 
-    def to_fock(self, shape: Optional[Union[int, Iterable[int]]] = None) -> CircuitComponent:
+    def to_fock(
+        self, shape: Optional[Union[int, Iterable[int]]] = None
+    ) -> CircuitComponent:
         r"""
         Returns a circuit component with the same attributes as this component, but
         with ``Fock`` representation.
@@ -306,9 +318,9 @@ class CircuitComponent:
                 defaults to the value of ``AUTOCUTOFF_MAX_CUTOFF`` in the settings.
         """
         return self.__class__._from_attributes(
-            self.name,
             to_fock(self.representation, shape=shape),
             self.wires,
+            self.name,
         )
 
     def __add__(self, other: CircuitComponent) -> CircuitComponent:
@@ -320,7 +332,7 @@ class CircuitComponent:
             raise ValueError(msg)
         rep = self.representation + other.representation
         name = self.name if self.name == other.name else ""
-        return self._from_attributes(name, rep, self.wires)
+        return self._from_attributes(rep, self.wires, name)
 
     def __sub__(self, other: CircuitComponent) -> CircuitComponent:
         r"""
@@ -331,13 +343,13 @@ class CircuitComponent:
             raise ValueError(msg)
         rep = self.representation - other.representation
         name = self.name if self.name == other.name else ""
-        return self._from_attributes(name, rep, self.wires)
+        return self._from_attributes(rep, self.wires, name)
 
     def __mul__(self, other: Scalar) -> CircuitComponent:
         r"""
         Implements the multiplication by a scalar on the right.
         """
-        return self._from_attributes(self.name, self.representation * other, self.wires)
+        return self._from_attributes(self.representation * other, self.wires, self.name)
 
     def __rmul__(self, other: Scalar) -> CircuitComponent:
         r"""
@@ -349,7 +361,7 @@ class CircuitComponent:
         r"""
         Implements the division by a scalar for circuit components.
         """
-        return self._from_attributes(self.name, self.representation / other, self.wires)
+        return self._from_attributes(self.representation / other, self.wires, self.name)
 
     def __eq__(self, other) -> bool:
         r"""
@@ -359,7 +371,9 @@ class CircuitComponent:
         """
         return self.representation == other.representation and self.wires == other.wires
 
-    def _matmul_indices(self, other: CircuitComponent) -> tuple[tuple[int, ...], tuple[int, ...]]:
+    def _matmul_indices(
+        self, other: CircuitComponent
+    ) -> tuple[tuple[int, ...], tuple[int, ...]]:
         r"""
         Finds the indices of the wires being contracted on the bra and ket sides of the components.
         """
@@ -381,7 +395,7 @@ class CircuitComponent:
         idx_z, idx_zconj = self._matmul_indices(other)
         rep = self.representation[idx_z] @ other.representation[idx_zconj]
         rep = rep.reorder(perm) if perm else rep
-        return CircuitComponent._from_attributes(None, rep, wires_ret)
+        return CircuitComponent._from_attributes(rep, wires_ret, None)
 
     def __rshift__(self, other: CircuitComponent) -> CircuitComponent:
         r"""
@@ -415,7 +429,7 @@ class CircuitComponent:
         raise ValueError(msg)
 
     def __repr__(self) -> str:
-        return f"CircuitComponent(name={self.name or None}, modes={self.modes})"
+        return f"CircuitComponent(modes={self.modes}, name={self.name or None})"
 
     def _repr_html_(self):  # pragma: no cover
         temp = Template(
@@ -425,7 +439,9 @@ class CircuitComponent:
         wires_temp = Template(filename=os.path.dirname(__file__) + "/assets/wires.txt")  # nosec
         wires_temp_uni = wires_temp.render_unicode(wires=self.wires)
         wires_temp_uni = (
-            wires_temp_uni.replace("<body>", "").replace("</body>", "").replace("h1", "h3")
+            wires_temp_uni.replace("<body>", "")
+            .replace("</body>", "")
+            .replace("h1", "h3")
         )
 
         rep_temp = (
@@ -436,7 +452,11 @@ class CircuitComponent:
             )  # nosec
         )
         rep_temp_uni = rep_temp.render_unicode(rep=self.representation)
-        rep_temp_uni = rep_temp_uni.replace("<body>", "").replace("</body>", "").replace("h1", "h3")
+        rep_temp_uni = (
+            rep_temp_uni.replace("<body>", "")
+            .replace("</body>", "")
+            .replace("h1", "h3")
+        )
 
         display(HTML(temp.render(comp=self, wires=wires_temp_uni, rep=rep_temp_uni)))
 

--- a/mrmustard/lab_dev/circuit_components_utils.py
+++ b/mrmustard/lab_dev/circuit_components_utils.py
@@ -24,7 +24,7 @@ from typing import Sequence
 
 from mrmustard.physics import triples
 from .circuit_components import CircuitComponent
-from mrmustard.lab_dev.transformations import Map, Operator
+from mrmustard.lab_dev.transformations import Map, Operation
 from ..physics.representations import Bargmann
 
 __all__ = ["TraceOut", "BtoPS", "BtoQ"]
@@ -63,11 +63,12 @@ class TraceOut(CircuitComponent):
         self,
         modes: Sequence[int],
     ):
-        super().__init__(modes_in_ket=modes, modes_in_bra=modes, name="Tr")
-
-    @property
-    def representation(self) -> Bargmann:
-        return Bargmann(*triples.identity_Abc(len(self.modes)))
+        super().__init__(
+            modes_in_ket=modes,
+            modes_in_bra=modes,
+            representation=Bargmann(*triples.identity_Abc(len(modes))),
+            name="Tr",
+        )
 
 
 class BtoPS(Map):
@@ -88,16 +89,15 @@ class BtoPS(Map):
         super().__init__(
             modes_out=modes,
             modes_in=modes,
+            representation=Bargmann(
+                *triples.displacement_map_s_parametrized_Abc(s, len(modes))
+            ),
             name="BtoPS",
         )
         self.s = s
 
-    @property
-    def representation(self) -> Bargmann:
-        return Bargmann(*triples.displacement_map_s_parametrized_Abc(self.s, len(self.modes)))
 
-
-class BtoQ(Operator):
+class BtoQ(Operation):
     r"""The kernel for the change of representation from ``Bargmann`` into quadrature.
 
     Used internally as a ``Unitary`` for transformations between representations on the ``Ket`` Wire.
@@ -116,9 +116,6 @@ class BtoQ(Operator):
         super().__init__(
             modes_out=modes,
             modes_in=modes,
+            representation=Bargmann(*triples.bargmann_to_quadrature_Abc(len(modes))),
             name="BtoQ",
         )
-
-    @property
-    def representation(self) -> Bargmann:
-        return Bargmann(*triples.bargmann_to_quadrature_Abc(len(self.modes)))

--- a/mrmustard/lab_dev/circuit_components_utils.py
+++ b/mrmustard/lab_dev/circuit_components_utils.py
@@ -24,9 +24,10 @@ from typing import Sequence
 
 from mrmustard.physics import triples
 from .circuit_components import CircuitComponent
+from mrmustard.lab_dev.transformations import Map, Operator
 from ..physics.representations import Bargmann
 
-__all__ = ["TraceOut", "DsMap", "BtoQMap"]
+__all__ = ["TraceOut", "BtoPS", "BtoQ"]
 
 
 class TraceOut(CircuitComponent):
@@ -62,15 +63,15 @@ class TraceOut(CircuitComponent):
         self,
         modes: Sequence[int],
     ):
-        super().__init__("Tr", modes_in_ket=modes, modes_in_bra=modes)
+        super().__init__(modes_in_ket=modes, modes_in_bra=modes, name="Tr")
 
     @property
     def representation(self) -> Bargmann:
         return Bargmann(*triples.identity_Abc(len(self.modes)))
 
 
-class DsMap(CircuitComponent):
-    r"""The `s`-parametrized ``Dgate`` as a ``Channel``.
+class BtoPS(Map):
+    r"""The `s`-parametrized ``Dgate`` as a ``Map``.
 
     Used internally as a ``Channel`` for transformations between representations.
 
@@ -85,20 +86,20 @@ class DsMap(CircuitComponent):
         s: float,
     ):
         super().__init__(
-            "DsMap",
-            modes_out_bra=modes,
-            modes_in_bra=modes,
-            modes_out_ket=modes,
-            modes_in_ket=modes,
+            modes_out=modes,
+            modes_in=modes,
+            name="BtoPS",
         )
         self.s = s
 
     @property
     def representation(self) -> Bargmann:
-        return Bargmann(*triples.displacement_map_s_parametrized_Abc(self.s, len(self.modes)))
+        return Bargmann(
+            *triples.displacement_map_s_parametrized_Abc(self.s, len(self.modes))
+        )
 
 
-class BtoQMap(CircuitComponent):
+class BtoQ(Operator):
     r"""The kernel for the change of representation from ``Bargmann`` into quadrature.
 
     Used internally as a ``Unitary`` for transformations between representations on the ``Ket`` Wire.
@@ -115,9 +116,9 @@ class BtoQMap(CircuitComponent):
         modes: Sequence[int],
     ):
         super().__init__(
-            "BtoQMap",
-            modes_out_ket=modes,
-            modes_in_ket=modes,
+            modes_out=modes,
+            modes_in=modes,
+            name="BtoQ",
         )
 
     @property

--- a/mrmustard/lab_dev/circuit_components_utils.py
+++ b/mrmustard/lab_dev/circuit_components_utils.py
@@ -94,9 +94,7 @@ class BtoPS(Map):
 
     @property
     def representation(self) -> Bargmann:
-        return Bargmann(
-            *triples.displacement_map_s_parametrized_Abc(self.s, len(self.modes))
-        )
+        return Bargmann(*triples.displacement_map_s_parametrized_Abc(self.s, len(self.modes)))
 
 
 class BtoQ(Operator):

--- a/mrmustard/lab_dev/states/base.py
+++ b/mrmustard/lab_dev/states/base.py
@@ -330,9 +330,7 @@ class State(CircuitComponent):
                 The covariance matrix, the mean vector and the coefficient of the state in s-parametrized phase space.
         """
         if not isinstance(self.representation, Bargmann):
-            raise ValueError(
-                f"Can not calculate phase space for ``{self.name}`` object."
-            )
+            raise ValueError(f"Can not calculate phase space for ``{self.name}`` object.")
 
         new_state = self >> BtoPS(self.modes, s=s)  # pylint: disable=protected-access
         return bargmann_Abc_to_phasespace_cov_means(
@@ -426,17 +424,13 @@ class State(CircuitComponent):
         fig.update_yaxes(range=pbounds, title_text="p", row=2, col=1)
 
         # X quadrature probability distribution
-        fig_11 = go.Scatter(
-            x=x, y=prob_x, line=dict(color="steelblue", width=2), name="Prob(x)"
-        )
+        fig_11 = go.Scatter(x=x, y=prob_x, line=dict(color="steelblue", width=2), name="Prob(x)")
         fig.add_trace(fig_11, row=1, col=1)
         fig.update_xaxes(range=xbounds, row=1, col=1, showticklabels=False)
         fig.update_yaxes(title_text="Prob(x)", range=(0, max(prob_x)), row=1, col=1)
 
         # P quadrature probability distribution
-        fig_22 = go.Scatter(
-            x=prob_p, y=-p, line=dict(color="steelblue", width=2), name="Prob(p)"
-        )
+        fig_22 = go.Scatter(x=prob_p, y=-p, line=dict(color="steelblue", width=2), name="Prob(p)")
         fig.add_trace(fig_22, row=2, col=2)
         fig.update_xaxes(title_text="Prob(p)", range=(0, max(prob_p)), row=2, col=2)
         fig.update_yaxes(range=pbounds, row=2, col=2, showticklabels=False)
@@ -531,14 +525,10 @@ class State(CircuitComponent):
             )
         )
         fig.update_traces(
-            contours_y=dict(
-                show=True, usecolormap=True, highlightcolor="red", project_y=False
-            )
+            contours_y=dict(show=True, usecolormap=True, highlightcolor="red", project_y=False)
         )
         fig.update_traces(
-            contours_x=dict(
-                show=True, usecolormap=True, highlightcolor="yellow", project_x=False
-            )
+            contours_x=dict(show=True, usecolormap=True, highlightcolor="yellow", project_x=False)
         )
         fig.update_scenes(
             xaxis_title_text="x",
@@ -580,9 +570,7 @@ class State(CircuitComponent):
         dm = math.sum(state.representation.array, axes=[0])
 
         fig = go.Figure(
-            data=go.Heatmap(
-                z=abs(dm), colorscale="viridis", name="abs(ρ)", showscale=False
-            )
+            data=go.Heatmap(z=abs(dm), colorscale="viridis", name="abs(ρ)", showscale=False)
         )
         fig.update_yaxes(autorange="reversed")
         fig.update_layout(
@@ -842,12 +830,12 @@ class DM(State):
         wires = Wires(modes_out_bra=modes, modes_out_ket=modes)
 
         idxz = [i for i, m in enumerate(self.modes) if m not in modes]
-        idxz_conj = [
-            i + len(self.modes) for i, m in enumerate(self.modes) if m not in modes
-        ]
+        idxz_conj = [i + len(self.modes) for i, m in enumerate(self.modes) if m not in modes]
         representation = self.representation.trace(idxz, idxz_conj)
 
-        return self.__class__._from_attributes(representation, wires, self.name)  # pylint: disable=protected-access
+        return self.__class__._from_attributes(
+            representation, wires, self.name
+        )  # pylint: disable=protected-access
 
 
 class Ket(State):
@@ -1006,11 +994,7 @@ class Ket(State):
         leftover_modes = self.wires.modes - operator.wires.modes
         if op_type is OperatorType.KET_LIKE:
             result = self @ operator.dual
-            result = (
-                result >> TraceOut(leftover_modes)
-                if leftover_modes
-                else result @ result.dual
-            )
+            result = result >> TraceOut(leftover_modes) if leftover_modes else result @ result.dual
         elif op_type is OperatorType.DM_LIKE:
             result = self @ (self.adjoint @ operator.dual)
             if leftover_modes:

--- a/mrmustard/lab_dev/states/states.py
+++ b/mrmustard/lab_dev/states/states.py
@@ -29,7 +29,14 @@ from mrmustard.physics import triples
 from .base import Ket, DM
 from ..utils import make_parameter, reshape_params
 
-__all__ = ["Coherent", "DisplacedSqueezed", "Number", "SqueezedVacuum", "Thermal", "Vacuum"]
+__all__ = [
+    "Coherent",
+    "DisplacedSqueezed",
+    "Number",
+    "SqueezedVacuum",
+    "Thermal",
+    "Vacuum",
+]
 
 
 #  ~~~~~~~~~~~
@@ -83,7 +90,7 @@ class Coherent(Ket):
         x_bounds: Tuple[Optional[float], Optional[float]] = (None, None),
         y_bounds: Tuple[Optional[float], Optional[float]] = (None, None),
     ):
-        super().__init__("Coherent", modes=modes)
+        super().__init__(modes=modes, name="Coherent")
         self._add_parameter(make_parameter(x_trainable, x, "x", x_bounds))
         self._add_parameter(make_parameter(y_trainable, y, "y", y_bounds))
 
@@ -139,7 +146,7 @@ class DisplacedSqueezed(Ket):
         r_bounds: Tuple[Optional[float], Optional[float]] = (None, None),
         phi_bounds: Tuple[Optional[float], Optional[float]] = (None, None),
     ):
-        super().__init__("DisplacedSqueezed", modes=modes)
+        super().__init__(modes=modes, name="DisplacedSqueezed")
         self._add_parameter(make_parameter(x_trainable, x, "x", x_bounds))
         self._add_parameter(make_parameter(y_trainable, y, "y", y_bounds))
         self._add_parameter(make_parameter(r_trainable, r, "r", r_bounds))
@@ -192,7 +199,7 @@ class Number(Ket):
         n: Union[int, Sequence[int]],
         cutoffs: Optional[Union[int, Sequence[int]]] = None,
     ) -> None:
-        super().__init__("N", modes=modes)
+        super().__init__(modes=modes, name="N")
 
         self._n = math.atleast_1d(n)
         if len(self._n) == 1:
@@ -260,7 +267,7 @@ class SqueezedVacuum(Ket):
         r_bounds: Tuple[Optional[float], Optional[float]] = (None, None),
         phi_bounds: Tuple[Optional[float], Optional[float]] = (None, None),
     ):
-        super().__init__("SqueezedVacuum", modes=modes)
+        super().__init__(modes=modes, name="SqueezedVacuum")
         self._add_parameter(make_parameter(r_trainable, r, "r", r_bounds))
         self._add_parameter(make_parameter(phi_trainable, phi, "phi", phi_bounds))
 
@@ -302,7 +309,7 @@ class Vacuum(Ket):
         self,
         modes: Sequence[int],
     ) -> None:
-        super().__init__("Vac", modes=modes)
+        super().__init__(modes=modes, name="Vac")
 
     @property
     def representation(self) -> Bargmann:
@@ -343,7 +350,7 @@ class Thermal(DM):
         nbar_trainable: bool = False,
         nbar_bounds: Tuple[Optional[float], Optional[float]] = (0, None),
     ) -> None:
-        super().__init__("Thermal", modes=modes)
+        super().__init__(modes=modes, name="Thermal")
         self._add_parameter(make_parameter(nbar_trainable, nbar, "nbar", nbar_bounds))
 
     @property

--- a/mrmustard/lab_dev/transformations/base.py
+++ b/mrmustard/lab_dev/transformations/base.py
@@ -32,7 +32,7 @@ from mrmustard.lab_dev.wires import Wires
 from mrmustard.physics.representations import Bargmann
 from ..circuit_components import CircuitComponent
 
-__all__ = ["Transformation", "Unitary", "Channel"]
+__all__ = ["Transformation", "Operator", "Unitary", "Map", "Channel"]
 
 
 class Transformation(CircuitComponent):
@@ -42,25 +42,69 @@ class Transformation(CircuitComponent):
 
     def inverse(self) -> Transformation:
         r"""Returns the inverse of the transformation."""
+        if not len(self.wires.input) == len(self.wires.output):
+            raise NotImplementedError(
+                "Only Transformations with the same number of input and output wires are supported."
+            )
         if not isinstance(self.representation, Bargmann):
             raise NotImplementedError("Only Bargmann representation is supported.")
         if self.representation.ansatz.batch_size > 1:
             raise NotImplementedError("Batched transformations are not supported.")
+
+        # compute the inverse
         A, b, _ = self.dual.representation.conj().triple  # apply X
-        almost_inverse = self.__class__.from_bargmann(
-            [0], (math.inv(A[0]), -math.inv(A[0]) @ b[0], 1 + 0j)
+        almost_inverse = self.__class__._from_attributes(
+            Bargmann(math.inv(A[0]), -math.inv(A[0]) @ b[0], 1 + 0j),
+            self.wires,
+            "",
         )
         almost_identity = (
             self >> almost_inverse
         )  # TODO: this is not efficient, need to get c from formula
         invert_this_c = almost_identity.representation.c
-        actual_inverse = self.__class__.from_bargmann(
-            [0], (math.inv(A[0]), -math.inv(A[0]) @ b[0], 1 / invert_this_c)
+        actual_inverse = self.__class__._from_attributes(
+            Bargmann(math.inv(A[0]), -math.inv(A[0]) @ b[0], 1 / invert_this_c),
+            self.wires,
+            self.name + "_inv",
         )
         return actual_inverse
 
 
-class Unitary(Transformation):
+class Operator(Transformation):
+    r"""A CircuitComponent with input and output wires, only on the ket side.
+    This class essentially relaxes the requirement that Unitaries have that
+    the input and output modes must be the same."""
+
+    def __init__(
+        self,
+        modes_out: tuple[int, ...] = (),
+        modes_in: tuple[int, ...] = (),
+        name: Optional[str] = None,
+    ):
+        super().__init__(
+            modes_out_ket=modes_in,
+            modes_in_ket=modes_out,
+            name=name or "Op" + "".join(str(m) for m in modes_in),
+        )
+
+    @classmethod
+    def from_bargmann(
+        cls,
+        modes_out: Sequence[int],
+        modes_in: Sequence[int],
+        triple: tuple[ComplexMatrix, ComplexVector, complex],
+        name: Optional[str] = None,
+    ) -> Operator:
+        A = math.astensor(triple[0])
+        b = math.astensor(triple[1])
+        c = math.astensor(triple[2])
+        shape_check(A, b, len(modes_out) + len(modes_in), "Bargmann")
+        return Operator._from_attributes(
+            Bargmann(A, b, c), Wires(set(), set(), set(modes_out), set(modes_in)), name
+        )
+
+
+class Unitary(Operator):
     r"""
     Base class for all unitary transformations.
 
@@ -71,9 +115,9 @@ class Unitary(Transformation):
 
     def __init__(self, name: Optional[str] = None, modes: tuple[int, ...] = ()):
         super().__init__(
-            name or "U" + "".join(str(m) for m in modes),
-            modes_in_ket=modes,
-            modes_out_ket=modes,
+            modes_in=modes,
+            modes_out=modes,
+            name=name or "U" + "".join(str(m) for m in modes),
         )
 
     def __rshift__(self, other: CircuitComponent) -> CircuitComponent:
@@ -87,9 +131,9 @@ class Unitary(Transformation):
         ret = super().__rshift__(other)
 
         if isinstance(other, Unitary):
-            return Unitary._from_attributes("", ret.representation, ret.wires)
+            return Unitary._from_attributes(ret.representation, ret.wires, "")
         elif isinstance(other, Channel):
-            return Channel._from_attributes("", ret.representation, ret.wires)
+            return Channel._from_attributes(ret.representation, ret.wires, "")
         return ret
 
     def __repr__(self) -> str:
@@ -107,7 +151,28 @@ class Unitary(Transformation):
         c = math.astensor(triple[2])
         shape_check(A, b, 2 * len(modes), "Bargmann")
         s = set(modes)
-        return Unitary._from_attributes(name, Bargmann(A, b, c), Wires(set(), set(), s, s))
+        return Unitary._from_attributes(
+            representation=Bargmann(A, b, c), wires=Wires(set(), set(), s, s), name=name
+        )
+
+
+class Map(Transformation):
+    r"""A CircuitComponent with input and output wires and same modes on bra and ket sides.
+    More general than Channels, which need to be CPTP."""
+
+    def __init__(
+        self,
+        modes_out: tuple[int, ...] = (),
+        modes_in: tuple[int, ...] = (),
+        name: Optional[str] = None,
+    ):
+        super().__init__(
+            modes_out_bra=modes_in,
+            modes_in_bra=modes_out,
+            modes_out_ket=modes_in,
+            modes_in_ket=modes_out,
+            name=name or "Map",
+        )
 
 
 class Channel(Transformation):
@@ -121,11 +186,11 @@ class Channel(Transformation):
 
     def __init__(self, name: Optional[str] = None, modes: tuple[int, ...] = ()):
         super().__init__(
-            name or "Ch" + "".join(str(m) for m in modes),
             modes_in_ket=modes,
             modes_out_ket=modes,
             modes_in_bra=modes,
             modes_out_bra=modes,
+            name=name or "Ch" + "".join(str(m) for m in modes),
         )
 
     def __rshift__(self, other: CircuitComponent) -> CircuitComponent:
@@ -139,7 +204,9 @@ class Channel(Transformation):
         ret = super().__rshift__(other)
 
         if isinstance(other, (Unitary, Channel)):
-            return Channel._from_attributes("", ret.representation, ret.wires)
+            return Channel._from_attributes(
+                representation=ret.representation, wires=ret.wires
+            )
         return ret
 
     def __repr__(self) -> str:
@@ -158,4 +225,6 @@ class Channel(Transformation):
         c = math.astensor(triple[2])
         shape_check(A, b, 4 * len(modes), "Bargmann")
         s = set(modes)
-        return Channel._from_attributes(name, Bargmann(A, b, c), Wires(s, s, s, s))
+        return Channel._from_attributes(
+            representation=Bargmann(A, b, c), wires=Wires(s, s, s, s), name=name
+        )

--- a/mrmustard/lab_dev/transformations/base.py
+++ b/mrmustard/lab_dev/transformations/base.py
@@ -29,7 +29,7 @@ from mrmustard.utils.typing import ComplexMatrix, ComplexVector, RealMatrix, Rea
 from mrmustard import math
 from mrmustard.lab_dev.utils import shape_check
 from mrmustard.lab_dev.wires import Wires
-from mrmustard.physics.representations import Bargmann
+from mrmustard.physics.representations import Bargmann, Fock
 from mrmustard import physics
 from ..circuit_components import CircuitComponent
 
@@ -87,13 +87,15 @@ class Operator(Transformation):
 
     def __init__(
         self,
-        modes_out_ket: tuple[int, ...] = (),
-        modes_in_ket: tuple[int, ...] = (),
+        representation: Bargmann | Fock = None,
+        modes_out: tuple[int, ...] = (),
+        modes_in: tuple[int, ...] = (),
         name: Optional[str] = None,
     ):
         super().__init__(
-            modes_out_ket=modes_in_ket,
-            modes_in_ket=modes_out_ket,
+            representation=representation,
+            modes_out_ket=modes_in,
+            modes_in_ket=modes_out,
             name=name or "Op",
         )
 
@@ -109,7 +111,7 @@ class Operator(Transformation):
         b = math.astensor(triple[1])
         c = math.astensor(triple[2])
         shape_check(A, b, len(modes_out) + len(modes_in), "Bargmann")
-        return Operator._from_attributes(
+        return cls._from_attributes(
             Bargmann(A, b, c), Wires(set(), set(), set(modes_out), set(modes_in)), name
         )
 
@@ -129,7 +131,7 @@ class Operator(Transformation):
             modes_out_ket=modes_out,
             modes_in_ket=modes_in,
         )
-        return Operator._from_attributes(
+        return cls._from_attributes(
             representation=CC.representation, wires=CC.wires, name=name
         )
 
@@ -145,8 +147,8 @@ class Unitary(Operator):
 
     def __init__(self, modes: tuple[int, ...] = (), name: Optional[str] = None):
         super().__init__(
-            modes_in_ket=modes,
-            modes_out_ket=modes,
+            modes_out=modes,
+            modes_in=modes,
             name=name or "U" + "".join(str(m) for m in modes),
         )
 
@@ -290,12 +292,10 @@ class Channel(Map):
         modes: The modes that this channel acts on.
     """
 
-    _cc_wires_type: tuple[Optional[int], ...] = (0, 0, 0, 0)
-
     def __init__(self, modes: tuple[int, ...] = (), name: Optional[str] = None):
         super().__init__(
-            modes_in=modes,
             modes_out=modes,
+            modes_in=modes,
             name=name or "Ch" + "".join(str(m) for m in modes),
         )
 

--- a/mrmustard/lab_dev/transformations/base.py
+++ b/mrmustard/lab_dev/transformations/base.py
@@ -204,9 +204,7 @@ class Channel(Transformation):
         ret = super().__rshift__(other)
 
         if isinstance(other, (Unitary, Channel)):
-            return Channel._from_attributes(
-                representation=ret.representation, wires=ret.wires
-            )
+            return Channel._from_attributes(representation=ret.representation, wires=ret.wires)
         return ret
 
     def __repr__(self) -> str:

--- a/mrmustard/lab_dev/transformations/transformations.py
+++ b/mrmustard/lab_dev/transformations/transformations.py
@@ -99,16 +99,12 @@ class BSgate(Unitary):
             raise ValueError(f"Expected a pair of modes, found {modes}.")
 
         super().__init__(modes=modes, name="BSgate")
-        self._add_parameter(
-            make_parameter(theta_trainable, theta, "theta", theta_bounds)
-        )
+        self._add_parameter(make_parameter(theta_trainable, theta, "theta", theta_bounds))
         self._add_parameter(make_parameter(phi_trainable, phi, "phi", phi_bounds))
 
     @property
     def representation(self) -> Bargmann:
-        return Bargmann(
-            *triples.beamsplitter_gate_Abc(self.theta.value, self.phi.value)
-        )
+        return Bargmann(*triples.beamsplitter_gate_Abc(self.theta.value, self.phi.value))
 
 
 class Dgate(Unitary):
@@ -209,9 +205,7 @@ class Rgate(Unitary):
         theta_bounds: Tuple[Optional[float], Optional[float]] = (0.0, None),
     ):
         super().__init__(modes=modes, name="Rgate")
-        self._add_parameter(
-            make_parameter(theta_trainable, theta, "theta", theta_bounds)
-        )
+        self._add_parameter(make_parameter(theta_trainable, theta, "theta", theta_bounds))
 
     @property
     def representation(self) -> Bargmann:

--- a/mrmustard/lab_dev/transformations/transformations.py
+++ b/mrmustard/lab_dev/transformations/transformations.py
@@ -99,12 +99,16 @@ class BSgate(Unitary):
             raise ValueError(f"Expected a pair of modes, found {modes}.")
 
         super().__init__(modes=modes, name="BSgate")
-        self._add_parameter(make_parameter(theta_trainable, theta, "theta", theta_bounds))
+        self._add_parameter(
+            make_parameter(theta_trainable, theta, "theta", theta_bounds)
+        )
         self._add_parameter(make_parameter(phi_trainable, phi, "phi", phi_bounds))
 
     @property
     def representation(self) -> Bargmann:
-        return Bargmann(*triples.beamsplitter_gate_Abc(self.theta.value, self.phi.value))
+        return Bargmann(
+            *triples.beamsplitter_gate_Abc(self.theta.value, self.phi.value)
+        )
 
 
 class Dgate(Unitary):
@@ -164,7 +168,7 @@ class Dgate(Unitary):
         x_bounds: Tuple[Optional[float], Optional[float]] = (None, None),
         y_bounds: Tuple[Optional[float], Optional[float]] = (None, None),
     ) -> None:
-        super().__init__("Dgate", modes=modes)
+        super().__init__(modes=modes, name="Dgate")
         self._add_parameter(make_parameter(x_trainable, x, "x", x_bounds))
         self._add_parameter(make_parameter(y_trainable, y, "y", y_bounds))
 
@@ -205,7 +209,9 @@ class Rgate(Unitary):
         theta_bounds: Tuple[Optional[float], Optional[float]] = (0.0, None),
     ):
         super().__init__(modes=modes, name="Rgate")
-        self._add_parameter(make_parameter(theta_trainable, theta, "theta", theta_bounds))
+        self._add_parameter(
+            make_parameter(theta_trainable, theta, "theta", theta_bounds)
+        )
 
     @property
     def representation(self) -> Bargmann:

--- a/mrmustard/lab_dev/utils.py
+++ b/mrmustard/lab_dev/utils.py
@@ -80,12 +80,14 @@ def shape_check(mat, vec, dim: int, name: str):
     Check that the given Gaussian representation is consistent with the given modes.
 
     Args:
-        mat: Bargmann A matrix
-        vec: Bargmann b vector
+        mat: matrix (e.g. A or cov, etc.)
+        vec: vector (e.g. b or means, etc.)
         dim: The required dimension of the representation
         name: The name of the representation for error messages
     """
     if mat.shape[-2:] != (dim, dim) or vec.shape[-1:] != (dim,):
-        msg = f"{name} representation is incompatible with the required dimension {dim}: "
+        msg = (
+            f"{name} representation is incompatible with the required dimension {dim}: "
+        )
         msg += f"{mat.shape[-2:]}!=({dim},{dim}) or {vec.shape[-1:]} != ({dim},)."
         raise ValueError(msg)

--- a/mrmustard/lab_dev/wires.py
+++ b/mrmustard/lab_dev/wires.py
@@ -223,9 +223,7 @@ class Wires:
             >>> assert w.input.indices == (2,3)
         """
         return tuple(
-            self.index_dicts[t][m]
-            for t, modes in enumerate(self.sorted_args)
-            for m in modes
+            self.index_dicts[t][m] for t, modes in enumerate(self.sorted_args) for m in modes
         )
 
     @cached_property
@@ -391,32 +389,22 @@ class Wires:
             raise ValueError(f"output ket modes {m} overlap")
         if m := sets[3] & sets[7]:
             raise ValueError(f"input ket modes {m} overlap")
-        bra_out = (
-            sets[0] | sets[4]
-        )  # (self.output.bra - other.input.bra) | other.output.bra
-        bra_in = (
-            sets[1] | sets[5]
-        )  # self.input.bra | (other.input.bra - self.output.bra)
-        ket_out = (
-            sets[2] | sets[6]
-        )  # (self.output.ket - other.input.ket) | other.output.ket
-        ket_in = (
-            sets[3] | sets[7]
-        )  # self.input.ket | (other.input.ket - self.output.ket)
+        bra_out = sets[0] | sets[4]  # (self.output.bra - other.input.bra) | other.output.bra
+        bra_in = sets[1] | sets[5]  # self.input.bra | (other.input.bra - self.output.bra)
+        ket_out = sets[2] | sets[6]  # (self.output.ket - other.input.ket) | other.output.ket
+        ket_in = sets[3] | sets[7]  # self.input.ket | (other.input.ket - self.output.ket)
         w = Wires(bra_out, bra_in, ket_out, ket_in)
 
         # preserve ids
         for t in (0, 1, 2, 3):
             for m in w.args[t]:
-                w.ids_dicts[t][m] = (
-                    self.ids_dicts[t][m] if m in sets[t] else other.ids_dicts[t][m]
-                )
+                w.ids_dicts[t][m] = self.ids_dicts[t][m] if m in sets[t] else other.ids_dicts[t][m]
 
         # calculate permutation
         result_ids = [id for d in w.ids_dicts for id in d.values()]
-        self_other_ids = [
-            self.ids_dicts[t][m] for t in (0, 1, 2, 3) for m in sorted(sets[t])
-        ] + [other.ids_dicts[t][m] for t in (0, 1, 2, 3) for m in sorted(sets[t + 4])]
+        self_other_ids = [self.ids_dicts[t][m] for t in (0, 1, 2, 3) for m in sorted(sets[t])] + [
+            other.ids_dicts[t][m] for t in (0, 1, 2, 3) for m in sorted(sets[t + 4])
+        ]
         perm = [self_other_ids.index(id) for id in result_ids]
         return w, perm
 

--- a/mrmustard/lab_dev/wires.py
+++ b/mrmustard/lab_dev/wires.py
@@ -175,6 +175,10 @@ class Wires:
         # Adds elements to the cache when calling ``__getitem__``
         self._mode_cache = {}
 
+    def __len__(self) -> int:
+        r"The number of wires."
+        return sum(len(s) for s in self.args)
+
     @cached_property
     def id(self) -> int:
         r"""
@@ -219,7 +223,9 @@ class Wires:
             >>> assert w.input.indices == (2,3)
         """
         return tuple(
-            self.index_dicts[t][m] for t, modes in enumerate(self.sorted_args) for m in modes
+            self.index_dicts[t][m]
+            for t, modes in enumerate(self.sorted_args)
+            for m in modes
         )
 
     @cached_property
@@ -385,22 +391,32 @@ class Wires:
             raise ValueError(f"output ket modes {m} overlap")
         if m := sets[3] & sets[7]:
             raise ValueError(f"input ket modes {m} overlap")
-        bra_out = sets[0] | sets[4]  # (self.output.bra - other.input.bra) | other.output.bra
-        bra_in = sets[1] | sets[5]  # self.input.bra | (other.input.bra - self.output.bra)
-        ket_out = sets[2] | sets[6]  # (self.output.ket - other.input.ket) | other.output.ket
-        ket_in = sets[3] | sets[7]  # self.input.ket | (other.input.ket - self.output.ket)
+        bra_out = (
+            sets[0] | sets[4]
+        )  # (self.output.bra - other.input.bra) | other.output.bra
+        bra_in = (
+            sets[1] | sets[5]
+        )  # self.input.bra | (other.input.bra - self.output.bra)
+        ket_out = (
+            sets[2] | sets[6]
+        )  # (self.output.ket - other.input.ket) | other.output.ket
+        ket_in = (
+            sets[3] | sets[7]
+        )  # self.input.ket | (other.input.ket - self.output.ket)
         w = Wires(bra_out, bra_in, ket_out, ket_in)
 
         # preserve ids
         for t in (0, 1, 2, 3):
             for m in w.args[t]:
-                w.ids_dicts[t][m] = self.ids_dicts[t][m] if m in sets[t] else other.ids_dicts[t][m]
+                w.ids_dicts[t][m] = (
+                    self.ids_dicts[t][m] if m in sets[t] else other.ids_dicts[t][m]
+                )
 
         # calculate permutation
         result_ids = [id for d in w.ids_dicts for id in d.values()]
-        self_other_ids = [self.ids_dicts[t][m] for t in (0, 1, 2, 3) for m in sorted(sets[t])] + [
-            other.ids_dicts[t][m] for t in (0, 1, 2, 3) for m in sorted(sets[t + 4])
-        ]
+        self_other_ids = [
+            self.ids_dicts[t][m] for t in (0, 1, 2, 3) for m in sorted(sets[t])
+        ] + [other.ids_dicts[t][m] for t in (0, 1, 2, 3) for m in sorted(sets[t + 4])]
         perm = [self_other_ids.index(id) for id in result_ids]
         return w, perm
 

--- a/tests/test_lab_dev/test_circuit_components.py
+++ b/tests/test_lab_dev/test_circuit_components.py
@@ -53,9 +53,7 @@ class TestCircuitComponent:
     def test_init(self, x, y):
         name = "my_component"
         representation = Bargmann(*displacement_gate_Abc(x, y))
-        cc = CircuitComponent(
-            representation, modes_out_ket=(1, 8), modes_in_ket=(1, 8), name=name
-        )
+        cc = CircuitComponent(representation, modes_out_ket=(1, 8), modes_in_ket=(1, 8), name=name)
 
         assert cc.name == name
         assert list(cc.modes) == [1, 8]
@@ -76,9 +74,7 @@ class TestCircuitComponent:
         r3 = (cc1.adjoint @ cc1).representation
         cc3 = CircuitComponent(r3, m2, m2, m2, m1)
         cc4 = CircuitComponent(r3, m2, m2, m2, m2)
-        assert cc3.representation == cc4.representation.reorder(
-            [0, 1, 2, 3, 4, 5, 7, 6]
-        )
+        assert cc3.representation == cc4.representation.reorder([0, 1, 2, 3, 4, 5, 7, 6])
 
     @pytest.mark.parametrize("x", [0.1, [0.2, 0.3]])
     @pytest.mark.parametrize("y", [0.4, [0.5, 0.6]])
@@ -428,11 +424,7 @@ class TestCircuitComponent:
 
     def test_quadrature_rho(self):
         "tests that transforming to quadrature and back gives the same density matrix"
-        rho = (
-            SqueezedVacuum([0], 0.4, 0.5)
-            >> Dgate([0], 0.3, 0.2)
-            >> Attenuator([0], 0.9)
-        )
+        rho = SqueezedVacuum([0], 0.4, 0.5) >> Dgate([0], 0.3, 0.2) >> Attenuator([0], 0.9)
         quad = rho.quadrature()
         back = DM.from_quadrature([0], [q[0] for q in quad])
         assert rho == back
@@ -460,9 +452,7 @@ class TestAdjointView:
         c2 = CircuitComponent(modes_out_ket=(0, 1, 2), name="my_component")
 
         assert repr(c1.adjoint) == "CircuitComponent(modes=[0, 1, 2], name=CC012)"
-        assert (
-            repr(c2.adjoint) == "CircuitComponent(modes=[0, 1, 2], name=my_component)"
-        )
+        assert repr(c2.adjoint) == "CircuitComponent(modes=[0, 1, 2], name=my_component)"
 
     def test_parameters_point_to_original_parameters(self):
         r"""

--- a/tests/test_lab_dev/test_circuit_components_utils.py
+++ b/tests/test_lab_dev/test_circuit_components_utils.py
@@ -97,17 +97,13 @@ class TestBtoPS:
 
     def test_representation(self):
         rep1 = BtoPS(modes=[0], s=0).representation  # pylint: disable=protected-access
-        A_correct, b_correct, c_correct = displacement_map_s_parametrized_Abc(
-            s=0, n_modes=1
-        )
+        A_correct, b_correct, c_correct = displacement_map_s_parametrized_Abc(s=0, n_modes=1)
         assert math.allclose(rep1.A[0], A_correct)
         assert math.allclose(rep1.b[0], b_correct)
         assert math.allclose(rep1.c[0], c_correct)
 
         rep2 = BtoPS(modes=[5, 10], s=1).representation  # pylint: disable=protected-access
-        A_correct, b_correct, c_correct = displacement_map_s_parametrized_Abc(
-            s=1, n_modes=2
-        )
+        A_correct, b_correct, c_correct = displacement_map_s_parametrized_Abc(s=1, n_modes=2)
         assert math.allclose(rep2.A[0], A_correct)
         assert math.allclose(rep2.b[0], b_correct)
         assert math.allclose(rep2.c[0], c_correct)

--- a/tests/test_lab_dev/test_circuit_components_utils.py
+++ b/tests/test_lab_dev/test_circuit_components_utils.py
@@ -30,7 +30,7 @@ from mrmustard.physics.gaussian_integrals import (
     join_Abc_real,
 )
 from mrmustard.physics.representations import Bargmann
-from mrmustard.lab_dev.circuit_components_utils import TraceOut, DsMap, BtoQMap
+from mrmustard.lab_dev.circuit_components_utils import TraceOut, BtoPS, BtoQ
 from mrmustard.lab_dev.states import Coherent, DM
 from mrmustard.lab_dev.wires import Wires
 
@@ -80,9 +80,9 @@ class TestTraceOut:
         settings.AUTOCUTOFF_MAX_CUTOFF = autocutoff_max0
 
 
-class TestDsMap:
+class TestBtoPS:
     r"""
-    Tests for the ``DsMap`` class.
+    Tests for the ``BtoPS`` class.
     """
 
     modes = [[0], [1, 2], [9, 7]]
@@ -90,25 +90,29 @@ class TestDsMap:
 
     @pytest.mark.parametrize("modes,s", zip(modes, s))
     def test_init(self, modes, s):
-        dsmap = DsMap(modes, s)  # pylint: disable=protected-access
+        dsmap = BtoPS(modes, s)  # pylint: disable=protected-access
 
-        assert dsmap.name == "DsMap"
+        assert dsmap.name == "BtoPS"
         assert dsmap.modes == [modes] if not isinstance(modes, list) else sorted(modes)
 
     def test_representation(self):
-        rep1 = DsMap(modes=[0], s=0).representation  # pylint: disable=protected-access
-        A_correct, b_correct, c_correct = displacement_map_s_parametrized_Abc(s=0, n_modes=1)
+        rep1 = BtoPS(modes=[0], s=0).representation  # pylint: disable=protected-access
+        A_correct, b_correct, c_correct = displacement_map_s_parametrized_Abc(
+            s=0, n_modes=1
+        )
         assert math.allclose(rep1.A[0], A_correct)
         assert math.allclose(rep1.b[0], b_correct)
         assert math.allclose(rep1.c[0], c_correct)
 
-        rep2 = DsMap(modes=[5, 10], s=1).representation  # pylint: disable=protected-access
-        A_correct, b_correct, c_correct = displacement_map_s_parametrized_Abc(s=1, n_modes=2)
+        rep2 = BtoPS(modes=[5, 10], s=1).representation  # pylint: disable=protected-access
+        A_correct, b_correct, c_correct = displacement_map_s_parametrized_Abc(
+            s=1, n_modes=2
+        )
         assert math.allclose(rep2.A[0], A_correct)
         assert math.allclose(rep2.b[0], b_correct)
         assert math.allclose(rep2.c[0], c_correct)
 
-    def testDsMap_contraction_with_state(self):
+    def testBtoPS_contraction_with_state(self):
         # The init state cov and means comes from the random state 'state = Gaussian(1) >> Dgate([0.2], [0.3])'
         state_cov = np.array([[0.32210229, -0.99732956], [-0.99732956, 6.1926484]])
         state_means = np.array([0.4, 0.6])
@@ -117,7 +121,7 @@ class TestDsMap:
         state_bargmann_triple = (A, b, c)
 
         # get new triple by right shift
-        state_after = state >> DsMap(modes=[0], s=0)  # pylint: disable=protected-access
+        state_after = state >> BtoPS(modes=[0], s=0)  # pylint: disable=protected-access
         A1, b1, c1 = state_after.bargmann
 
         # get new triple by contraction
@@ -145,7 +149,7 @@ class TestDsMap:
         state_bargmann_triple = (A, b, c)
 
         # get new triple by right shift
-        state_after = state >> DsMap(modes=[0, 1], s=0)  # pylint: disable=protected-access
+        state_after = state >> BtoPS(modes=[0, 1], s=0)  # pylint: disable=protected-access
         A1, b1, c1 = state_after.bargmann
 
         # get new triple by contraction
@@ -162,22 +166,22 @@ class TestDsMap:
         assert math.allclose(c1[0], c2)
 
 
-class TestBtoQMap:
+class TestBtoQ:
     r"""
-    Tests for the ``BtoQMap`` class.
+    Tests for the ``BtoQ`` class.
     """
 
-    def testBtoQMap_works_correctly_by_applying_it_twice_on_a_state(self):
+    def testBtoQ_works_correctly_by_applying_it_twice_on_a_state(self):
         A0 = np.array([[0.5, 0.3], [0.3, 0.5]])
         b0 = np.zeros(2)
         c0 = 1.0 + 0j
 
         modes = [0, 1]
-        BtoQMap_CC1 = BtoQMap(modes)
+        BtoQ_CC1 = BtoQ(modes)
         step1A, step1b, step1c = (
-            BtoQMap_CC1.representation.A[0],
-            BtoQMap_CC1.representation.b[0],
-            BtoQMap_CC1.representation.c[0],
+            BtoQ_CC1.representation.A[0],
+            BtoQ_CC1.representation.b[0],
+            BtoQ_CC1.representation.c[0],
         )
         Ainter, binter, cinter = complex_gaussian_integral(
             join_Abc((A0, b0, c0), (step1A, step1b, step1c)),
@@ -185,7 +189,7 @@ class TestBtoQMap:
             idx_zconj=[4, 5],
             measure=-1,
         )
-        QtoBMap_CC2 = BtoQMap(modes).dual
+        QtoBMap_CC2 = BtoQ(modes).dual
         step2A, step2b, step2c = (
             QtoBMap_CC2.representation.A[0],
             QtoBMap_CC2.representation.b[0],
@@ -207,11 +211,11 @@ class TestBtoQMap:
         c0 = 1.0 + 0j
 
         modes = [0]
-        BtoQMap_CC1 = BtoQMap(modes)
+        BtoQ_CC1 = BtoQ(modes)
         step1A, step1b, step1c = (
-            BtoQMap_CC1.representation.A[0],
-            BtoQMap_CC1.representation.b[0],
-            BtoQMap_CC1.representation.c[0],
+            BtoQ_CC1.representation.A[0],
+            BtoQ_CC1.representation.b[0],
+            BtoQ_CC1.representation.c[0],
         )
         Ainter, binter, cinter = complex_gaussian_integral(
             join_Abc((A0, b0, c0), (step1A, step1b, step1c)),
@@ -221,7 +225,7 @@ class TestBtoQMap:
             idx_zconj=[2],
             measure=-1,
         )
-        QtoBMap_CC2 = BtoQMap(modes).dual
+        QtoBMap_CC2 = BtoQ(modes).dual
         step2A, step2b, step2c = (
             QtoBMap_CC2.representation.A[0],
             QtoBMap_CC2.representation.b[0],

--- a/tests/test_lab_dev/test_circuits.py
+++ b/tests/test_lab_dev/test_circuits.py
@@ -101,9 +101,7 @@ class TestCircuit:
         exp2 += "mode 2:   ──╰BSgate(0.0,0.0)\n\n\n\n"
         assert out2 == exp2
 
-    @pytest.mark.parametrize(
-        "path", [[(0, 1), (2, 3)], [(0, 1), (2, 3), (0, 2), (0, 4), (0, 5)]]
-    )
+    @pytest.mark.parametrize("path", [[(0, 1), (2, 3)], [(0, 1), (2, 3), (0, 2), (0, 4), (0, 5)]])
     def test_path(self, path):
         vac12 = Vacuum([1, 2])
         d1 = Dgate([1], x=0.1, y=0.1)
@@ -213,7 +211,9 @@ class TestCircuit:
         bs12 = BSgate([1, 2])
         n12 = Number([0, 1], n=3)
         n2 = Number([2], n=3)
-        cc = CircuitComponent._from_attributes(bs01.representation, bs01.wires, "my_cc")  # pylint: disable=protected-access
+        cc = CircuitComponent._from_attributes(
+            bs01.representation, bs01.wires, "my_cc"
+        )  # pylint: disable=protected-access
 
         assert repr(Circuit()) == ""
 
@@ -231,9 +231,7 @@ class TestCircuit:
         r2 += "\nmode 2:     ◖Vac◗────────────────────────────────────╰BSgate(0.0,0.0)─────────────"
         assert repr(circ2) == r2 + "\n\n"
 
-        circ3 = Circuit(
-            [bs01, bs01, bs01, bs01, bs01, bs01, bs01, bs01, bs01, bs01, bs01]
-        )
+        circ3 = Circuit([bs01, bs01, bs01, bs01, bs01, bs01, bs01, bs01, bs01, bs01, bs01])
         r3 = ""
         r3 += "\nmode 0:   ──╭•────────────────╭•────────────────╭•────────────────╭•────────────── ---"
         r3 += "\nmode 1:   ──╰BSgate(0.0,0.0)──╰BSgate(0.0,0.0)──╰BSgate(0.0,0.0)──╰BSgate(0.0,0.0) ---"

--- a/tests/test_lab_dev/test_circuits.py
+++ b/tests/test_lab_dev/test_circuits.py
@@ -101,7 +101,9 @@ class TestCircuit:
         exp2 += "mode 2:   ──╰BSgate(0.0,0.0)\n\n\n\n"
         assert out2 == exp2
 
-    @pytest.mark.parametrize("path", [[(0, 1), (2, 3)], [(0, 1), (2, 3), (0, 2), (0, 4), (0, 5)]])
+    @pytest.mark.parametrize(
+        "path", [[(0, 1), (2, 3)], [(0, 1), (2, 3), (0, 2), (0, 4), (0, 5)]]
+    )
     def test_path(self, path):
         vac12 = Vacuum([1, 2])
         d1 = Dgate([1], x=0.1, y=0.1)
@@ -211,9 +213,7 @@ class TestCircuit:
         bs12 = BSgate([1, 2])
         n12 = Number([0, 1], n=3)
         n2 = Number([2], n=3)
-        cc = CircuitComponent._from_attributes(
-            "my_cc", bs01.representation, bs01.wires
-        )  # pylint: disable=protected-access
+        cc = CircuitComponent._from_attributes(bs01.representation, bs01.wires, "my_cc")  # pylint: disable=protected-access
 
         assert repr(Circuit()) == ""
 
@@ -231,7 +231,9 @@ class TestCircuit:
         r2 += "\nmode 2:     ◖Vac◗────────────────────────────────────╰BSgate(0.0,0.0)─────────────"
         assert repr(circ2) == r2 + "\n\n"
 
-        circ3 = Circuit([bs01, bs01, bs01, bs01, bs01, bs01, bs01, bs01, bs01, bs01, bs01])
+        circ3 = Circuit(
+            [bs01, bs01, bs01, bs01, bs01, bs01, bs01, bs01, bs01, bs01, bs01]
+        )
         r3 = ""
         r3 += "\nmode 0:   ──╭•────────────────╭•────────────────╭•────────────────╭•────────────── ---"
         r3 += "\nmode 1:   ──╰BSgate(0.0,0.0)──╰BSgate(0.0,0.0)──╰BSgate(0.0,0.0)──╰BSgate(0.0,0.0) ---"

--- a/tests/test_lab_dev/test_states.py
+++ b/tests/test_lab_dev/test_states.py
@@ -116,9 +116,7 @@ class TestKet:
 
         r = [i / 10 for i in range(n_modes)]
         phi = [(i + 1) / 10 for i in range(n_modes)]
-        state2 = Ket.from_phase_space(
-            modes, squeezed_vacuum_cov(r, phi), vacuum_means(n_modes)
-        )
+        state2 = Ket.from_phase_space(modes, squeezed_vacuum_cov(r, phi), vacuum_means(n_modes))
         assert state2 == Vacuum(modes) >> Sgate(modes, r, phi)
 
     def test_to_from_quadrature(self):
@@ -211,9 +209,7 @@ class TestKet:
 
         ket = Coherent([0, 1], x=1, y=[2, 3]).to_fock()
 
-        assert math.allclose(
-            ket.expectation(ket), (ket @ ket.dual).representation.array ** 2
-        )
+        assert math.allclose(ket.expectation(ket), (ket @ ket.dual).representation.array ** 2)
 
         k0 = Coherent([0], x=1, y=2)
         k1 = Coherent([1], x=1, y=3)
@@ -311,9 +307,7 @@ class TestKet:
 
         si = s[m]
         assert isinstance(si, DisplacedSqueezed)
-        assert si == DisplacedSqueezed(
-            m, x=x[idx], y=3, y_trainable=True, y_bounds=(0, 6)
-        )
+        assert si == DisplacedSqueezed(m, x=x[idx], y=3, y_trainable=True, y_bounds=(0, 6))
 
         assert isinstance(si.x, Constant)
         assert math.allclose(si.x.value, x[idx])
@@ -497,12 +491,8 @@ class TestDM:
         k1 = Coherent([1], x=1, y=3)
         k01 = Coherent([0, 1], x=1, y=[2, 3])
 
-        res_k0 = (
-            (dm @ k0.dual @ k0.dual.adjoint) >> TraceOut([1])
-        ).representation.array
-        res_k1 = (
-            (dm @ k1.dual @ k1.dual.adjoint) >> TraceOut([0])
-        ).representation.array
+        res_k0 = ((dm @ k0.dual @ k0.dual.adjoint) >> TraceOut([1])).representation.array
+        res_k1 = ((dm @ k1.dual @ k1.dual.adjoint) >> TraceOut([0])).representation.array
         res_k01 = (dm @ k01.dual @ k01.dual.adjoint).representation.array
 
         assert math.allclose(dm.expectation(k0), res_k0)
@@ -688,9 +678,7 @@ class TestDisplacedSqueezed:
     @pytest.mark.parametrize("modes,x,y,r,phi", zip(modes, x, y, r, phi))
     def test_representation(self, modes, x, y, r, phi):
         rep = DisplacedSqueezed(modes, x, y, r, phi).representation
-        exp = (
-            Vacuum(modes) >> Sgate(modes, r, phi) >> Dgate(modes, x, y)
-        ).representation
+        exp = (Vacuum(modes) >> Sgate(modes, r, phi) >> Dgate(modes, x, y)).representation
         assert rep == exp
 
     def test_representation_error(self):
@@ -825,9 +813,7 @@ class TestThermal:
     @pytest.mark.parametrize("nbar", [1, [2, 3], [4, 4]])
     def test_representation(self, nbar):
         rep = Thermal([0, 1], nbar).representation
-        exp = Bargmann(
-            *thermal_state_Abc([nbar, nbar] if isinstance(nbar, int) else nbar)
-        )
+        exp = Bargmann(*thermal_state_Abc([nbar, nbar] if isinstance(nbar, int) else nbar))
         assert rep == exp
 
     def test_representation_error(self):
@@ -848,9 +834,7 @@ class TestVisualization:
 
     def test_visualize_2d(self):
         st = Coherent([0], y=1) + Coherent([0], y=-1)
-        fig = st.visualize_2d(
-            resolution=20, xbounds=(-3, 3), pbounds=(-4, 4), return_fig=True
-        )
+        fig = st.visualize_2d(resolution=20, xbounds=(-3, 3), pbounds=(-4, 4), return_fig=True)
         data = fig.to_dict()
 
         if self.regenerate_assets:
@@ -873,9 +857,7 @@ class TestVisualization:
 
     def test_visualize_3d(self):
         st = Coherent([0], y=1) + Coherent([0], y=-1)
-        fig = st.visualize_3d(
-            resolution=20, xbounds=(-3, 3), pbounds=(-4, 4), return_fig=True
-        )
+        fig = st.visualize_3d(resolution=20, xbounds=(-3, 3), pbounds=(-4, 4), return_fig=True)
         data = fig.to_dict()
 
         if self.regenerate_assets:

--- a/tests/test_lab_dev/test_states.py
+++ b/tests/test_lab_dev/test_states.py
@@ -54,7 +54,7 @@ class TestKet:
     @pytest.mark.parametrize("name", [None, "my_ket"])
     @pytest.mark.parametrize("modes", [[0], [0, 1], [3, 19, 2]])
     def test_init(self, name, modes):
-        state = Ket(name, modes)
+        state = Ket(modes, None, name)
 
         assert state.name in ("Ket0", "Ket01", "Ket2319") if not name else name
         assert list(state.modes) == sorted(modes)
@@ -116,7 +116,9 @@ class TestKet:
 
         r = [i / 10 for i in range(n_modes)]
         phi = [(i + 1) / 10 for i in range(n_modes)]
-        state2 = Ket.from_phase_space(modes, squeezed_vacuum_cov(r, phi), vacuum_means(n_modes))
+        state2 = Ket.from_phase_space(
+            modes, squeezed_vacuum_cov(r, phi), vacuum_means(n_modes)
+        )
         assert state2 == Vacuum(modes) >> Sgate(modes, r, phi)
 
     def test_to_from_quadrature(self):
@@ -151,7 +153,7 @@ class TestKet:
 
     @pytest.mark.parametrize("modes", [[0], [0, 1], [3, 19, 2]])
     def test_purity(self, modes):
-        state = Ket("my_ket", modes)
+        state = Ket(modes, None, "my_ket")
         assert state.purity == 1
         assert state.is_pure
 
@@ -209,7 +211,9 @@ class TestKet:
 
         ket = Coherent([0, 1], x=1, y=[2, 3]).to_fock()
 
-        assert math.allclose(ket.expectation(ket), (ket @ ket.dual).representation.array ** 2)
+        assert math.allclose(
+            ket.expectation(ket), (ket @ ket.dual).representation.array ** 2
+        )
 
         k0 = Coherent([0], x=1, y=2)
         k1 = Coherent([1], x=1, y=3)
@@ -307,7 +311,9 @@ class TestKet:
 
         si = s[m]
         assert isinstance(si, DisplacedSqueezed)
-        assert si == DisplacedSqueezed(m, x=x[idx], y=3, y_trainable=True, y_bounds=(0, 6))
+        assert si == DisplacedSqueezed(
+            m, x=x[idx], y=3, y_trainable=True, y_bounds=(0, 6)
+        )
 
         assert isinstance(si.x, Constant)
         assert math.allclose(si.x.value, x[idx])
@@ -345,7 +351,7 @@ class TestDM:
     @pytest.mark.parametrize("name", [None, "my_dm"])
     @pytest.mark.parametrize("modes", [{0}, {0, 1}, {3, 19, 2}])
     def test_init(self, name, modes):
-        state = DM(name, modes)
+        state = DM(modes, None, name)
 
         assert state.name in ("DM0", "DM01", "DM2319") if not name else name
         assert list(state.modes) == sorted(modes)
@@ -491,8 +497,12 @@ class TestDM:
         k1 = Coherent([1], x=1, y=3)
         k01 = Coherent([0, 1], x=1, y=[2, 3])
 
-        res_k0 = ((dm @ k0.dual @ k0.dual.adjoint) >> TraceOut([1])).representation.array
-        res_k1 = ((dm @ k1.dual @ k1.dual.adjoint) >> TraceOut([0])).representation.array
+        res_k0 = (
+            (dm @ k0.dual @ k0.dual.adjoint) >> TraceOut([1])
+        ).representation.array
+        res_k1 = (
+            (dm @ k1.dual @ k1.dual.adjoint) >> TraceOut([0])
+        ).representation.array
         res_k01 = (dm @ k01.dual @ k01.dual.adjoint).representation.array
 
         assert math.allclose(dm.expectation(k0), res_k0)
@@ -678,7 +688,9 @@ class TestDisplacedSqueezed:
     @pytest.mark.parametrize("modes,x,y,r,phi", zip(modes, x, y, r, phi))
     def test_representation(self, modes, x, y, r, phi):
         rep = DisplacedSqueezed(modes, x, y, r, phi).representation
-        exp = (Vacuum(modes) >> Sgate(modes, r, phi) >> Dgate(modes, x, y)).representation
+        exp = (
+            Vacuum(modes) >> Sgate(modes, r, phi) >> Dgate(modes, x, y)
+        ).representation
         assert rep == exp
 
     def test_representation_error(self):
@@ -813,7 +825,9 @@ class TestThermal:
     @pytest.mark.parametrize("nbar", [1, [2, 3], [4, 4]])
     def test_representation(self, nbar):
         rep = Thermal([0, 1], nbar).representation
-        exp = Bargmann(*thermal_state_Abc([nbar, nbar] if isinstance(nbar, int) else nbar))
+        exp = Bargmann(
+            *thermal_state_Abc([nbar, nbar] if isinstance(nbar, int) else nbar)
+        )
         assert rep == exp
 
     def test_representation_error(self):
@@ -834,7 +848,9 @@ class TestVisualization:
 
     def test_visualize_2d(self):
         st = Coherent([0], y=1) + Coherent([0], y=-1)
-        fig = st.visualize_2d(resolution=20, xbounds=(-3, 3), pbounds=(-4, 4), return_fig=True)
+        fig = st.visualize_2d(
+            resolution=20, xbounds=(-3, 3), pbounds=(-4, 4), return_fig=True
+        )
         data = fig.to_dict()
 
         if self.regenerate_assets:
@@ -857,7 +873,9 @@ class TestVisualization:
 
     def test_visualize_3d(self):
         st = Coherent([0], y=1) + Coherent([0], y=-1)
-        fig = st.visualize_3d(resolution=20, xbounds=(-3, 3), pbounds=(-4, 4), return_fig=True)
+        fig = st.visualize_3d(
+            resolution=20, xbounds=(-3, 3), pbounds=(-4, 4), return_fig=True
+        )
         data = fig.to_dict()
 
         if self.regenerate_assets:

--- a/tests/test_lab_dev/test_states.py
+++ b/tests/test_lab_dev/test_states.py
@@ -116,7 +116,9 @@ class TestKet:
 
         r = [i / 10 for i in range(n_modes)]
         phi = [(i + 1) / 10 for i in range(n_modes)]
-        state2 = Ket.from_phase_space(modes, squeezed_vacuum_cov(r, phi), vacuum_means(n_modes))
+        state2 = Ket.from_phase_space(
+            modes, squeezed_vacuum_cov(r, phi), vacuum_means(n_modes)
+        )
         assert state2 == Vacuum(modes) >> Sgate(modes, r, phi)
 
     def test_to_from_quadrature(self):
@@ -209,7 +211,9 @@ class TestKet:
 
         ket = Coherent([0, 1], x=1, y=[2, 3]).to_fock()
 
-        assert math.allclose(ket.expectation(ket), (ket @ ket.dual).representation.array ** 2)
+        assert math.allclose(
+            ket.expectation(ket), (ket @ ket.dual).representation.array ** 2
+        )
 
         k0 = Coherent([0], x=1, y=2)
         k1 = Coherent([1], x=1, y=3)
@@ -256,7 +260,7 @@ class TestKet:
         with pytest.raises(ValueError, match="Cannot calculate the expectation value"):
             ket.expectation(op1)
 
-        op2 = CircuitComponent("", None, modes_in_ket=[0], modes_out_ket=[1])
+        op2 = CircuitComponent(None, modes_in_ket=[0], modes_out_ket=[1])
         with pytest.raises(ValueError, match="different modes"):
             ket.expectation(op2)
 
@@ -268,11 +272,13 @@ class TestKet:
         ket = Coherent([0, 1], 1)
         unitary = Dgate([0], 1)
         u_component = CircuitComponent._from_attributes(
-            unitary.name, unitary.representation, unitary.wires
+            unitary.representation, unitary.wires, unitary.name
         )  # pylint: disable=protected-access
         channel = Attenuator([1], 1)
         ch_component = CircuitComponent._from_attributes(
-            channel.name, channel.representation, channel.wires
+            channel.representation,
+            channel.wires,
+            channel.name,
         )  # pylint: disable=protected-access
 
         # gates
@@ -305,7 +311,9 @@ class TestKet:
 
         si = s[m]
         assert isinstance(si, DisplacedSqueezed)
-        assert si == DisplacedSqueezed(m, x=x[idx], y=3, y_trainable=True, y_bounds=(0, 6))
+        assert si == DisplacedSqueezed(
+            m, x=x[idx], y=3, y_trainable=True, y_bounds=(0, 6)
+        )
 
         assert isinstance(si.x, Constant)
         assert math.allclose(si.x.value, x[idx])
@@ -489,8 +497,12 @@ class TestDM:
         k1 = Coherent([1], x=1, y=3)
         k01 = Coherent([0, 1], x=1, y=[2, 3])
 
-        res_k0 = ((dm @ k0.dual @ k0.dual.adjoint) >> TraceOut([1])).representation.array
-        res_k1 = ((dm @ k1.dual @ k1.dual.adjoint) >> TraceOut([0])).representation.array
+        res_k0 = (
+            (dm @ k0.dual @ k0.dual.adjoint) >> TraceOut([1])
+        ).representation.array
+        res_k1 = (
+            (dm @ k1.dual @ k1.dual.adjoint) >> TraceOut([0])
+        ).representation.array
         res_k01 = (dm @ k01.dual @ k01.dual.adjoint).representation.array
 
         assert math.allclose(dm.expectation(k0), res_k0)
@@ -530,7 +542,7 @@ class TestDM:
         with pytest.raises(ValueError, match="Cannot calculate the expectation value"):
             dm.expectation(op1)
 
-        op2 = CircuitComponent("", None, modes_in_ket=[0], modes_out_ket=[1])
+        op2 = CircuitComponent(None, modes_in_ket=[0], modes_out_ket=[1])
         with pytest.raises(ValueError, match="different modes"):
             dm.expectation(op2)
 
@@ -542,11 +554,11 @@ class TestDM:
         ket = Coherent([0, 1], 1)
         unitary = Dgate([0], 1)
         u_component = CircuitComponent._from_attributes(
-            unitary.name, unitary.representation, unitary.wires
+            unitary.representation, unitary.wires, unitary.name
         )  # pylint: disable=protected-access
         channel = Attenuator([1], 1)
         ch_component = CircuitComponent._from_attributes(
-            channel.name, channel.representation, channel.wires
+            channel.representation, channel.wires, channel.name
         )  # pylint: disable=protected-access
 
         dm = ket >> channel
@@ -676,7 +688,9 @@ class TestDisplacedSqueezed:
     @pytest.mark.parametrize("modes,x,y,r,phi", zip(modes, x, y, r, phi))
     def test_representation(self, modes, x, y, r, phi):
         rep = DisplacedSqueezed(modes, x, y, r, phi).representation
-        exp = (Vacuum(modes) >> Sgate(modes, r, phi) >> Dgate(modes, x, y)).representation
+        exp = (
+            Vacuum(modes) >> Sgate(modes, r, phi) >> Dgate(modes, x, y)
+        ).representation
         assert rep == exp
 
     def test_representation_error(self):
@@ -811,7 +825,9 @@ class TestThermal:
     @pytest.mark.parametrize("nbar", [1, [2, 3], [4, 4]])
     def test_representation(self, nbar):
         rep = Thermal([0, 1], nbar).representation
-        exp = Bargmann(*thermal_state_Abc([nbar, nbar] if isinstance(nbar, int) else nbar))
+        exp = Bargmann(
+            *thermal_state_Abc([nbar, nbar] if isinstance(nbar, int) else nbar)
+        )
         assert rep == exp
 
     def test_representation_error(self):
@@ -832,7 +848,9 @@ class TestVisualization:
 
     def test_visualize_2d(self):
         st = Coherent([0], y=1) + Coherent([0], y=-1)
-        fig = st.visualize_2d(resolution=20, xbounds=(-3, 3), pbounds=(-4, 4), return_fig=True)
+        fig = st.visualize_2d(
+            resolution=20, xbounds=(-3, 3), pbounds=(-4, 4), return_fig=True
+        )
         data = fig.to_dict()
 
         if self.regenerate_assets:
@@ -855,7 +873,9 @@ class TestVisualization:
 
     def test_visualize_3d(self):
         st = Coherent([0], y=1) + Coherent([0], y=-1)
-        fig = st.visualize_3d(resolution=20, xbounds=(-3, 3), pbounds=(-4, 4), return_fig=True)
+        fig = st.visualize_3d(
+            resolution=20, xbounds=(-3, 3), pbounds=(-4, 4), return_fig=True
+        )
         data = fig.to_dict()
 
         if self.regenerate_assets:

--- a/tests/test_lab_dev/test_transformations.py
+++ b/tests/test_lab_dev/test_transformations.py
@@ -238,18 +238,12 @@ class TestDgate:
         assert math.allclose(rep1.c, [0.990049833749168])
 
         rep2 = Dgate(modes=[0, 1], x=[0.1, 0.2], y=0.1).representation
-        assert math.allclose(
-            rep2.A, [[[0, 0, 1, 0], [0, 0, 0, 1], [1, 0, 0, 0], [0, 1, 0, 0]]]
-        )
-        assert math.allclose(
-            rep2.b, [[0.1 + 0.1j, 0.2 + 0.1j, -0.1 + 0.1j, -0.2 + 0.1j]]
-        )
+        assert math.allclose(rep2.A, [[[0, 0, 1, 0], [0, 0, 0, 1], [1, 0, 0, 0], [0, 1, 0, 0]]])
+        assert math.allclose(rep2.b, [[0.1 + 0.1j, 0.2 + 0.1j, -0.1 + 0.1j, -0.2 + 0.1j]])
         assert math.allclose(rep2.c, [0.9656054162575665])
 
         rep3 = Dgate(modes=[1, 8], x=[0.1, 0.2]).representation
-        assert math.allclose(
-            rep3.A, [[[0, 0, 1, 0], [0, 0, 0, 1], [1, 0, 0, 0], [0, 1, 0, 0]]]
-        )
+        assert math.allclose(rep3.A, [[[0, 0, 1, 0], [0, 0, 0, 1], [1, 0, 0, 0], [0, 1, 0, 0]]])
         assert math.allclose(rep3.b, [[0.1, 0.2, -0.1, -0.2]])
         assert math.allclose(rep3.c, [0.9753099120283327])
 
@@ -505,9 +499,7 @@ class TestAttenuator:
     def test_representation(self):
         rep1 = Attenuator(modes=[0], transmissivity=0.1).representation
         e = 0.31622777
-        assert math.allclose(
-            rep1.A, [[[0, e, 0, 0], [e, 0, 0, 0.9], [0, 0, 0, e], [0, 0.9, e, 0]]]
-        )
+        assert math.allclose(rep1.A, [[[0, e, 0, 0], [e, 0, 0, 0.9], [0, 0, 0, e], [0, 0.9, e, 0]]])
         assert math.allclose(rep1.b, np.zeros((1, 4)))
         assert math.allclose(rep1.c, [1.0])
 

--- a/tests/test_lab_dev/test_transformations.py
+++ b/tests/test_lab_dev/test_transformations.py
@@ -52,11 +52,11 @@ class TestUnitary:
         unitary1 = Dgate([0, 1], 1)
         unitary2 = Dgate([1, 2], 2)
         u_component = CircuitComponent._from_attributes(
-            unitary1.name, unitary1.representation, unitary1.wires
+            unitary1.representation, unitary1.wires, unitary1.name
         )  # pylint: disable=protected-access
         channel = Attenuator([1], 1)
         ch_component = CircuitComponent._from_attributes(
-            channel.name, channel.representation, channel.wires
+            channel.representation, channel.wires, channel.name
         )  # pylint: disable=protected-access
 
         assert isinstance(unitary1 >> unitary2, Unitary)
@@ -67,11 +67,11 @@ class TestUnitary:
     def test_repr(self):
         unitary1 = Dgate([0, 1], 1)
         u_component = CircuitComponent._from_attributes(
-            unitary1.name, unitary1.representation, unitary1.wires
+            unitary1.representation, unitary1.wires, unitary1.name
         )  # pylint: disable=protected-access
 
-        assert repr(unitary1) == "Unitary(name=Dgate, modes=[0, 1])"
-        assert repr(u_component) == "CircuitComponent(name=Dgate, modes=[0, 1])"
+        assert repr(unitary1) == "Unitary(modes=[0, 1], name=Dgate)"
+        assert repr(u_component) == "CircuitComponent(modes=[0, 1], name=Dgate)"
 
     def test_init_from_bargmann(self):
         A = np.array([[0, 1], [1, 0]])
@@ -117,12 +117,12 @@ class TestChannel:
     def test_rshift(self):
         unitary = Dgate([0, 1], 1)
         u_component = CircuitComponent._from_attributes(
-            unitary.name, unitary.representation, unitary.wires
+            unitary.representation, unitary.wires, unitary.name
         )  # pylint: disable=protected-access
         channel1 = Attenuator([1, 2], 0.9)
         channel2 = Attenuator([2, 3], 0.9)
         ch_component = CircuitComponent._from_attributes(
-            channel1.name, channel1.representation, channel1.wires
+            channel1.representation, channel1.wires, channel1.name
         )  # pylint: disable=protected-access
 
         assert isinstance(channel1 >> unitary, Channel)
@@ -133,11 +133,11 @@ class TestChannel:
     def test_repr(self):
         channel1 = Attenuator([0, 1], 0.9)
         ch_component = CircuitComponent._from_attributes(
-            channel1.name, channel1.representation, channel1.wires
+            channel1.representation, channel1.wires, channel1.name
         )  # pylint: disable=protected-access
 
-        assert repr(channel1) == "Channel(name=Att, modes=[0, 1])"
-        assert repr(ch_component) == "CircuitComponent(name=Att, modes=[0, 1])"
+        assert repr(channel1) == "Channel(modes=[0, 1], name=Att)"
+        assert repr(ch_component) == "CircuitComponent(modes=[0, 1], name=Att)"
 
     def test_inverse_channel(self):
         gate = Sgate([0], 0.1, 0.2) >> Dgate([0], 0.1, 0.2) >> Attenuator([0], 0.5)
@@ -238,12 +238,18 @@ class TestDgate:
         assert math.allclose(rep1.c, [0.990049833749168])
 
         rep2 = Dgate(modes=[0, 1], x=[0.1, 0.2], y=0.1).representation
-        assert math.allclose(rep2.A, [[[0, 0, 1, 0], [0, 0, 0, 1], [1, 0, 0, 0], [0, 1, 0, 0]]])
-        assert math.allclose(rep2.b, [[0.1 + 0.1j, 0.2 + 0.1j, -0.1 + 0.1j, -0.2 + 0.1j]])
+        assert math.allclose(
+            rep2.A, [[[0, 0, 1, 0], [0, 0, 0, 1], [1, 0, 0, 0], [0, 1, 0, 0]]]
+        )
+        assert math.allclose(
+            rep2.b, [[0.1 + 0.1j, 0.2 + 0.1j, -0.1 + 0.1j, -0.2 + 0.1j]]
+        )
         assert math.allclose(rep2.c, [0.9656054162575665])
 
         rep3 = Dgate(modes=[1, 8], x=[0.1, 0.2]).representation
-        assert math.allclose(rep3.A, [[[0, 0, 1, 0], [0, 0, 0, 1], [1, 0, 0, 0], [0, 1, 0, 0]]])
+        assert math.allclose(
+            rep3.A, [[[0, 0, 1, 0], [0, 0, 0, 1], [1, 0, 0, 0], [0, 1, 0, 0]]]
+        )
         assert math.allclose(rep3.b, [[0.1, 0.2, -0.1, -0.2]])
         assert math.allclose(rep3.c, [0.9753099120283327])
 
@@ -499,7 +505,9 @@ class TestAttenuator:
     def test_representation(self):
         rep1 = Attenuator(modes=[0], transmissivity=0.1).representation
         e = 0.31622777
-        assert math.allclose(rep1.A, [[[0, e, 0, 0], [e, 0, 0, 0.9], [0, 0, 0, e], [0, 0.9, e, 0]]])
+        assert math.allclose(
+            rep1.A, [[[0, e, 0, 0], [e, 0, 0, 0.9], [0, 0, 0, e], [0, 0.9, e, 0]]]
+        )
         assert math.allclose(rep1.b, np.zeros((1, 4)))
         assert math.allclose(rep1.c, [1.0])
 

--- a/tests/test_lab_dev/test_transformations.py
+++ b/tests/test_lab_dev/test_transformations.py
@@ -42,7 +42,7 @@ class TestUnitary:
     @pytest.mark.parametrize("name", [None, "my_unitary"])
     @pytest.mark.parametrize("modes", [{0}, {0, 1}, {3, 19, 2}])
     def test_init(self, name, modes):
-        gate = Unitary(name, modes)
+        gate = Unitary(modes, name=name)
 
         assert gate.name[:1] == (name or "U")[:1]
         assert list(gate.modes) == sorted(modes)
@@ -95,7 +95,7 @@ class TestChannel:
     @pytest.mark.parametrize("name", [None, "my_channel"])
     @pytest.mark.parametrize("modes", [{0}, {0, 1}, {3, 19, 2}])
     def test_init(self, name, modes):
-        gate = Channel(name, modes)
+        gate = Channel(modes, name=name)
 
         assert gate.name[:2] == (name or "Ch")[:2]
         assert list(gate.modes) == sorted(modes)
@@ -238,12 +238,18 @@ class TestDgate:
         assert math.allclose(rep1.c, [0.990049833749168])
 
         rep2 = Dgate(modes=[0, 1], x=[0.1, 0.2], y=0.1).representation
-        assert math.allclose(rep2.A, [[[0, 0, 1, 0], [0, 0, 0, 1], [1, 0, 0, 0], [0, 1, 0, 0]]])
-        assert math.allclose(rep2.b, [[0.1 + 0.1j, 0.2 + 0.1j, -0.1 + 0.1j, -0.2 + 0.1j]])
+        assert math.allclose(
+            rep2.A, [[[0, 0, 1, 0], [0, 0, 0, 1], [1, 0, 0, 0], [0, 1, 0, 0]]]
+        )
+        assert math.allclose(
+            rep2.b, [[0.1 + 0.1j, 0.2 + 0.1j, -0.1 + 0.1j, -0.2 + 0.1j]]
+        )
         assert math.allclose(rep2.c, [0.9656054162575665])
 
         rep3 = Dgate(modes=[1, 8], x=[0.1, 0.2]).representation
-        assert math.allclose(rep3.A, [[[0, 0, 1, 0], [0, 0, 0, 1], [1, 0, 0, 0], [0, 1, 0, 0]]])
+        assert math.allclose(
+            rep3.A, [[[0, 0, 1, 0], [0, 0, 0, 1], [1, 0, 0, 0], [0, 1, 0, 0]]]
+        )
         assert math.allclose(rep3.b, [[0.1, 0.2, -0.1, -0.2]])
         assert math.allclose(rep3.c, [0.9753099120283327])
 
@@ -499,7 +505,9 @@ class TestAttenuator:
     def test_representation(self):
         rep1 = Attenuator(modes=[0], transmissivity=0.1).representation
         e = 0.31622777
-        assert math.allclose(rep1.A, [[[0, e, 0, 0], [e, 0, 0, 0.9], [0, 0, 0, e], [0, 0.9, e, 0]]])
+        assert math.allclose(
+            rep1.A, [[[0, e, 0, 0], [e, 0, 0, 0.9], [0, 0, 0, e], [0, 0.9, e, 0]]]
+        )
         assert math.allclose(rep1.b, np.zeros((1, 4)))
         assert math.allclose(rep1.c, [1.0])
 

--- a/tests/test_physics/test_ansatz.py
+++ b/tests/test_physics/test_ansatz.py
@@ -280,12 +280,8 @@ class TestArrayAnsatz:
         assert isinstance(aa1_div_aa2, ArrayAnsatz)
         assert aa1_div_aa2.array.shape == (4, 2, 2)
         assert np.allclose(aa1_div_aa2.array[0], np.array([[1.0, 1.0], [1.0, 1.0]]))
-        assert np.allclose(
-            aa1_div_aa2.array[1], np.array([[0.2, 0.33333], [0.42857143, 0.5]])
-        )
-        assert np.allclose(
-            aa1_div_aa2.array[2], np.array([[5.0, 3.0], [2.33333333, 2.0]])
-        )
+        assert np.allclose(aa1_div_aa2.array[1], np.array([[0.2, 0.33333], [0.42857143, 0.5]]))
+        assert np.allclose(aa1_div_aa2.array[2], np.array([[5.0, 3.0], [2.33333333, 2.0]]))
         assert np.allclose(aa1_div_aa2.array[3], np.array([[1.0, 1.0], [1.0, 1.0]]))
 
     def test_algebra_with_different_shape_of_array_raise_errors(self):
@@ -345,7 +341,9 @@ class TestArrayAnsatz:
             new_state_coeff1,
         ) = bargmann_Abc_to_phasespace_cov_means(A1, b1, c1)
 
-        A22, b22, c22 = (state >> BtoPS([0], 0) >> BtoPS([1], 0)).bargmann  # pylint: disable=protected-access
+        A22, b22, c22 = (
+            state >> BtoPS([0], 0) >> BtoPS([1], 0)
+        ).bargmann  # pylint: disable=protected-access
         (
             new_state_cov22,
             new_state_means22,

--- a/tests/test_physics/test_ansatz.py
+++ b/tests/test_physics/test_ansatz.py
@@ -27,7 +27,7 @@ from mrmustard.physics.ansatze import (
 )
 from mrmustard.lab_dev.states.base import DM
 from mrmustard.physics.bargmann import wigner_to_bargmann_rho
-from mrmustard.lab_dev.circuit_components_utils import DsMap
+from mrmustard.lab_dev.circuit_components_utils import BtoPS
 from ..random import Abc_triple
 
 
@@ -280,8 +280,12 @@ class TestArrayAnsatz:
         assert isinstance(aa1_div_aa2, ArrayAnsatz)
         assert aa1_div_aa2.array.shape == (4, 2, 2)
         assert np.allclose(aa1_div_aa2.array[0], np.array([[1.0, 1.0], [1.0, 1.0]]))
-        assert np.allclose(aa1_div_aa2.array[1], np.array([[0.2, 0.33333], [0.42857143, 0.5]]))
-        assert np.allclose(aa1_div_aa2.array[2], np.array([[5.0, 3.0], [2.33333333, 2.0]]))
+        assert np.allclose(
+            aa1_div_aa2.array[1], np.array([[0.2, 0.33333], [0.42857143, 0.5]])
+        )
+        assert np.allclose(
+            aa1_div_aa2.array[2], np.array([[5.0, 3.0], [2.33333333, 2.0]])
+        )
         assert np.allclose(aa1_div_aa2.array[3], np.array([[1.0, 1.0], [1.0, 1.0]]))
 
     def test_algebra_with_different_shape_of_array_raise_errors(self):
@@ -310,7 +314,7 @@ class TestArrayAnsatz:
         state_cov = np.array([[0.32210229, -0.99732956], [-0.99732956, 6.1926484]])
         state_means = np.array([0.2, 0.3])
         state = DM.from_bargmann([0], wigner_to_bargmann_rho(state_cov, state_means))
-        state_after = state >> DsMap(modes=[0], s=0)  # pylint: disable=protected-access
+        state_after = state >> BtoPS(modes=[0], s=0)  # pylint: disable=protected-access
         A1, b1, c1 = state_after.bargmann
         (
             new_state_cov,
@@ -333,7 +337,7 @@ class TestArrayAnsatz:
         A, b, c = wigner_to_bargmann_rho(state_cov, state_means)
         state = DM.from_bargmann(modes=[0, 1], triple=(A, b, c))
 
-        state_after = state >> DsMap(modes=[0, 1], s=0)  # pylint: disable=protected-access
+        state_after = state >> BtoPS(modes=[0, 1], s=0)  # pylint: disable=protected-access
         A1, b1, c1 = state_after.bargmann
         (
             new_state_cov1,
@@ -341,9 +345,7 @@ class TestArrayAnsatz:
             new_state_coeff1,
         ) = bargmann_Abc_to_phasespace_cov_means(A1, b1, c1)
 
-        A22, b22, c22 = (
-            state >> DsMap([0], 0) >> DsMap([1], 0)
-        ).bargmann  # pylint: disable=protected-access
+        A22, b22, c22 = (state >> BtoPS([0], 0) >> BtoPS([1], 0)).bargmann  # pylint: disable=protected-access
         (
             new_state_cov22,
             new_state_means22,

--- a/tests/test_physics/test_gaussian_integrals.py
+++ b/tests/test_physics/test_gaussian_integrals.py
@@ -33,9 +33,21 @@ def test_real_gaussian_integral():
     A = math.astensor(
         np.array(
             [
-                [0.35307718 - 0.09738001j, -0.01297994 + 0.26050244j, 0.05349344 - 0.13728068j],
-                [-0.01297994 + 0.26050244j, 0.05696707 - 0.2351408j, 0.18954838 - 0.42959383j],
-                [0.05349344 - 0.13728068j, 0.18954838 - 0.42959383j, -0.16931712 - 0.09205837j],
+                [
+                    0.35307718 - 0.09738001j,
+                    -0.01297994 + 0.26050244j,
+                    0.05349344 - 0.13728068j,
+                ],
+                [
+                    -0.01297994 + 0.26050244j,
+                    0.05696707 - 0.2351408j,
+                    0.18954838 - 0.42959383j,
+                ],
+                [
+                    0.05349344 - 0.13728068j,
+                    0.18954838 - 0.42959383j,
+                    -0.16931712 - 0.09205837j,
+                ],
             ]
         )
     )
@@ -43,7 +55,9 @@ def test_real_gaussian_integral():
     c = 1.0 + 0j
     res = real_gaussian_integral((A, b, c), idx=[0, 1])
     assert np.allclose(res[0], A[2, 2] - A[2:, :2] @ math.inv(A[:2, :2]) @ A[:2, 2:])
-    assert np.allclose(res[1], b[2] - math.sum(A[2:, :2] * math.matvec(math.inv(A[:2, :2]), b[:2])))
+    assert np.allclose(
+        res[1], b[2] - math.sum(A[2:, :2] * math.matvec(math.inv(A[:2, :2]), b[:2]))
+    )
     assert np.allclose(
         res[2],
         c
@@ -87,11 +101,6 @@ def test_join_Abc():
     assert np.allclose(joined_Abc[0], math.block_diag(A1, A2))
     assert np.allclose(joined_Abc[1], math.concat([b1, b2], axis=-1))
     assert np.allclose(joined_Abc[2], math.outer(c1, c2))
-
-    A12 = math.block_diag(A1, A2)
-    b12 = math.concat([b1, b2], axis=-1)
-    c12 = math.outer(c1, c2)
-    return A12, b12, c12
 
 
 def test_join_Abc_real():
@@ -148,7 +157,9 @@ def test_complex_gaussian_integral():
     assert np.allclose(res2[1], b3)
     assert np.allclose(res2[2], c3)
 
-    res3 = complex_gaussian_integral(join_Abc((A1, b1, c1), (A1, b1, c1)), [0, 1], [2, 3])
+    res3 = complex_gaussian_integral(
+        join_Abc((A1, b1, c1), (A1, b1, c1)), [0, 1], [2, 3]
+    )
     assert np.allclose(res3[0], 0)
     assert np.allclose(res3[1], 0)
     assert np.allclose(res3[2], 1)
@@ -176,7 +187,9 @@ def test_contract_two_Abc():
 
     res1 = contract_two_Abc((A1, b1, c1), (A2, b2, c2), [], [])
     assert np.allclose(res1[0], math.block_diag(A1, A2))
-    assert np.allclose(res1[1], [0, 0, 0.1 + 0.3j, 0.2 + 0.3j, -0.1 + 0.3j, -0.2 + 0.3j])
+    assert np.allclose(
+        res1[1], [0, 0, 0.1 + 0.3j, 0.2 + 0.3j, -0.1 + 0.3j, -0.2 + 0.3j]
+    )
     assert np.allclose(res1[2], c1 * c2)
 
     res2 = contract_two_Abc((A1, b1, c1), (A2, b2, c2), [0, 1], [2, 3])
@@ -203,9 +216,13 @@ def test_reorder_abc():
     same = reorder_abc((A, b, c), (0, 1))
     assert all(np.allclose(x, y) for x, y in zip(same, (A, b, c)))
     flipped = reorder_abc((A, b, c), (1, 0))
-    assert all(np.allclose(x, y) for x, y in zip(flipped, (A[[1, 0], :][:, [1, 0]], b[[1, 0]], c)))
+    assert all(
+        np.allclose(x, y)
+        for x, y in zip(flipped, (A[[1, 0], :][:, [1, 0]], b[[1, 0]], c))
+    )
     c = np.array([[6, 7], [8, 9]])
     flipped = reorder_abc((A, b, c), (1, 0))  #  test transposition of c
     assert all(
-        np.allclose(x, y) for x, y in zip(flipped, (A[[1, 0], :][:, [1, 0]], b[[1, 0]], c.T))
+        np.allclose(x, y)
+        for x, y in zip(flipped, (A[[1, 0], :][:, [1, 0]], b[[1, 0]], c.T))
     )


### PR DESCRIPTION
**Context:**
We can use the inverse of BtoQ to define a QtoB map. This way the code to initialize from quadrature is drastically simplified, and it can be placed higher in the hierarchy. 

**Description of the Change:**
Introduces two classes: Operation <- Unitary and Map <- Channel (in the sense that Operation and Map are the parents of Unitary and Channel). This sets things up for Kraus operators and allows us to correctly type objects that are not strictly unitaries or channels.

**Benefits:**
Simpler code, more robust. 

**Possible Drawbacks:**
More classes