### PR TITLE
skip training on numpy, improve drawing

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Save pytest timings to an S3 bucket for regression analysis. Also add a script to help
   visualize the timing results quickly.
   [(#404)](https://github.com/XanaduAI/MrMustard/pull/404)
+  [(#421)](https://github.com/XanaduAI/MrMustard/pull/421)
 
 ### Bug fixes
 * Fix the bug in the order of indices of the triples for DsMap CircuitComponent. 

--- a/.github/workflows/scripts/visualize_timings.py
+++ b/.github/workflows/scripts/visualize_timings.py
@@ -52,43 +52,26 @@ def load_timings(file: Path):
     ]
 
 
-if __name__ == "__main__":
-    parser = ArgumentParser(
-        usage=(
-            "visualize_timings.py [-h] data_folder"
-            "\n\n1. Sync files from S3 using the AWS CLI. For example:\n\t"
-            "aws s3 sync s3://top-secret-bucket-name/numpy_tests/develop/ /path/to/local/folder/\n"
-            "2. Run this script:\n\t"
-            "python .github/workflows/scripts/visualize_timings.py /path/to/local/folder"
-        ),
-        description="Visualize pytest duration data to detect regressions.",
-    )
-    parser.add_argument("data_folder", type=str, help="Folder where duration files are synced")
-    args = parser.parse_args()
-    data_folder = Path(args.data_folder)
+def draw_mpl(timings_dict, ncols=3):
+    """
+    Draw using the Matplotlib backend.
 
-    # sort duration files (named with epoch timestamps) then load timings
-    duration_files = sorted(data_folder.glob("durations_*.txt"))
-    all_timings = list(map(load_timings, duration_files))
-
-    timings_dict: Dict[str, List[Tuple[int, float]]] = defaultdict(list)
-    for i, commit_timings in enumerate(all_timings):
-        for test_name, timing in commit_timings:
-            timings_dict[test_name].append((i, timing))
-
-    # LineCollection usage taken from: https://stackoverflow.com/a/15773341
-
-    groups = {group_name: list(group) for group_name, group in groupby(sorted(timings_dict), key=lambda x: x.split("/")[1])}
+    LineCollection usage taken from: https://stackoverflow.com/a/15773341
+    """
+    groups = {
+        group_name: list(group)
+        for group_name, group in groupby(sorted(timings_dict), key=lambda x: x.split("/")[1])
+    }
 
     fig = plt.figure(1)
-    my_cmap = plt.get_cmap('jet')
+    my_cmap = plt.get_cmap("jet")
 
     tot = len(groups)
-    cols = 3
+    cols = ncols
     rows = sum(divmod(tot, cols))
 
     for idx, (group, test_names) in enumerate(groups.items()):
-        ax = fig.add_subplot(rows, cols, idx+1)
+        ax = fig.add_subplot(rows, cols, idx + 1)
         ax.set_title(group)
         colours = [my_cmap(random()) for _ in test_names]
         values = [timings_dict[n] for n in test_names]
@@ -100,6 +83,139 @@ if __name__ == "__main__":
     fig.tight_layout()
     fig.set_dpi(200)
     plt.show()
+
+
+def draw_plotly(timings_dict, use_short_name):
+    """Draw using the plotly backend."""
+    import plotly.graph_objs as go
+
+    layout = go.Layout(
+        title="Test durations over history of commits",
+        xaxis=dict(title="Commit"),
+        yaxis=dict(title="Test Duration (s)"),
+    )
+    lines = []
+    timings_sorted = {
+        k: v
+        for k, v in sorted(
+            timings_dict.items(), key=lambda item: max(val[1] for val in item[1]), reverse=True
+        )
+    }
+    for test_name, data in timings_sorted.items():
+        x, y = list(zip(*data))
+        if use_short_name:
+            test_name = test_name.split("::")[-1]
+        lines.append(go.Scatter(x=x, y=y, mode="lines", name=test_name))
+    fig = go.Figure(data=lines, layout=layout)
+
+    fig.show()
+    return fig
+
+
+def draw_plotly_group(timings_dict, use_short_name, ncols=3):
+    """Draw using the plotly backend, grouping by test module."""
+    import numpy as np
+    import plotly.graph_objs as go
+    from plotly.subplots import make_subplots
+
+    groups = {
+        group_name: list(group)
+        for group_name, group in groupby(sorted(timings_dict), key=lambda x: x.split("/")[1])
+    }
+    tot = len(groups)
+    cols = ncols
+    rows = sum(divmod(tot, cols))
+    fig = make_subplots(rows, cols, subplot_titles=list(groups))
+    fig.update_layout(dict(title="Test durations over history of commits"))
+
+    for (row, col), (group, test_names) in zip(np.ndindex((rows, cols)), groups.items()):
+        for test_name in test_names:
+            x, y = list(zip(*timings_dict[test_name]))
+            if use_short_name:
+                test_name = test_name.split("::")[-1]
+            fig.add_trace(
+                go.Scatter(
+                    x=x,
+                    y=y,
+                    mode="lines",
+                    name=test_name,
+                    legendgroup=group,
+                    legendgrouptitle_text=group,
+                ),
+                row=row + 1,
+                col=col + 1,
+            )
+
+    fig.show()
+    return fig
+
+
+def remove_n_largest_plotly(fig, n):
+    """Hide the first ``n`` traces in a plotly figure."""
+    fig.update_traces(visible=None)  # reset in case some were hidden before
+    for n in range(-1, -1 - n, -1):
+        fig.update_traces(selector=n, visible="legendonly")
+    fig.show()
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser(
+        usage=(
+            "visualize_timings.py [-h] data_folder [--mode <mode>] [--ncols <NCOLS>] [--short-name]"
+            "\n\n1. Sync files from S3 using the AWS CLI. For example:\n\t"
+            "aws s3 sync s3://top-secret-bucket-name/numpy_tests/develop/ /path/to/local/folder/\n"
+            "2. Run this script:\n\t"
+            "python .github/workflows/scripts/visualize_timings.py /path/to/local/folder"
+        ),
+        description="Visualize pytest duration data to detect regressions.",
+    )
+    parser.add_argument("data_folder", type=str, help="Folder where duration files are synced")
+    parser.add_argument(
+        "-m",
+        "--mode",
+        required=False,
+        default="plotly",
+        choices=["plotly", "mpl", "plotly-grouped"],
+        help="The plotting backend to use",
+    )
+    parser.add_argument(
+        "--ncols",
+        default=3,
+        required=False,
+        type=int,
+        help="Number of modules per row (does nothing in the default 'plotly' mode)",
+    )
+    parser.add_argument(
+        "--short-name", action="store_true", help="Show only the test name without the file path"
+    )
+    args = parser.parse_args()
+    data_folder = Path(args.data_folder)
+    mode, ncols, use_short_name = args.mode, args.ncols, args.short_name
+
+    # sort duration files (named with epoch timestamps) then load timings
+    duration_files = sorted(data_folder.glob("durations_*.txt"))
+    all_timings = list(map(load_timings, duration_files))
+
+    timings_dict: Dict[str, List[Tuple[int, float]]] = defaultdict(list)
+    for i, commit_timings in enumerate(all_timings):
+        for test_name, timing in commit_timings:
+            timings_dict[test_name].append((i, timing))
+
+    # delete test_about and any tests that are all-zero
+    to_delete = {"tests/test_about.py::test_about"}
+    for test_name, commit_and_times in timings_dict.items():
+        if all(t == 0 for _, t in commit_and_times):
+            to_delete.add(test_name)
+
+    for test_name in to_delete:
+        del timings_dict[test_name]
+
+    if mode == "mpl":
+        draw_mpl(timings_dict, ncols)
+    elif mode == "plotly":
+        draw_plotly(timings_dict, use_short_name)
+    elif mode == "plotly-grouped":
+        draw_plotly_group(timings_dict, use_short_name, ncols)
 
     # test_times: Dict[str, List[float]] = {test_name: [t for _, t in idx_and_timing] for test_name, idx_and_timing in timings_dict.items()}
     # """Map from test name to sorted list of timings. Useful for computational analysis."""

--- a/.github/workflows/scripts/visualize_timings.py
+++ b/.github/workflows/scripts/visualize_timings.py
@@ -55,7 +55,7 @@ def load_timings(file: Path):
     ]
 
 
-def draw_mpl(timings_dict, ncols=3):
+def draw_mpl(timings_dict, ncols, num_commits):
     """
     Draw using the Matplotlib backend.
 
@@ -80,7 +80,7 @@ def draw_mpl(timings_dict, ncols=3):
         values = [timings_dict[n] for n in test_names]
         ln_coll = LineCollection(values, colors=colours)
         ax.add_collection(ln_coll)
-        ax.set_xlim(0, len(all_timings) - 1)
+        ax.set_xlim(0, num_commits - 1)
         ax.set_ylim(0, max(max(v[1] for v in value_set) for value_set in values) + 0.01)
 
     fig.tight_layout()
@@ -110,7 +110,7 @@ def draw_plotly(timings_dict, use_short_name):
     return fig
 
 
-def draw_plotly_group(timings_dict, use_short_name, ncols=3):
+def draw_plotly_group(timings_dict, use_short_name, ncols):
     """Draw using the plotly backend, grouping by test module."""
 
     groups = {
@@ -173,7 +173,7 @@ def main(data_folder, mode, ncols, use_short_name):
         del timings_dict[test_name]
 
     if mode == "mpl":
-        draw_mpl(timings_dict, ncols)
+        draw_mpl(timings_dict, ncols, len(all_timings))
     elif mode == "plotly":
         draw_plotly(timings_dict, use_short_name)
     elif mode == "plotly-grouped":
@@ -214,6 +214,5 @@ if __name__ == "__main__":
         "--short-name", action="store_true", help="Show only the test name without the file path"
     )
     args = parser.parse_args()
-    data_folder = Path(args.data_folder)
-    mode, ncols, use_short_name = args.mode, args.ncols, args.short_name
-    main(data_folder, mode, ncols, use_short_name)
+    folder = Path(args.data_folder)
+    main(folder, args.mode, args.ncols, args.use_short_name)

--- a/.github/workflows/scripts/visualize_timings.py
+++ b/.github/workflows/scripts/visualize_timings.py
@@ -154,6 +154,7 @@ def remove_n_largest_plotly(fig, n):
 
 
 def main(data_folder, mode, ncols, use_short_name):
+    """Load durations by commit, then draw them using the appropriate backend."""
     # sort duration files (named with epoch timestamps) then load timings
     duration_files = sorted(data_folder.glob("durations_*.txt"))
     all_timings = list(map(load_timings, duration_files))

--- a/.github/workflows/scripts/visualize_timings.py
+++ b/.github/workflows/scripts/visualize_timings.py
@@ -96,9 +96,9 @@ def draw_plotly(timings_dict, use_short_name):
         yaxis={"title": "Test Duration (s)"},
     )
     lines = []
-    timings_sorted = dict(sorted(
-        timings_dict.items(), key=lambda item: max(val[1] for val in item[1]), reverse=True
-    ))
+    timings_sorted = dict(
+        sorted(timings_dict.items(), key=lambda item: max(val[1] for val in item[1]), reverse=True)
+    )
     for test_name, data in timings_sorted.items():
         x, y = list(zip(*data))
         if use_short_name:

--- a/.github/workflows/scripts/visualize_timings.py
+++ b/.github/workflows/scripts/visualize_timings.py
@@ -216,4 +216,4 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
     folder = Path(args.data_folder)
-    main(folder, args.mode, args.ncols, args.use_short_name)
+    main(folder, args.mode, args.ncols, args.short_name)

--- a/mrmustard/lab_dev/states/base.py
+++ b/mrmustard/lab_dev/states/base.py
@@ -423,6 +423,7 @@ class State(CircuitComponent):
             z=math.transpose(z),
             colorscale=colorscale,
             name="Wigner function",
+            autocolorscale=False,
         )
         fig.add_trace(fig_21, row=2, col=1)
         fig.update_traces(row=2, col=1, showscale=False)
@@ -631,7 +632,7 @@ class DM(State):
 
     def __init__(
         self,
-        modes: Sequence[int, ...] = (),
+        modes: Sequence[int] = (),
         representation: Optional[Bargmann | Fock] = None,
         name: Optional[str] = None,
     ):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+from pathlib import Path
 import pytest
 
 from mrmustard import math
@@ -50,6 +51,13 @@ def backend(request):
     Extracts ``backend`` from request.
     """
     return request.config.getoption("--backend")
+
+
+def pytest_ignore_collect(path, config):
+    backend = config.getoption("--backend")
+    if backend == "numpy" and "test_training" in Path(path).parts:
+        return True
+    return False
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,8 +54,8 @@ def backend(request):
 
 
 def pytest_ignore_collect(path, config):
-    backend = config.getoption("--backend")
-    if backend == "numpy" and "test_training" in Path(path).parts:
+    """Skip test_training when using the numpy backend."""
+    if config.getoption("--backend") == "numpy" and "test_training" in Path(path).parts:
         return True
     return False
 


### PR DESCRIPTION
**Context:**
The drawing tool is not very useful today, so I touched it up a bit by adding `plotly` support.

**Description of the Change:**
1. Skip all `test_training` tests when using `numpy` because they do nothing
2. Add the `plotly` and `plotly-grouped` modes to the test visualizer because it's much better
3. filter out `test_about` and any tests that always return 0.0 (in other words, that always finish in 50ms or less) because we can't get anything useful from that

**Benefits:**
- Easier to glean some information from the visualizer
- No time wasted running silly numpy tests that do nothing

**Possible Drawbacks:**
N/A

<details>
<summary>How to use it (from a notebook)</summary>

```
# authenticate with AWS first!
!aws s3 sync s3://<top-secret-bucket-name>/ /some/path/you/choose/
%run .github/workflows/scripts/visualize_timings.py /some/path/you/choose/numpy_tests/develop/
%run .github/workflows/scripts/visualize_timings.py /some/path/you/choose/tf_tests/develop/ --mode plotly-grouped --ncols 2 --short-name
```
</details>