### PR TITLE
Added methods and test for `normalize()`

### DIFF
--- a/mrmustard/lab_dev/circuit_components.py
+++ b/mrmustard/lab_dev/circuit_components.py
@@ -247,6 +247,9 @@ class CircuitComponent:
         r"""
         The quadrature representation data of this circuit component.
         """
+        if isinstance(self.representation, Fock):
+            raise NotImplementedError("not implemented with Fock representation")
+
         from mrmustard.lab_dev.circuit_components_utils import BtoQ
 
         BtoQ_ob = BtoQ(self.wires.output.bra.modes, phi).adjoint

--- a/mrmustard/lab_dev/circuit_components.py
+++ b/mrmustard/lab_dev/circuit_components.py
@@ -250,7 +250,7 @@ class CircuitComponent:
         The quadrature representation data of this circuit component.
         """
         if isinstance(self.representation, Fock):
-            raise NotImplementedError("not implemented with Fock representation")
+            raise NotImplementedError("Not implemented with Fock representation.")
 
         from mrmustard.lab_dev.circuit_components_utils import BtoQ
 

--- a/mrmustard/lab_dev/states/base.py
+++ b/mrmustard/lab_dev/states/base.py
@@ -846,7 +846,7 @@ class Ket(State):
 
     def normalize(self) -> Ket:
         r"""
-        Normalizes this ket.
+        Returns a rescaled version of the state such that its probability is 1
         """
         return self / math.sqrt(self.probability)
 

--- a/mrmustard/lab_dev/states/base.py
+++ b/mrmustard/lab_dev/states/base.py
@@ -673,6 +673,10 @@ class DM(State):
         shape_check(cov, means, 2 * len(modes), "Phase space")
         return coeff * DM(modes, Bargmann(*wigner_to_bargmann_rho(cov, means)), name)
 
+    def normalize(self) -> DM:
+        r"""Returns a rescaled version of the state such that its probability is 1."""
+        return self / self.probability
+
     @property
     def _probabilities(self) -> RealVector:
         r"""Element-wise probabilities along the batch dimension of this DM.
@@ -838,6 +842,12 @@ class Ket(State):
                 msg = f"Cannot initialize a Ket: purity is {p:.5f} (must be at least 1.0-{atol_purity})."
                 raise ValueError(msg)
         return Ket(modes, coeff * Bargmann(*wigner_to_bargmann_psi(cov, means)), name)
+
+    def normalize(self) -> Ket:
+        r"""
+        Normalizes this ket.
+        """
+        return self / math.sqrt(self.probability)
 
     @property
     def _probabilities(self) -> RealVector:

--- a/mrmustard/lab_dev/states/base.py
+++ b/mrmustard/lab_dev/states/base.py
@@ -675,7 +675,9 @@ class DM(State):
         return coeff * DM(modes, Bargmann(*wigner_to_bargmann_rho(cov, means)), name)
 
     def normalize(self) -> DM:
-        r"""Returns a rescaled version of the state such that its probability is 1."""
+        r"""
+        Returns a rescaled version of the state such that its probability is 1.
+        """
         return self / self.probability
 
     @property

--- a/mrmustard/math/backend_tensorflow.py
+++ b/mrmustard/math/backend_tensorflow.py
@@ -61,6 +61,7 @@ class BackendTensorflow(BackendBase):  # pragma: no cover
     complex128 = tf.complex128
 
     def __init__(self):
+        tf.experimental.numpy.experimental_enable_numpy_behavior()
         super().__init__(name="tensorflow")
 
     def __repr__(self) -> str:
@@ -294,7 +295,6 @@ class BackendTensorflow(BackendBase):  # pragma: no cover
         return tf.math.pow(x, y)
 
     def kron(self, tensor1: tf.Tensor, tensor2: tf.Tensor):
-        tf.experimental.numpy.experimental_enable_numpy_behavior()
         return tf.experimental.numpy.kron(tensor1, tensor2)
 
     def prod(self, x: tf.Tensor, axis: Union[None, int]):

--- a/mrmustard/physics/ansatze.py
+++ b/mrmustard/physics/ansatze.py
@@ -377,8 +377,9 @@ class PolyExpAnsatz(PolyExpBase):
             return self.__class__(A=new_a, b=new_b, c=new_c)
         else:
             try:
-                return self.__class__(self.A, self.b, self.c / other)
+                return self.__class__(self.A, self.b, self.c / math.cast(other, math.complex128))
             except Exception as e:
+                print(e)
                 raise TypeError(f"Cannot divide {self.__class__} and {other.__class__}.") from e
 
     def __and__(self, other: PolyExpAnsatz) -> PolyExpAnsatz:
@@ -494,7 +495,7 @@ class ArrayAnsatz(Ansatz):
             except Exception as e:
                 raise TypeError(f"Cannot divide {self.__class__} and {other.__class__}.") from e
         else:
-            return self.__class__(array=self.array / other)
+            return self.__class__(array=self.array / math.cast(other, math.complex128))
 
     def __mul__(self, other: Union[Scalar, ArrayAnsatz]) -> ArrayAnsatz:
         r"""

--- a/mrmustard/physics/ansatze.py
+++ b/mrmustard/physics/ansatze.py
@@ -379,7 +379,6 @@ class PolyExpAnsatz(PolyExpBase):
             try:
                 return self.__class__(self.A, self.b, self.c / other)
             except Exception as e:
-                print(e)
                 raise TypeError(f"Cannot divide {self.__class__} and {other.__class__}.") from e
 
     def __and__(self, other: PolyExpAnsatz) -> PolyExpAnsatz:

--- a/mrmustard/physics/ansatze.py
+++ b/mrmustard/physics/ansatze.py
@@ -377,7 +377,7 @@ class PolyExpAnsatz(PolyExpBase):
             return self.__class__(A=new_a, b=new_b, c=new_c)
         else:
             try:
-                return self.__class__(self.A, self.b, self.c / math.cast(other, math.complex128))
+                return self.__class__(self.A, self.b, self.c / other)
             except Exception as e:
                 print(e)
                 raise TypeError(f"Cannot divide {self.__class__} and {other.__class__}.") from e
@@ -495,7 +495,7 @@ class ArrayAnsatz(Ansatz):
             except Exception as e:
                 raise TypeError(f"Cannot divide {self.__class__} and {other.__class__}.") from e
         else:
-            return self.__class__(array=self.array / math.cast(other, math.complex128))
+            return self.__class__(array=self.array / other)
 
     def __mul__(self, other: Union[Scalar, ArrayAnsatz]) -> ArrayAnsatz:
         r"""

--- a/tests/test_lab_dev/test_states.py
+++ b/tests/test_lab_dev/test_states.py
@@ -47,7 +47,7 @@ from mrmustard.lab_dev.wires import Wires
 autocutoff_max0 = settings.AUTOCUTOFF_MAX_CUTOFF
 
 
-class TestKet:
+class TestKet:  # pylint: disable=too-many-public-methods
     r"""
     Tests for the ``Ket`` class.
     """
@@ -122,7 +122,9 @@ class TestKet:
 
         n_modes = len(modes)
 
-        state1 = Ket.from_phase_space(modes, (vacuum_cov(n_modes), vacuum_means(n_modes), 1.0))
+        state1 = Ket.from_phase_space(
+            modes, (vacuum_cov(n_modes), vacuum_means(n_modes), 1.0)
+        )
         assert state1 == Vacuum(modes)
 
         r = [i / 10 for i in range(n_modes)]
@@ -320,7 +322,9 @@ class TestKet:
 
         si = s[m]
         assert isinstance(si, DisplacedSqueezed)
-        assert si == DisplacedSqueezed(m, x=x[idx], y=3, y_trainable=True, y_bounds=(0, 6))
+        assert si == DisplacedSqueezed(
+            m, x=x[idx], y=3, y_trainable=True, y_bounds=(0, 6)
+        )
 
         assert isinstance(si.x, Constant)
         assert math.allclose(si.x.value, x[idx])
@@ -679,7 +683,9 @@ class TestDisplacedSqueezed:
     @pytest.mark.parametrize("modes,x,y,r,phi", zip(modes, x, y, r, phi))
     def test_representation(self, modes, x, y, r, phi):
         rep = DisplacedSqueezed(modes, x, y, r, phi).representation
-        exp = (Vacuum(modes) >> Sgate(modes, r, phi) >> Dgate(modes, x, y)).representation
+        exp = (
+            Vacuum(modes) >> Sgate(modes, r, phi) >> Dgate(modes, x, y)
+        ).representation
         assert rep == exp
 
     def test_representation_error(self):
@@ -800,7 +806,9 @@ class TestTwoModeSqueezedVacuum:
     def test_trainable_parameters(self):
         state1 = TwoModeSqueezedVacuum([0, 1], 1, 1)
         state2 = TwoModeSqueezedVacuum([0, 1], 1, 1, r_trainable=True, r_bounds=(0, 2))
-        state3 = TwoModeSqueezedVacuum([0, 1], 1, 1, phi_trainable=True, phi_bounds=(-2, 2))
+        state3 = TwoModeSqueezedVacuum(
+            [0, 1], 1, 1, phi_trainable=True, phi_bounds=(-2, 2)
+        )
 
         with pytest.raises(AttributeError):
             state1.r.value = 3
@@ -866,7 +874,9 @@ class TestThermal:
     @pytest.mark.parametrize("nbar", [1, [2, 3], [4, 4]])
     def test_representation(self, nbar):
         rep = Thermal([0, 1], nbar).representation
-        exp = Bargmann(*thermal_state_Abc([nbar, nbar] if isinstance(nbar, int) else nbar))
+        exp = Bargmann(
+            *thermal_state_Abc([nbar, nbar] if isinstance(nbar, int) else nbar)
+        )
         assert rep == exp
 
     def test_representation_error(self):
@@ -887,7 +897,9 @@ class TestVisualization:
 
     def test_visualize_2d(self):
         st = Coherent([0], y=1) + Coherent([0], y=-1)
-        fig = st.visualize_2d(resolution=20, xbounds=(-3, 3), pbounds=(-4, 4), return_fig=True)
+        fig = st.visualize_2d(
+            resolution=20, xbounds=(-3, 3), pbounds=(-4, 4), return_fig=True
+        )
         data = fig.to_dict()
 
         if self.regenerate_assets:
@@ -910,7 +922,9 @@ class TestVisualization:
 
     def test_visualize_3d(self):
         st = Coherent([0], y=1) + Coherent([0], y=-1)
-        fig = st.visualize_3d(resolution=20, xbounds=(-3, 3), pbounds=(-4, 4), return_fig=True)
+        fig = st.visualize_3d(
+            resolution=20, xbounds=(-3, 3), pbounds=(-4, 4), return_fig=True
+        )
         data = fig.to_dict()
 
         if self.regenerate_assets:

--- a/tests/test_lab_dev/test_states.py
+++ b/tests/test_lab_dev/test_states.py
@@ -419,6 +419,7 @@ class TestDM:
         state = state.to_fock(5)  # truncated
         normalized = state.normalize()
         assert np.isclose(normalized.probability, 1.0)
+
     @pytest.mark.parametrize("modes", [[0], [0, 1], [3, 19, 2]])
     def test_to_from_fock(self, modes):
         state_in = Coherent(modes, x=1, y=2) >> Attenuator([modes[0]], 0.8)

--- a/tests/test_lab_dev/test_states.py
+++ b/tests/test_lab_dev/test_states.py
@@ -52,6 +52,11 @@ class TestKet:  # pylint: disable=too-many-public-methods
     Tests for the ``Ket`` class.
     """
 
+    modes = [[[0]], [[0]]]
+    x = [[1.0], [1.0, -1.0]]
+    y = [[1.0], [1.0, -1.0]]
+    coeff = [0.5, 0.3]
+
     @pytest.mark.parametrize("name", [None, "my_ket"])
     @pytest.mark.parametrize("modes", [[0], [0, 1], [3, 19, 2]])
     def test_init(self, name, modes):
@@ -87,14 +92,12 @@ class TestKet:  # pylint: disable=too-many-public-methods
         with pytest.raises(AttributeError):
             Number([0], n=10).bargmann
 
-    @pytest.mark.parametrize(
-        "state",
-        [
-            0.5 * Coherent([0], x=1.0, y=1.0),
-            0.3 * (Coherent([0], x=1.0, y=1.0) + Coherent([0], x=-1.0, y=-1.0)),
-        ],
-    )
-    def test_normalize(self, state):
+    @pytest.mark.parametrize("modes,x,y,coeff", zip(modes, x, y, coeff))
+    def test_normalize(self, modes, x, y, coeff):
+        state = Coherent(modes[0], x[0], y[0])
+        for i in range(1, len(modes)):
+            state += Coherent(modes[i], x[i], y[i])
+        state = coeff * state
         # Bargmann
         normalized = state.normalize()
         assert np.isclose(normalized.probability, 1.0)
@@ -102,6 +105,7 @@ class TestKet:  # pylint: disable=too-many-public-methods
         state = state.to_fock(5)  # truncated
         normalized = state.normalize()
         assert np.isclose(normalized.probability, 1.0)
+
     @pytest.mark.parametrize("modes", [[0], [0, 1], [3, 19, 2]])
     def test_to_from_fock(self, modes):
         state_in = Coherent(modes, x=1, y=2)
@@ -360,6 +364,11 @@ class TestDM:
     Tests for the ``DM`` class.
     """
 
+    modes = [[[0]], [[0]]]
+    x = [[1], [1, -1]]
+    y = [[1], [1, -1]]
+    coeff = [0.5, 0.3]
+
     @pytest.mark.parametrize("name", [None, "my_dm"])
     @pytest.mark.parametrize("modes", [{0}, {0, 1}, {3, 19, 2}])
     def test_init(self, name, modes):
@@ -397,14 +406,12 @@ class TestDM:
         with pytest.raises(AttributeError):
             fock.bargmann
 
-    @pytest.mark.parametrize(
-        "state",
-        [
-            0.5 * Coherent([0], x=1.0, y=1.0).dm(),
-            0.3 * (Coherent([0], x=1.0, y=1.0).dm() + Coherent([0], x=-1.0, y=-1.0).dm()),
-        ],
-    )
-    def test_normalize(self, state):
+    @pytest.mark.parametrize("modes,x,y,coeff", zip(modes, x, y, coeff))
+    def test_normalize(self, modes, x, y, coeff):
+        state = Coherent(modes[0], x[0], y[0]).dm()
+        for i in range(1, len(modes)):
+            state += Coherent(modes[i], x[i], y[i]).dm()
+        state *= coeff
         # Bargmann
         normalized = state.normalize()
         assert np.isclose(normalized.probability, 1.0)

--- a/tests/test_lab_dev/test_states.py
+++ b/tests/test_lab_dev/test_states.py
@@ -87,16 +87,21 @@ class TestKet:  # pylint: disable=too-many-public-methods
         with pytest.raises(AttributeError):
             Number([0], n=10).bargmann
 
-    def test_normalize(self):
+    @pytest.mark.parametrize(
+        "state",
+        [
+            0.5 * Coherent([0], x=1.0, y=1.0),
+            0.3 * (Coherent([0], x=1.0, y=1.0) + Coherent([0], x=-1.0, y=-1.0)),
+        ],
+    )
+    def test_normalize(self, state):
         # Bargmann
-        coh = Coherent([0], x=1.0, y=1.0) * 0.5
-        normalized = coh.normalize()
+        normalized = state.normalize()
         assert np.isclose(normalized.probability, 1.0)
         # Fock
-        coh.to_fock(5)  # truncated
-        normalized = coh.normalize()
+        state = state.to_fock(5)  # truncated
+        normalized = state.normalize()
         assert np.isclose(normalized.probability, 1.0)
-
     @pytest.mark.parametrize("modes", [[0], [0, 1], [3, 19, 2]])
     def test_to_from_fock(self, modes):
         state_in = Coherent(modes, x=1, y=2)

--- a/tests/test_lab_dev/test_states.py
+++ b/tests/test_lab_dev/test_states.py
@@ -397,16 +397,21 @@ class TestDM:
         with pytest.raises(AttributeError):
             fock.bargmann
 
-    def test_normalize(self):
+    @pytest.mark.parametrize(
+        "state",
+        [
+            0.5 * Coherent([0], x=1.0, y=1.0).dm(),
+            0.3 * (Coherent([0], x=1.0, y=1.0).dm() + Coherent([0], x=-1.0, y=-1.0).dm()),
+        ],
+    )
+    def test_normalize(self, state):
         # Bargmann
-        coh = Coherent([0], x=1.0, y=1.0).dm() * 0.5
-        normalized = coh.normalize()
+        normalized = state.normalize()
         assert np.isclose(normalized.probability, 1.0)
         # Fock
-        coh.to_fock(5)  # truncated
-        normalized = coh.normalize()
+        state = state.to_fock(5)  # truncated
+        normalized = state.normalize()
         assert np.isclose(normalized.probability, 1.0)
-
     @pytest.mark.parametrize("modes", [[0], [0, 1], [3, 19, 2]])
     def test_to_from_fock(self, modes):
         state_in = Coherent(modes, x=1, y=2) >> Attenuator([modes[0]], 0.8)

--- a/tests/test_lab_dev/test_states.py
+++ b/tests/test_lab_dev/test_states.py
@@ -122,9 +122,7 @@ class TestKet:  # pylint: disable=too-many-public-methods
 
         n_modes = len(modes)
 
-        state1 = Ket.from_phase_space(
-            modes, (vacuum_cov(n_modes), vacuum_means(n_modes), 1.0)
-        )
+        state1 = Ket.from_phase_space(modes, (vacuum_cov(n_modes), vacuum_means(n_modes), 1.0))
         assert state1 == Vacuum(modes)
 
         r = [i / 10 for i in range(n_modes)]
@@ -322,9 +320,7 @@ class TestKet:  # pylint: disable=too-many-public-methods
 
         si = s[m]
         assert isinstance(si, DisplacedSqueezed)
-        assert si == DisplacedSqueezed(
-            m, x=x[idx], y=3, y_trainable=True, y_bounds=(0, 6)
-        )
+        assert si == DisplacedSqueezed(m, x=x[idx], y=3, y_trainable=True, y_bounds=(0, 6))
 
         assert isinstance(si.x, Constant)
         assert math.allclose(si.x.value, x[idx])
@@ -683,9 +679,7 @@ class TestDisplacedSqueezed:
     @pytest.mark.parametrize("modes,x,y,r,phi", zip(modes, x, y, r, phi))
     def test_representation(self, modes, x, y, r, phi):
         rep = DisplacedSqueezed(modes, x, y, r, phi).representation
-        exp = (
-            Vacuum(modes) >> Sgate(modes, r, phi) >> Dgate(modes, x, y)
-        ).representation
+        exp = (Vacuum(modes) >> Sgate(modes, r, phi) >> Dgate(modes, x, y)).representation
         assert rep == exp
 
     def test_representation_error(self):
@@ -806,9 +800,7 @@ class TestTwoModeSqueezedVacuum:
     def test_trainable_parameters(self):
         state1 = TwoModeSqueezedVacuum([0, 1], 1, 1)
         state2 = TwoModeSqueezedVacuum([0, 1], 1, 1, r_trainable=True, r_bounds=(0, 2))
-        state3 = TwoModeSqueezedVacuum(
-            [0, 1], 1, 1, phi_trainable=True, phi_bounds=(-2, 2)
-        )
+        state3 = TwoModeSqueezedVacuum([0, 1], 1, 1, phi_trainable=True, phi_bounds=(-2, 2))
 
         with pytest.raises(AttributeError):
             state1.r.value = 3
@@ -874,9 +866,7 @@ class TestThermal:
     @pytest.mark.parametrize("nbar", [1, [2, 3], [4, 4]])
     def test_representation(self, nbar):
         rep = Thermal([0, 1], nbar).representation
-        exp = Bargmann(
-            *thermal_state_Abc([nbar, nbar] if isinstance(nbar, int) else nbar)
-        )
+        exp = Bargmann(*thermal_state_Abc([nbar, nbar] if isinstance(nbar, int) else nbar))
         assert rep == exp
 
     def test_representation_error(self):
@@ -897,9 +887,7 @@ class TestVisualization:
 
     def test_visualize_2d(self):
         st = Coherent([0], y=1) + Coherent([0], y=-1)
-        fig = st.visualize_2d(
-            resolution=20, xbounds=(-3, 3), pbounds=(-4, 4), return_fig=True
-        )
+        fig = st.visualize_2d(resolution=20, xbounds=(-3, 3), pbounds=(-4, 4), return_fig=True)
         data = fig.to_dict()
 
         if self.regenerate_assets:
@@ -922,9 +910,7 @@ class TestVisualization:
 
     def test_visualize_3d(self):
         st = Coherent([0], y=1) + Coherent([0], y=-1)
-        fig = st.visualize_3d(
-            resolution=20, xbounds=(-3, 3), pbounds=(-4, 4), return_fig=True
-        )
+        fig = st.visualize_3d(resolution=20, xbounds=(-3, 3), pbounds=(-4, 4), return_fig=True)
         data = fig.to_dict()
 
         if self.regenerate_assets:

--- a/tests/test_lab_dev/test_states.py
+++ b/tests/test_lab_dev/test_states.py
@@ -87,6 +87,16 @@ class TestKet:
         with pytest.raises(AttributeError):
             Number([0], n=10).bargmann
 
+    def test_normalize(self):
+        # Bargmann
+        coh = Coherent([0], x=1.0, y=1.0) * 0.5
+        normalized = coh.normalize()
+        assert np.isclose(normalized.probability, 1.0)
+        # Fock
+        coh.to_fock(5)  # truncated
+        normalized = coh.normalize()
+        assert np.isclose(normalized.probability, 1.0)
+
     @pytest.mark.parametrize("modes", [[0], [0, 1], [3, 19, 2]])
     def test_to_from_fock(self, modes):
         state_in = Coherent(modes, x=1, y=2)
@@ -381,6 +391,16 @@ class TestDM:
         fock = Number([0], n=10).dm()
         with pytest.raises(AttributeError):
             fock.bargmann
+
+    def test_normalize(self):
+        # Bargmann
+        coh = Coherent([0], x=1.0, y=1.0).dm() * 0.5
+        normalized = coh.normalize()
+        assert np.isclose(normalized.probability, 1.0)
+        # Fock
+        coh.to_fock(5)  # truncated
+        normalized = coh.normalize()
+        assert np.isclose(normalized.probability, 1.0)
 
     @pytest.mark.parametrize("modes", [[0], [0, 1], [3, 19, 2]])
     def test_to_from_fock(self, modes):


### PR DESCRIPTION
`Ket` and `DM` now have a method `normalize()` which returns a normalized version of the state (prob = 1)