### PR TITLE
Unitary override inverse 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ lint:
 
 test:
 	@echo "Testing Mr Mustard..."
-	$(PYTHON) $(TESTRUNNER)
+	$(PYTHON3) $(TESTRUNNER)
 
 coverage:
 	@echo "Generating coverage report for Mr Mustard..."

--- a/mrmustard/lab_dev/transformations/base.py
+++ b/mrmustard/lab_dev/transformations/base.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Xanadu Quantum Technologies Inc.
+# Copyright 2024 Xanadu Quantum Technologies Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mrmustard/lab_dev/transformations/base.py
+++ b/mrmustard/lab_dev/transformations/base.py
@@ -49,9 +49,11 @@ class Transformation(CircuitComponent):
         phi: float = 0,
         name: Optional[str] = None,
     ) -> Operation:
-        r"""Initialize an Operation from the given quadrature triple (A, b, c).
+        r"""
+        Initialize an Operation from the given quadrature triple (A, b, c).
         The triple parametrizes the quadrature representation of the transformation as
-        :math:`c * exp(0.5*x^T A x + b^T x)`."""
+        :math:`c * exp(0.5*x^T A x + b^T x)`.
+        """
         from mrmustard.lab_dev.circuit_components_utils import BtoQ
 
         QtoB_out = BtoQ(modes_out, phi).inverse()
@@ -68,13 +70,16 @@ class Transformation(CircuitComponent):
         triple: tuple,
         name: Optional[str] = None,
     ) -> Operation:
-        r"""Initialize a Transformation from the given Bargmann triple (A,b,c)
+        r"""
+        Initialize a Transformation from the given Bargmann triple (A,b,c)
         which parametrizes the Bargmann function of the transformation as
-        :math:`c * exp(0.5*z^T A z + b^T z)`."""
+        :math:`c * exp(0.5*z^T A z + b^T z)`.
+        """
         return cls(modes_out, modes_in, Bargmann(*triple), name)
 
     def inverse(self) -> Transformation:
-        r"""Returns the mathematical inverse of the transformation, if it exists.
+        r"""
+        Returns the mathematical inverse of the transformation, if it exists.
         Note that it can be unphysical, for example when the original is not unitary.
 
         Returns:
@@ -108,8 +113,10 @@ class Transformation(CircuitComponent):
 
 
 class Operation(Transformation):
-    r"""A CircuitComponent with input and output wires on the ket side. Operation are allowed
-    to have a different number of input and output wires."""
+    r"""
+    A CircuitComponent with input and output wires on the ket side. Operation are allowed
+    to have a different number of input and output wires.
+    """
 
     short_name = "Op"
 
@@ -169,7 +176,10 @@ class Unitary(Operation):
         symplectic: tuple,
         name: Optional[str] = None,
     ) -> Unitary:
-        r"""Initialize a Unitary from the given symplectic matrix in qqpp basis, i.e. the axes are ordered as [q0, q1, ..., p0, p1, ...]."""
+        r"""
+        Initialize a Unitary from the given symplectic matrix in qqpp basis,
+        i.e. the axes are ordered as [q0, q1, ..., p0, p1, ...].
+        """
         M = len(modes_in) + len(modes_out)
         if symplectic.shape[-2:] != (M, M):
             raise ValueError(
@@ -184,9 +194,12 @@ class Unitary(Operation):
             name=name,
         )
 
+    def inverse(self) -> Transformation:
+        return self.dual
 
 class Map(Transformation):
-    r"""A CircuitComponent more general than Channels, which are CPTP Maps.
+    r"""
+    A CircuitComponent more general than Channels, which are CPTP Maps.
 
     Arguments:
         modes_out: The output modes of this Map.

--- a/mrmustard/lab_dev/transformations/base.py
+++ b/mrmustard/lab_dev/transformations/base.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Xanadu Quantum Technologies Inc.
+# Copyright 2023 Xanadu Quantum Technologies Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ from mrmustard import math
 from mrmustard.lab_dev.wires import Wires
 from mrmustard.physics.representations import Bargmann, Fock
 from mrmustard import physics
-from ..circuit_components import CircuitComponent
+from ..circuit_components import CircuitComponent, DualView
 
 __all__ = ["Transformation", "Operation", "Unitary", "Map", "Channel"]
 
@@ -194,7 +194,7 @@ class Unitary(Operation):
             name=name,
         )
 
-    def inverse(self) -> Transformation:
+    def inverse(self) -> DualView:
         return self.dual
 
 

--- a/mrmustard/lab_dev/transformations/base.py
+++ b/mrmustard/lab_dev/transformations/base.py
@@ -30,7 +30,7 @@ from mrmustard import math
 from mrmustard.lab_dev.wires import Wires
 from mrmustard.physics.representations import Bargmann, Fock
 from mrmustard import physics
-from ..circuit_components import CircuitComponent, DualView
+from ..circuit_components import CircuitComponent
 
 __all__ = ["Transformation", "Operation", "Unitary", "Map", "Channel"]
 
@@ -194,8 +194,13 @@ class Unitary(Operation):
             name=name,
         )
 
-    def inverse(self) -> DualView:
-        return self.dual
+    def inverse(self) -> Unitary:
+        unitary_dual = self.dual
+        return Unitary._from_attributes(
+            representation=unitary_dual.representation,
+            wires=unitary_dual.wires,
+            name=unitary_dual.name,
+        )
 
 
 class Map(Transformation):

--- a/mrmustard/lab_dev/transformations/base.py
+++ b/mrmustard/lab_dev/transformations/base.py
@@ -197,6 +197,7 @@ class Unitary(Operation):
     def inverse(self) -> Transformation:
         return self.dual
 
+
 class Map(Transformation):
     r"""
     A CircuitComponent more general than Channels, which are CPTP Maps.

--- a/tests/test_lab_dev/test_transformations.py
+++ b/tests/test_lab_dev/test_transformations.py
@@ -107,7 +107,10 @@ class TestUnitary:
 
     def test_inverse_unitary(self):
         gate = Sgate([0], 0.1, 0.2) >> Dgate([0], 0.1, 0.2)
-        should_be_identity = gate >> gate.inverse()
+        gate_inv = gate.inverse()
+        gate_inv_inv = gate_inv.inverse()
+        assert gate_inv_inv == gate
+        should_be_identity = gate >> gate_inv
         assert should_be_identity.representation == Dgate([0], 0.0, 0.0).representation
 
 

--- a/tests/test_math/test_backend_manager.py
+++ b/tests/test_math/test_backend_manager.py
@@ -266,7 +266,7 @@ class TestBackendManager:
         arr2 = np.array([[5, 6], [7, 8]])
         params = ((arr1, arr2), axis)
         res = math.asnumpy(math.concat(*params))
-        return np.allclose(res, np.concatenate(*params))
+        assert np.allclose(res, np.concatenate(*params))
 
     @pytest.mark.parametrize("l", lists)
     def test_conj(self, l):


### PR DESCRIPTION
**Context:**
`Transformation`'s `inverse()` method numerically computes the inverse. We can avoid this on `Unitary` by calling `self.dual`.

**Description of the Change:**
`Unitary` now overrides `inverse()` to call `self.dual`. Additionally, small formatting changes are included and a fix to the Makefile.