### PR TITLE
shape of c

### DIFF
--- a/mrmustard/math/lattice/strategies/vanilla.py
+++ b/mrmustard/math/lattice/strategies/vanilla.py
@@ -53,8 +53,8 @@ def vanilla(shape: tuple[int, ...], A, b, c) -> ComplexTensor:  # pragma: no cov
     next(index_u_iter)
 
     # write vacuum amplitude
-    # ret[0] = c
-    ret[0] = 1
+    ret[0] = c
+
 
     # iterate over the rest of the indices
     for index_u in index_u_iter:
@@ -73,7 +73,7 @@ def vanilla(shape: tuple[int, ...], A, b, c) -> ComplexTensor:  # pragma: no cov
             value_at_index += A[i, j] * np.sqrt(index_u[j]) * ret[n]
         ret[index] = value_at_index / np.sqrt(index_u[i])
 
-    return ret.reshape(shape) * c
+    return ret.reshape(shape)
 
 
 @njit

--- a/mrmustard/math/lattice/strategies/vanilla.py
+++ b/mrmustard/math/lattice/strategies/vanilla.py
@@ -53,7 +53,8 @@ def vanilla(shape: tuple[int, ...], A, b, c) -> ComplexTensor:  # pragma: no cov
     next(index_u_iter)
 
     # write vacuum amplitude
-    ret[0] = c
+    # ret[0] = c
+    ret[0] = 1
 
     # iterate over the rest of the indices
     for index_u in index_u_iter:
@@ -72,7 +73,7 @@ def vanilla(shape: tuple[int, ...], A, b, c) -> ComplexTensor:  # pragma: no cov
             value_at_index += A[i, j] * np.sqrt(index_u[j]) * ret[n]
         ret[index] = value_at_index / np.sqrt(index_u[i])
 
-    return ret.reshape(shape)
+    return ret.reshape(shape) * c
 
 
 @njit

--- a/mrmustard/math/lattice/strategies/vanilla.py
+++ b/mrmustard/math/lattice/strategies/vanilla.py
@@ -55,7 +55,6 @@ def vanilla(shape: tuple[int, ...], A, b, c) -> ComplexTensor:  # pragma: no cov
     # write vacuum amplitude
     ret[0] = c
 
-
     # iterate over the rest of the indices
     for index_u in index_u_iter:
         # update index

--- a/mrmustard/physics/ansatze.py
+++ b/mrmustard/physics/ansatze.py
@@ -394,20 +394,10 @@ class PolyExpAnsatz(PolyExpBase):
             The tensor product of this ansatz and other.
         """
 
-        def andc(c1, c2):
-            if c1.shape == (1,) and c2.shape == (1,):
-                c3 = math.outer(c1, c2).reshape(-1)
-            elif c1.shape == (1,):
-                c3 = math.outer(c1, c2).reshape(c2.shape)
-            elif c2.shape == (1,):
-                c3 = math.outer(c1, c2).reshape(c1.shape)
-            else:
-                c3 = math.outer(c1, c2).reshape(c1.shape + c2.shape)
-            return c3
 
         As = [math.block_diag(a1, a2) for a1 in self.A for a2 in other.A]
         bs = [math.concat([b1, b2], axis=-1) for b1 in self.b for b2 in other.b]
-        cs = [andc(c1, c2) for c1 in self.c for c2 in other.c]
+        cs = [math.outer(c1, c2).reshape(-1) for c1 in self.c for c2 in other.c]
         return self.__class__(As, bs, cs)
 
 

--- a/mrmustard/physics/ansatze.py
+++ b/mrmustard/physics/ansatze.py
@@ -393,9 +393,20 @@ class PolyExpAnsatz(PolyExpBase):
         Returns:
             The tensor product of this ansatz and other.
         """
+        def andc(c1,c2):
+            if c1.shape==(1,) and c2.shape==(1,):
+                c3 = math.outer(c1,c2).reshape(-1)
+            elif c1.shape==(1,):
+                c3 = math.outer(c1,c2).reshape(c2.shape)
+            elif c2.shape==(1,):
+                c3 = math.outer(c1,c2).reshape(c1.shape)
+            else:
+                c3 = math.outer(c1,c2).reshape(c1.shape+c2.shape)
+            return c3
+
         As = [math.block_diag(a1, a2) for a1 in self.A for a2 in other.A]
         bs = [math.concat([b1, b2], axis=-1) for b1 in self.b for b2 in other.b]
-        cs = [math.outer(c1, c2) for c1 in self.c for c2 in other.c]
+        cs = [andc(c1, c2) for c1 in self.c for c2 in other.c]
         return self.__class__(As, bs, cs)
 
 

--- a/mrmustard/physics/ansatze.py
+++ b/mrmustard/physics/ansatze.py
@@ -139,9 +139,9 @@ class PolyExpBase(Ansatz):
     """
 
     def __init__(self, mat: Batch[Matrix], vec: Batch[Vector], array: Batch[Tensor]):
-        self.mat = math.atleast_3d(math.astensor(mat))
-        self.vec = math.atleast_2d(math.astensor(vec))
-        self.array = math.atleast_2d(math.astensor(array))
+        self.mat = math.atleast_3d(mat)
+        self.vec = math.atleast_2d(vec)
+        self.array = math.atleast_2d(array)
         self.batch_size = self.mat.shape[0]
         self.num_vars = self.mat.shape[-1]
         self._simplified = False

--- a/mrmustard/physics/ansatze.py
+++ b/mrmustard/physics/ansatze.py
@@ -394,7 +394,6 @@ class PolyExpAnsatz(PolyExpBase):
             The tensor product of this ansatz and other.
         """
 
-
         As = [math.block_diag(a1, a2) for a1 in self.A for a2 in other.A]
         bs = [math.concat([b1, b2], axis=-1) for b1 in self.b for b2 in other.b]
         cs = [math.outer(c1, c2).reshape(-1) for c1 in self.c for c2 in other.c]

--- a/mrmustard/physics/ansatze.py
+++ b/mrmustard/physics/ansatze.py
@@ -393,15 +393,16 @@ class PolyExpAnsatz(PolyExpBase):
         Returns:
             The tensor product of this ansatz and other.
         """
-        def andc(c1,c2):
-            if c1.shape==(1,) and c2.shape==(1,):
-                c3 = math.outer(c1,c2).reshape(-1)
-            elif c1.shape==(1,):
-                c3 = math.outer(c1,c2).reshape(c2.shape)
-            elif c2.shape==(1,):
-                c3 = math.outer(c1,c2).reshape(c1.shape)
+
+        def andc(c1, c2):
+            if c1.shape == (1,) and c2.shape == (1,):
+                c3 = math.outer(c1, c2).reshape(-1)
+            elif c1.shape == (1,):
+                c3 = math.outer(c1, c2).reshape(c2.shape)
+            elif c2.shape == (1,):
+                c3 = math.outer(c1, c2).reshape(c1.shape)
             else:
-                c3 = math.outer(c1,c2).reshape(c1.shape+c2.shape)
+                c3 = math.outer(c1, c2).reshape(c1.shape + c2.shape)
             return c3
 
         As = [math.block_diag(a1, a2) for a1 in self.A for a2 in other.A]

--- a/mrmustard/physics/ansatze.py
+++ b/mrmustard/physics/ansatze.py
@@ -141,7 +141,7 @@ class PolyExpBase(Ansatz):
     def __init__(self, mat: Batch[Matrix], vec: Batch[Vector], array: Batch[Tensor]):
         self.mat = math.atleast_3d(math.astensor(mat))
         self.vec = math.atleast_2d(math.astensor(vec))
-        self.array = math.atleast_1d(math.astensor(array))
+        self.array = math.atleast_2d(math.astensor(array))
         self.batch_size = self.mat.shape[0]
         self.num_vars = self.mat.shape[-1]
         self._simplified = False

--- a/mrmustard/physics/ansatze.py
+++ b/mrmustard/physics/ansatze.py
@@ -398,7 +398,7 @@ class PolyExpAnsatz(PolyExpBase):
 
         As = [math.block_diag(a1, a2) for a1 in self.A for a2 in other.A]
         bs = [math.concat([b1, b2], axis=-1) for b1 in self.b for b2 in other.b]
-        cs = [math.outer(c1, c2).reshape(-1) for c1 in self.c for c2 in other.c]
+        cs = [math.reshape(math.outer(c1, c2), -1) for c1 in self.c for c2 in other.c]
         return self.__class__(As, bs, cs)
 
 

--- a/mrmustard/physics/converters.py
+++ b/mrmustard/physics/converters.py
@@ -61,8 +61,7 @@ def to_fock(rep: Representation, shape: Optional[Union[int, Iterable[int]]] = No
             raise ValueError(msg)
 
         array = [
-            math.hermite_renormalized(A, b, c[0], shape)
-            for A, b, c in zip(rep.A, rep.b, rep.c)
+            math.hermite_renormalized(A, b, c[0], shape) for A, b, c in zip(rep.A, rep.b, rep.c)
         ]
         fock = Fock(math.astensor(array), batched=True)
         fock._original_bargmann_data = rep.data

--- a/mrmustard/physics/converters.py
+++ b/mrmustard/physics/converters.py
@@ -60,7 +60,10 @@ def to_fock(rep: Representation, shape: Optional[Union[int, Iterable[int]]] = No
             msg += f"the number of variables of this ansatz ({rep.ansatz.num_vars})."
             raise ValueError(msg)
 
-        array = [math.hermite_renormalized(A, b, complex(c), shape) for A, b, c in zip(rep.A, rep.b, rep.c)]
+        array = [
+            math.hermite_renormalized(A, b, complex(c), shape)
+            for A, b, c in zip(rep.A, rep.b, rep.c)
+        ]
         fock = Fock(math.astensor(array), batched=True)
         fock._original_bargmann_data = rep.data
         return fock

--- a/mrmustard/physics/converters.py
+++ b/mrmustard/physics/converters.py
@@ -61,7 +61,7 @@ def to_fock(rep: Representation, shape: Optional[Union[int, Iterable[int]]] = No
             raise ValueError(msg)
 
         array = [
-            math.hermite_renormalized(A, b, complex(c), shape)
+            math.hermite_renormalized(A, b, c[0], shape)
             for A, b, c in zip(rep.A, rep.b, rep.c)
         ]
         fock = Fock(math.astensor(array), batched=True)

--- a/mrmustard/physics/converters.py
+++ b/mrmustard/physics/converters.py
@@ -60,7 +60,7 @@ def to_fock(rep: Representation, shape: Optional[Union[int, Iterable[int]]] = No
             msg += f"the number of variables of this ansatz ({rep.ansatz.num_vars})."
             raise ValueError(msg)
 
-        array = [math.hermite_renormalized(A, b, c, shape) for A, b, c in zip(rep.A, rep.b, rep.c)]
+        array = [math.hermite_renormalized(A, b, complex(c), shape) for A, b, c in zip(rep.A, rep.b, rep.c)]
         fock = Fock(math.astensor(array), batched=True)
         fock._original_bargmann_data = rep.data
         return fock

--- a/mrmustard/physics/gaussian_integrals.py
+++ b/mrmustard/physics/gaussian_integrals.py
@@ -186,7 +186,6 @@ def join_Abc_real(
     idx1: Sequence[int],
     idx2: Sequence[int],
 ):
-    # pylint: disable=R1260
     r"""Direct sum of two ``(A,b,c)`` triples into a single ``(A,b,c)`` triple, where indices corresponding to the same variable are "fused together", by considering their Bargmann function has having the same variables. For example ``idx1=(0,1,2)`` and ``idx2=(1,2,3)`` means that indices 1 and 2 will be fused because they are present on both tuples. This is useful for computing real Gaussian integrals where the variable on either object is the same, rather than a pair of conjugate variables for complex Gaussian integrals.
 
     Arguments:

--- a/mrmustard/physics/gaussian_integrals.py
+++ b/mrmustard/physics/gaussian_integrals.py
@@ -284,7 +284,7 @@ def contract_two_Abc(
     Abc2: Tuple[ComplexMatrix, ComplexVector, complex],
     idx1: Sequence[int],
     idx2: Sequence[int],
-): 
+):
     r"""
     Returns the contraction of two ``(A,b,c)`` triples with given indices.
 

--- a/mrmustard/physics/gaussian_integrals.py
+++ b/mrmustard/physics/gaussian_integrals.py
@@ -185,7 +185,7 @@ def join_Abc_real(
     Abc2: Tuple[ComplexMatrix, ComplexVector, ComplexTensor],
     idx1: Sequence[int],
     idx2: Sequence[int],
-): # pylint: disable=too-complex
+):  # pylint: disable=R1260
     r"""Direct sum of two ``(A,b,c)`` triples into a single ``(A,b,c)`` triple, where indices corresponding to the same variable are "fused together", by considering their Bargmann function has having the same variables. For example ``idx1=(0,1,2)`` and ``idx2=(1,2,3)`` means that indices 1 and 2 will be fused because they are present on both tuples. This is useful for computing real Gaussian integrals where the variable on either object is the same, rather than a pair of conjugate variables for complex Gaussian integrals.
 
     Arguments:

--- a/mrmustard/physics/gaussian_integrals.py
+++ b/mrmustard/physics/gaussian_integrals.py
@@ -168,6 +168,8 @@ def join_Abc(
     A12 = math.block_diag(math.cast(A1, "complex128"), math.cast(A2, "complex128"))
     b12 = math.concat([b1, b2], axis=-1)
     # c12 = math.outer(c1, c2)
+    c1 = math.astensor(c1)
+    c2 = math.astensor(c2)
     if c1.shape==(1,) and c2.shape==(1,):
         c12 = math.outer(c1,c2).reshape(-1)
     elif c1.shape==(1,):
@@ -228,11 +230,31 @@ def join_Abc_real(
     if math.asnumpy(not_idx1).shape == (0,):
         A12 = math.block([[A1 + A2_idx_idx, A2_notidx_idx], [A2_idx_notidx, A2_notidx_notidx]])
         b12 = math.concat([b1 + b2_idx, b2_notidx], axis=-1)
-        c12 = math.outer(c1, c2)
+        # c12 = math.outer(c1, c2)
+        c1 = math.astensor(c1)
+        c2 = math.astensor(c2)
+        if c1.shape==(1,) and c2.shape==(1,):
+            c12 = math.outer(c1,c2).reshape(-1)
+        elif c1.shape==(1,):
+            c12 = math.outer(c1,c2).reshape(c2.shape)
+        elif c2.shape==(1,):
+            c12 = math.outer(c1,c2).reshape(c1.shape)
+        else:
+            c12 = math.outer(c1,c2).reshape(c1.shape+c2.shape)
     elif math.asnumpy(not_idx2).shape == (0,):
         A12 = math.block([[A2 + A1_idx_idx, A1_notidx_idx], [A1_idx_notidx, A1_notidx_notidx]])
         b12 = math.concat([b2 + b1_idx, b1_notidx], axis=-1)
-        c12 = math.outer(c1, c2)
+        # c12 = math.outer(c1, c2)
+        c1 = math.astensor(c1)
+        c2 = math.astensor(c2)
+        if c1.shape==(1,) and c2.shape==(1,):
+            c12 = math.outer(c1,c2).reshape(-1)
+        elif c1.shape==(1,):
+            c12 = math.outer(c1,c2).reshape(c2.shape)
+        elif c2.shape==(1,):
+            c12 = math.outer(c1,c2).reshape(c1.shape)
+        else:
+            c12 = math.outer(c1,c2).reshape(c1.shape+c2.shape)
     else:
         O_n = math.zeros((len(not_idx1), len(not_idx2)), math.complex128)
         A12 = math.block(
@@ -243,7 +265,17 @@ def join_Abc_real(
             ]
         )
         b12 = math.concat([b1_idx + b2_idx, b1_notidx, b2_notidx], axis=-1)
-        c12 = math.outer(c1, c2)
+        # c12 = math.outer(c1, c2)
+        c1 = math.astensor(c1)
+        c2 = math.astensor(c2)
+        if c1.shape==(1,) and c2.shape==(1,):
+            c12 = math.outer(c1,c2).reshape(-1)
+        elif c1.shape==(1,):
+            c12 = math.outer(c1,c2).reshape(c2.shape)
+        elif c2.shape==(1,):
+            c12 = math.outer(c1,c2).reshape(c1.shape)
+        else:
+            c12 = math.outer(c1,c2).reshape(c1.shape+c2.shape)
     return A12, b12, c12
 
 

--- a/mrmustard/physics/gaussian_integrals.py
+++ b/mrmustard/physics/gaussian_integrals.py
@@ -180,12 +180,12 @@ def join_Abc(
     return A12, b12, c12
 
 
-def join_Abc_real(  # noqa: C901
+def join_Abc_real(
     Abc1: Tuple[ComplexMatrix, ComplexVector, ComplexTensor],
     Abc2: Tuple[ComplexMatrix, ComplexVector, ComplexTensor],
     idx1: Sequence[int],
     idx2: Sequence[int],
-):
+): # noqa: C901
     r"""Direct sum of two ``(A,b,c)`` triples into a single ``(A,b,c)`` triple, where indices corresponding to the same variable are "fused together", by considering their Bargmann function has having the same variables. For example ``idx1=(0,1,2)`` and ``idx2=(1,2,3)`` means that indices 1 and 2 will be fused because they are present on both tuples. This is useful for computing real Gaussian integrals where the variable on either object is the same, rather than a pair of conjugate variables for complex Gaussian integrals.
 
     Arguments:

--- a/mrmustard/physics/gaussian_integrals.py
+++ b/mrmustard/physics/gaussian_integrals.py
@@ -170,14 +170,14 @@ def join_Abc(
     # c12 = math.outer(c1, c2)
     c1 = math.astensor(c1)
     c2 = math.astensor(c2)
-    if c1.shape==(1,) and c2.shape==(1,):
-        c12 = math.outer(c1,c2).reshape(-1)
-    elif c1.shape==(1,):
-        c12 = math.outer(c1,c2).reshape(c2.shape)
-    elif c2.shape==(1,):
-        c12 = math.outer(c1,c2).reshape(c1.shape)
+    if c1.shape == (1,) and c2.shape == (1,):
+        c12 = math.outer(c1, c2).reshape(-1)
+    elif c1.shape == (1,):
+        c12 = math.outer(c1, c2).reshape(c2.shape)
+    elif c2.shape == (1,):
+        c12 = math.outer(c1, c2).reshape(c1.shape)
     else:
-        c12 = math.outer(c1,c2).reshape(c1.shape+c2.shape)
+        c12 = math.outer(c1, c2).reshape(c1.shape + c2.shape)
     return A12, b12, c12
 
 
@@ -233,28 +233,28 @@ def join_Abc_real(
         # c12 = math.outer(c1, c2)
         c1 = math.astensor(c1)
         c2 = math.astensor(c2)
-        if c1.shape==(1,) and c2.shape==(1,):
-            c12 = math.outer(c1,c2).reshape(-1)
-        elif c1.shape==(1,):
-            c12 = math.outer(c1,c2).reshape(c2.shape)
-        elif c2.shape==(1,):
-            c12 = math.outer(c1,c2).reshape(c1.shape)
+        if c1.shape == (1,) and c2.shape == (1,):
+            c12 = math.outer(c1, c2).reshape(-1)
+        elif c1.shape == (1,):
+            c12 = math.outer(c1, c2).reshape(c2.shape)
+        elif c2.shape == (1,):
+            c12 = math.outer(c1, c2).reshape(c1.shape)
         else:
-            c12 = math.outer(c1,c2).reshape(c1.shape+c2.shape)
+            c12 = math.outer(c1, c2).reshape(c1.shape + c2.shape)
     elif math.asnumpy(not_idx2).shape == (0,):
         A12 = math.block([[A2 + A1_idx_idx, A1_notidx_idx], [A1_idx_notidx, A1_notidx_notidx]])
         b12 = math.concat([b2 + b1_idx, b1_notidx], axis=-1)
         # c12 = math.outer(c1, c2)
         c1 = math.astensor(c1)
         c2 = math.astensor(c2)
-        if c1.shape==(1,) and c2.shape==(1,):
-            c12 = math.outer(c1,c2).reshape(-1)
-        elif c1.shape==(1,):
-            c12 = math.outer(c1,c2).reshape(c2.shape)
-        elif c2.shape==(1,):
-            c12 = math.outer(c1,c2).reshape(c1.shape)
+        if c1.shape == (1,) and c2.shape == (1,):
+            c12 = math.outer(c1, c2).reshape(-1)
+        elif c1.shape == (1,):
+            c12 = math.outer(c1, c2).reshape(c2.shape)
+        elif c2.shape == (1,):
+            c12 = math.outer(c1, c2).reshape(c1.shape)
         else:
-            c12 = math.outer(c1,c2).reshape(c1.shape+c2.shape)
+            c12 = math.outer(c1, c2).reshape(c1.shape + c2.shape)
     else:
         O_n = math.zeros((len(not_idx1), len(not_idx2)), math.complex128)
         A12 = math.block(
@@ -268,14 +268,14 @@ def join_Abc_real(
         # c12 = math.outer(c1, c2)
         c1 = math.astensor(c1)
         c2 = math.astensor(c2)
-        if c1.shape==(1,) and c2.shape==(1,):
-            c12 = math.outer(c1,c2).reshape(-1)
-        elif c1.shape==(1,):
-            c12 = math.outer(c1,c2).reshape(c2.shape)
-        elif c2.shape==(1,):
-            c12 = math.outer(c1,c2).reshape(c1.shape)
+        if c1.shape == (1,) and c2.shape == (1,):
+            c12 = math.outer(c1, c2).reshape(-1)
+        elif c1.shape == (1,):
+            c12 = math.outer(c1, c2).reshape(c2.shape)
+        elif c2.shape == (1,):
+            c12 = math.outer(c1, c2).reshape(c1.shape)
         else:
-            c12 = math.outer(c1,c2).reshape(c1.shape+c2.shape)
+            c12 = math.outer(c1, c2).reshape(c1.shape + c2.shape)
     return A12, b12, c12
 
 

--- a/mrmustard/physics/gaussian_integrals.py
+++ b/mrmustard/physics/gaussian_integrals.py
@@ -185,7 +185,7 @@ def join_Abc_real(
     Abc2: Tuple[ComplexMatrix, ComplexVector, complex],
     idx1: Sequence[int],
     idx2: Sequence[int],
-): # noqa: C901 
+):
     r"""Direct sum of two ``(A,b,c)`` triples into a single ``(A,b,c)`` triple, where indices corresponding to the same variable are "fused together", by considering their Bargmann function has having the same variables. For example ``idx1=(0,1,2)`` and ``idx2=(1,2,3)`` means that indices 1 and 2 will be fused because they are present on both tuples. This is useful for computing real Gaussian integrals where the variable on either object is the same, rather than a pair of conjugate variables for complex Gaussian integrals.
 
     Arguments:

--- a/mrmustard/physics/gaussian_integrals.py
+++ b/mrmustard/physics/gaussian_integrals.py
@@ -167,7 +167,6 @@ def join_Abc(
     A2, b2, c2 = Abc2
     A12 = math.block_diag(math.cast(A1, "complex128"), math.cast(A2, "complex128"))
     b12 = math.concat([b1, b2], axis=-1)
-    # c12 = math.outer(c1, c2)
     c1 = math.astensor(c1)
     c2 = math.astensor(c2)
     if c1.shape == (1,) and c2.shape == (1,):
@@ -186,7 +185,7 @@ def join_Abc_real(
     Abc2: Tuple[ComplexMatrix, ComplexVector, complex],
     idx1: Sequence[int],
     idx2: Sequence[int],
-):
+): # noqa: C901 
     r"""Direct sum of two ``(A,b,c)`` triples into a single ``(A,b,c)`` triple, where indices corresponding to the same variable are "fused together", by considering their Bargmann function has having the same variables. For example ``idx1=(0,1,2)`` and ``idx2=(1,2,3)`` means that indices 1 and 2 will be fused because they are present on both tuples. This is useful for computing real Gaussian integrals where the variable on either object is the same, rather than a pair of conjugate variables for complex Gaussian integrals.
 
     Arguments:
@@ -285,7 +284,7 @@ def contract_two_Abc(
     Abc2: Tuple[ComplexMatrix, ComplexVector, complex],
     idx1: Sequence[int],
     idx2: Sequence[int],
-):
+): 
     r"""
     Returns the contraction of two ``(A,b,c)`` triples with given indices.
 

--- a/mrmustard/physics/gaussian_integrals.py
+++ b/mrmustard/physics/gaussian_integrals.py
@@ -180,7 +180,7 @@ def join_Abc(
     return A12, b12, c12
 
 
-def join_Abc_real( # noqa: max-complexity=24
+def join_Abc_real(  # noqa: C901
     Abc1: Tuple[ComplexMatrix, ComplexVector, ComplexTensor],
     Abc2: Tuple[ComplexMatrix, ComplexVector, ComplexTensor],
     idx1: Sequence[int],

--- a/mrmustard/physics/gaussian_integrals.py
+++ b/mrmustard/physics/gaussian_integrals.py
@@ -19,7 +19,7 @@ This module contains gaussian integral functions and related helper functions.
 from typing import Sequence, Tuple
 import numpy as np
 from mrmustard import math
-from mrmustard.utils.typing import ComplexMatrix, ComplexVector
+from mrmustard.utils.typing import ComplexMatrix, ComplexVector, ComplexTensor
 
 
 def real_gaussian_integral(
@@ -150,8 +150,8 @@ def complex_gaussian_integral(
 
 
 def join_Abc(
-    Abc1: Tuple[ComplexMatrix, ComplexVector, complex],
-    Abc2: Tuple[ComplexMatrix, ComplexVector, complex],
+    Abc1: Tuple[ComplexMatrix, ComplexVector, ComplexTensor],
+    Abc2: Tuple[ComplexMatrix, ComplexVector, ComplexTensor],
 ):
     r"""Joins two ``(A,b,c)`` triples into a single ``(A,b,c)`` triple by block addition of the ``A``
     matrices and concatenating the ``b`` vectors.
@@ -181,8 +181,8 @@ def join_Abc(
 
 
 def join_Abc_real(
-    Abc1: Tuple[ComplexMatrix, ComplexVector, complex],
-    Abc2: Tuple[ComplexMatrix, ComplexVector, complex],
+    Abc1: Tuple[ComplexMatrix, ComplexVector, ComplexTensor],
+    Abc2: Tuple[ComplexMatrix, ComplexVector, ComplexTensor],
     idx1: Sequence[int],
     idx2: Sequence[int],
 ):
@@ -280,8 +280,8 @@ def reorder_abc(Abc: tuple, order: Sequence[int]):
 
 
 def contract_two_Abc(
-    Abc1: Tuple[ComplexMatrix, ComplexVector, complex],
-    Abc2: Tuple[ComplexMatrix, ComplexVector, complex],
+    Abc1: Tuple[ComplexMatrix, ComplexVector, ComplexTensor],
+    Abc2: Tuple[ComplexMatrix, ComplexVector, ComplexTensor],
     idx1: Sequence[int],
     idx2: Sequence[int],
 ):

--- a/mrmustard/physics/gaussian_integrals.py
+++ b/mrmustard/physics/gaussian_integrals.py
@@ -227,34 +227,25 @@ def join_Abc_real(
         A2_notidx_notidx = math.gather(math.gather(A2, not_idx2, axis=-1), not_idx2, axis=-2)
         b2_notidx = math.gather(b2, not_idx2, axis=-1)
 
+    c1 = math.astensor(c1)
+    c2 = math.astensor(c2)
+    if c1.shape == (1,) and c2.shape == (1,):
+        c12 = math.outer(c1, c2).reshape(-1)
+    elif c1.shape == (1,):
+        c12 = math.outer(c1, c2).reshape(c2.shape)
+    elif c2.shape == (1,):
+        c12 = math.outer(c1, c2).reshape(c1.shape)
+    else:
+        c12 = math.outer(c1, c2).reshape(c1.shape + c2.shape)
+
     if math.asnumpy(not_idx1).shape == (0,):
         A12 = math.block([[A1 + A2_idx_idx, A2_notidx_idx], [A2_idx_notidx, A2_notidx_notidx]])
         b12 = math.concat([b1 + b2_idx, b2_notidx], axis=-1)
-        # c12 = math.outer(c1, c2)
-        c1 = math.astensor(c1)
-        c2 = math.astensor(c2)
-        if c1.shape == (1,) and c2.shape == (1,):
-            c12 = math.outer(c1, c2).reshape(-1)
-        elif c1.shape == (1,):
-            c12 = math.outer(c1, c2).reshape(c2.shape)
-        elif c2.shape == (1,):
-            c12 = math.outer(c1, c2).reshape(c1.shape)
-        else:
-            c12 = math.outer(c1, c2).reshape(c1.shape + c2.shape)
+
     elif math.asnumpy(not_idx2).shape == (0,):
         A12 = math.block([[A2 + A1_idx_idx, A1_notidx_idx], [A1_idx_notidx, A1_notidx_notidx]])
         b12 = math.concat([b2 + b1_idx, b1_notidx], axis=-1)
-        # c12 = math.outer(c1, c2)
-        c1 = math.astensor(c1)
-        c2 = math.astensor(c2)
-        if c1.shape == (1,) and c2.shape == (1,):
-            c12 = math.outer(c1, c2).reshape(-1)
-        elif c1.shape == (1,):
-            c12 = math.outer(c1, c2).reshape(c2.shape)
-        elif c2.shape == (1,):
-            c12 = math.outer(c1, c2).reshape(c1.shape)
-        else:
-            c12 = math.outer(c1, c2).reshape(c1.shape + c2.shape)
+
     else:
         O_n = math.zeros((len(not_idx1), len(not_idx2)), math.complex128)
         A12 = math.block(
@@ -265,17 +256,7 @@ def join_Abc_real(
             ]
         )
         b12 = math.concat([b1_idx + b2_idx, b1_notidx, b2_notidx], axis=-1)
-        # c12 = math.outer(c1, c2)
-        c1 = math.astensor(c1)
-        c2 = math.astensor(c2)
-        if c1.shape == (1,) and c2.shape == (1,):
-            c12 = math.outer(c1, c2).reshape(-1)
-        elif c1.shape == (1,):
-            c12 = math.outer(c1, c2).reshape(c2.shape)
-        elif c2.shape == (1,):
-            c12 = math.outer(c1, c2).reshape(c1.shape)
-        else:
-            c12 = math.outer(c1, c2).reshape(c1.shape + c2.shape)
+
     return A12, b12, c12
 
 

--- a/mrmustard/physics/gaussian_integrals.py
+++ b/mrmustard/physics/gaussian_integrals.py
@@ -185,7 +185,7 @@ def join_Abc_real(
     Abc2: Tuple[ComplexMatrix, ComplexVector, ComplexTensor],
     idx1: Sequence[int],
     idx2: Sequence[int],
-): # noqa: C901
+):  # noqa: C901
     r"""Direct sum of two ``(A,b,c)`` triples into a single ``(A,b,c)`` triple, where indices corresponding to the same variable are "fused together", by considering their Bargmann function has having the same variables. For example ``idx1=(0,1,2)`` and ``idx2=(1,2,3)`` means that indices 1 and 2 will be fused because they are present on both tuples. This is useful for computing real Gaussian integrals where the variable on either object is the same, rather than a pair of conjugate variables for complex Gaussian integrals.
 
     Arguments:

--- a/mrmustard/physics/gaussian_integrals.py
+++ b/mrmustard/physics/gaussian_integrals.py
@@ -180,7 +180,7 @@ def join_Abc(
     return A12, b12, c12
 
 
-def join_Abc_real(
+def join_Abc_real( # noqa: max-complexity=24
     Abc1: Tuple[ComplexMatrix, ComplexVector, ComplexTensor],
     Abc2: Tuple[ComplexMatrix, ComplexVector, ComplexTensor],
     idx1: Sequence[int],

--- a/mrmustard/physics/gaussian_integrals.py
+++ b/mrmustard/physics/gaussian_integrals.py
@@ -185,7 +185,8 @@ def join_Abc_real(
     Abc2: Tuple[ComplexMatrix, ComplexVector, ComplexTensor],
     idx1: Sequence[int],
     idx2: Sequence[int],
-):  # pylint: disable=R1260
+):
+    # pylint: disable=R1260
     r"""Direct sum of two ``(A,b,c)`` triples into a single ``(A,b,c)`` triple, where indices corresponding to the same variable are "fused together", by considering their Bargmann function has having the same variables. For example ``idx1=(0,1,2)`` and ``idx2=(1,2,3)`` means that indices 1 and 2 will be fused because they are present on both tuples. This is useful for computing real Gaussian integrals where the variable on either object is the same, rather than a pair of conjugate variables for complex Gaussian integrals.
 
     Arguments:

--- a/mrmustard/physics/gaussian_integrals.py
+++ b/mrmustard/physics/gaussian_integrals.py
@@ -185,7 +185,7 @@ def join_Abc_real(
     Abc2: Tuple[ComplexMatrix, ComplexVector, ComplexTensor],
     idx1: Sequence[int],
     idx2: Sequence[int],
-):
+): # pylint: disable=too-complex
     r"""Direct sum of two ``(A,b,c)`` triples into a single ``(A,b,c)`` triple, where indices corresponding to the same variable are "fused together", by considering their Bargmann function has having the same variables. For example ``idx1=(0,1,2)`` and ``idx2=(1,2,3)`` means that indices 1 and 2 will be fused because they are present on both tuples. This is useful for computing real Gaussian integrals where the variable on either object is the same, rather than a pair of conjugate variables for complex Gaussian integrals.
 
     Arguments:

--- a/mrmustard/physics/gaussian_integrals.py
+++ b/mrmustard/physics/gaussian_integrals.py
@@ -167,7 +167,15 @@ def join_Abc(
     A2, b2, c2 = Abc2
     A12 = math.block_diag(math.cast(A1, "complex128"), math.cast(A2, "complex128"))
     b12 = math.concat([b1, b2], axis=-1)
-    c12 = math.outer(c1, c2)
+    # c12 = math.outer(c1, c2)
+    if c1.shape==(1,) and c2.shape==(1,):
+        c12 = math.outer(c1,c2).reshape(-1)
+    elif c1.shape==(1,):
+        c12 = math.outer(c1,c2).reshape(c2.shape)
+    elif c2.shape==(1,):
+        c12 = math.outer(c1,c2).reshape(c1.shape)
+    else:
+        c12 = math.outer(c1,c2).reshape(c1.shape+c2.shape)
     return A12, b12, c12
 
 

--- a/mrmustard/physics/gaussian_integrals.py
+++ b/mrmustard/physics/gaussian_integrals.py
@@ -157,13 +157,13 @@ def join_cs(
     c1 = math.astensor(c1)
     c2 = math.astensor(c2)
     if c1.shape == (1,) and c2.shape == (1,):
-        c12 = math.outer(c1, c2).reshape(-1)
+        c12 = math.reshape(math.outer(c1, c2), -1)
     elif c1.shape == (1,):
-        c12 = math.outer(c1, c2).reshape(c2.shape)
+        c12 = math.reshape(math.outer(c1, c2), c2.shape)
     elif c2.shape == (1,):
-        c12 = math.outer(c1, c2).reshape(c1.shape)
+        c12 = math.reshape(math.outer(c1, c2), c1.shape)
     else:
-        c12 = math.outer(c1, c2).reshape(c1.shape + c2.shape)
+        c12 = math.reshape(math.outer(c1, c2), c1.shape + c2.shape)
     return c12
 
 

--- a/tests/test_lab_dev/test_circuit_components_utils.py
+++ b/tests/test_lab_dev/test_circuit_components_utils.py
@@ -108,13 +108,13 @@ class TestBtoPS:
         A_correct, b_correct, c_correct = displacement_map_s_parametrized_Abc(s=0, n_modes=1)
         assert math.allclose(rep1.A[0], A_correct)
         assert math.allclose(rep1.b[0], b_correct)
-        assert math.allclose(rep1.c[0], c_correct)
+        assert math.allclose(rep1.c[0], np.array([c_correct]))
 
         rep2 = BtoPS(modes=[5, 10], s=1).representation  # pylint: disable=protected-access
         A_correct, b_correct, c_correct = displacement_map_s_parametrized_Abc(s=1, n_modes=2)
         assert math.allclose(rep2.A[0], A_correct)
         assert math.allclose(rep2.b[0], b_correct)
-        assert math.allclose(rep2.c[0], c_correct)
+        assert math.allclose(rep2.c[0], np.array([c_correct]))
 
     def testBtoPS_contraction_with_state(self):
         # The init state cov and means comes from the random state 'state = Gaussian(1) >> Dgate([0.2], [0.3])'
@@ -136,7 +136,7 @@ class TestBtoPS:
 
         assert math.allclose(A1[0], A2)
         assert math.allclose(b1[0], b2)
-        assert math.allclose(c1[0], c2)
+        assert math.allclose(c1[0], np.array([c2]))
 
         # The init state cov and means comes from the random state 'state = Gaussian(2) >> Dgate([0.2], [0.3])'
         state_cov = np.array(
@@ -167,7 +167,7 @@ class TestBtoPS:
 
         assert math.allclose(A1[0], A2)
         assert math.allclose(b1[0], b2)
-        assert math.allclose(c1[0], c2)
+        assert math.allclose(c1[0], np.array([c2]))
 
 
 class TestBtoQ:

--- a/tests/test_lab_dev/test_states.py
+++ b/tests/test_lab_dev/test_states.py
@@ -106,7 +106,7 @@ class TestKet:
     @pytest.mark.parametrize("modes", [[0], [0, 1], [3, 19, 2]])
     def test_to_from_phase_space(self, modes):
         cov, means, coeff = Coherent([0], x=1, y=2).phase_space(s=0)
-        assert math.allclose(coeff[0], 1.0)
+        assert math.allclose(coeff[0], np.array([1.0]))
         assert math.allclose(cov[0], np.eye(2))
         assert math.allclose(means[0], np.array([2.0, 4.0]))
 
@@ -126,7 +126,7 @@ class TestKet:
         modes = [0]
         A0 = np.array([[0]])
         b0 = np.array([0.2j])
-        c0 = np.exp(-0.5 * 0.04)  # z^*
+        c0 = np.array(np.exp(-0.5 * 0.04))  # z^*
 
         state0 = Ket.from_bargmann(modes, (A0, b0, c0))
         Atest, btest, ctest = state0.quadrature()
@@ -134,7 +134,7 @@ class TestKet:
         Atest2, btest2, ctest2 = state1.bargmann
         assert math.allclose(Atest2[0], A0)
         assert math.allclose(btest2[0], b0)
-        assert math.allclose(ctest2[0], c0)
+        assert math.allclose(ctest2[0], np.array([c0]))
 
     def test_L2_norm(self):
         state = Coherent([0], x=1)
@@ -421,7 +421,7 @@ class TestDM:
         Atest2, btest2, ctest2 = state1.bargmann
         assert math.allclose(Atest2[0], A0)
         assert math.allclose(btest2[0], b0)
-        assert math.allclose(ctest2[0], c0)
+        assert math.allclose(ctest2[0], np.array([c0]))
 
     def test_L2_norms(self):
         state = Coherent([0], x=1).dm() + Coherent([0], x=-1).dm()  # incoherent
@@ -462,7 +462,7 @@ class TestDM:
 
         assert math.allclose(dm.expectation(k0), res_k0)
         assert math.allclose(dm.expectation(k1), res_k1)
-        assert math.allclose(dm.expectation(k01), res_k01.representation.c[0])
+        assert math.allclose(np.array([dm.expectation(k01)]), res_k01.representation.c[0])
 
         dm0 = Coherent([0], x=1, y=2).dm()
         dm1 = Coherent([1], x=1, y=3).dm()
@@ -474,11 +474,11 @@ class TestDM:
 
         assert math.allclose(dm.expectation(dm0), res_dm0)
         assert math.allclose(dm.expectation(dm1), res_dm1)
-        assert math.allclose(dm.expectation(dm01), res_dm01.representation.c[0])
+        assert math.allclose(np.array([dm.expectation(dm01)]), res_dm01.representation.c[0])
 
         assert math.allclose(dm.expectation(k0), res_k0)
         assert math.allclose(dm.expectation(k1), res_k1)
-        assert math.allclose(dm.expectation(k01), res_k01.representation.c[0])
+        assert math.allclose(np.array([dm.expectation(k01)]), res_k01.representation.c[0])
 
         dm0 = Coherent([0], x=1, y=2).dm()
         dm1 = Coherent([1], x=1, y=3).dm()
@@ -490,7 +490,7 @@ class TestDM:
 
         assert math.allclose(dm.expectation(dm0), res_dm0)
         assert math.allclose(dm.expectation(dm1), res_dm1)
-        assert math.allclose(dm.expectation(dm01), res_dm01.representation.c[0])
+        assert math.allclose(np.array([dm.expectation(dm01)]), res_dm01.representation.c[0])
 
         u0 = Dgate([0], x=0.1)
         u1 = Dgate([1], x=0.2)
@@ -587,17 +587,17 @@ class TestCoherent:
         rep1 = Coherent(modes=[0], x=0.1, y=0.2).representation
         assert math.allclose(rep1.A, np.zeros((1, 1, 1)))
         assert math.allclose(rep1.b, [[0.1 + 0.2j]])
-        assert math.allclose(rep1.c, [0.97530991])
+        assert math.allclose(rep1.c, [[0.97530991]])
 
         rep2 = Coherent(modes=[0, 1], x=0.1, y=[0.2, 0.3]).representation
         assert math.allclose(rep2.A, np.zeros((1, 2, 2)))
         assert math.allclose(rep2.b, [[0.1 + 0.2j, 0.1 + 0.3j]])
-        assert math.allclose(rep2.c, [0.9277434863])
+        assert math.allclose(rep2.c, [[0.9277434863]])
 
         rep3 = Coherent(modes=[1], x=0.1).representation
         assert math.allclose(rep3.A, np.zeros((1, 1, 1)))
         assert math.allclose(rep3.b, [[0.1]])
-        assert math.allclose(rep3.c, [0.9950124791926823])
+        assert math.allclose(rep3.c, [[0.9950124791926823]])
 
     def test_representation_error(self):
         with pytest.raises(ValueError):
@@ -821,7 +821,7 @@ class TestVacuum:
 
         assert math.allclose(rep.A, np.zeros((1, n_modes, n_modes)))
         assert math.allclose(rep.b, np.zeros((1, n_modes)))
-        assert math.allclose(rep.c, [1.0])
+        assert math.allclose(rep.c, [[1.0]])
 
 
 class TestThermal:

--- a/tests/test_lab_dev/test_transformations.py
+++ b/tests/test_lab_dev/test_transformations.py
@@ -205,7 +205,7 @@ class TestBSgate:
         ]
         assert math.allclose(rep1.A, A_exp)
         assert math.allclose(rep1.b, np.zeros((1, 4)))
-        assert math.allclose(rep1.c, [1])
+        assert math.allclose(rep1.c, [[1]])
 
         rep2 = BSgate([0, 1], 0.1).representation
         A_exp = [
@@ -218,7 +218,7 @@ class TestBSgate:
         ]
         assert math.allclose(rep2.A, A_exp)
         assert math.allclose(rep2.b, np.zeros((1, 4)))
-        assert math.allclose(rep2.c, [1])
+        assert math.allclose(rep2.c, [[1]])
 
     def test_trainable_parameters(self):
         gate1 = BSgate([0, 1], 1, 1)
@@ -262,17 +262,17 @@ class TestDgate:
         rep1 = Dgate(modes=[0], x=0.1, y=0.1).representation
         assert math.allclose(rep1.A, [[[0, 1], [1, 0]]])
         assert math.allclose(rep1.b, [[0.1 + 0.1j, -0.1 + 0.1j]])
-        assert math.allclose(rep1.c, [0.990049833749168])
+        assert math.allclose(rep1.c, [[0.990049833749168]])
 
         rep2 = Dgate(modes=[0, 1], x=[0.1, 0.2], y=0.1).representation
         assert math.allclose(rep2.A, [[[0, 0, 1, 0], [0, 0, 0, 1], [1, 0, 0, 0], [0, 1, 0, 0]]])
         assert math.allclose(rep2.b, [[0.1 + 0.1j, 0.2 + 0.1j, -0.1 + 0.1j, -0.2 + 0.1j]])
-        assert math.allclose(rep2.c, [0.9656054162575665])
+        assert math.allclose(rep2.c, [[0.9656054162575665]])
 
         rep3 = Dgate(modes=[1, 8], x=[0.1, 0.2]).representation
         assert math.allclose(rep3.A, [[[0, 0, 1, 0], [0, 0, 0, 1], [1, 0, 0, 0], [0, 1, 0, 0]]])
         assert math.allclose(rep3.b, [[0.1, 0.2, -0.1, -0.2]])
-        assert math.allclose(rep3.c, [0.9753099120283327])
+        assert math.allclose(rep3.c, [[0.9753099120283327]])
 
     def test_trainable_parameters(self):
         gate1 = Dgate([0], 1, 1)
@@ -324,7 +324,7 @@ class TestRgate:
             ],
         )
         assert math.allclose(rep1.b, np.zeros((1, 2)))
-        assert math.allclose(rep1.c, [1.0 + 0.0j])
+        assert math.allclose(rep1.c, [[1.0 + 0.0j]])
 
         rep2 = Rgate(modes=[0, 1], phi=[0.1, 0.3]).representation
         assert math.allclose(
@@ -339,7 +339,7 @@ class TestRgate:
             ],
         )
         assert math.allclose(rep2.b, np.zeros((1, 4)))
-        assert math.allclose(rep2.c, [1.0 + 0.0j])
+        assert math.allclose(rep2.c, [[1.0 + 0.0j]])
 
         rep3 = Rgate(modes=[1], phi=0.1).representation
         assert math.allclose(
@@ -352,7 +352,7 @@ class TestRgate:
             ],
         )
         assert math.allclose(rep3.b, np.zeros((1, 2)))
-        assert math.allclose(rep3.c, [1.0 + 0.0j])
+        assert math.allclose(rep3.c, [[1.0 + 0.0j]])
 
     def test_trainable_parameters(self):
         gate1 = Rgate([0], 1)
@@ -404,7 +404,7 @@ class TestSgate:
             ],
         )
         assert math.allclose(rep1.b, np.zeros((1, 2)))
-        assert math.allclose(rep1.c, [0.9975072676192522])
+        assert math.allclose(rep1.c, [[0.9975072676192522]])
 
         rep2 = Sgate(modes=[0, 1], r=[0.1, 0.3], phi=0.2).representation
         assert math.allclose(
@@ -419,7 +419,7 @@ class TestSgate:
             ],
         )
         assert math.allclose(rep2.b, np.zeros((1, 4)))
-        assert math.allclose(rep2.c, [0.9756354961606032])
+        assert math.allclose(rep2.c, [[0.9756354961606032]])
 
         rep3 = Sgate(modes=[1], r=0.1).representation
         assert math.allclose(
@@ -432,7 +432,7 @@ class TestSgate:
             ],
         )
         assert math.allclose(rep3.b, np.zeros((1, 2)))
-        assert math.allclose(rep3.c, [0.9975072676192522])
+        assert math.allclose(rep3.c, [[0.9975072676192522]])
 
     def test_trainable_parameters(self):
         gate1 = Sgate([0], 1, 1)
@@ -486,7 +486,7 @@ class TestIdentity:
             ],
         )
         assert math.allclose(rep1.b, np.zeros((1, 2)))
-        assert math.allclose(rep1.c, [1.0 + 0.0j])
+        assert math.allclose(rep1.c, [[1.0 + 0.0j]])
 
         rep2 = Identity(modes=[0, 1]).representation
         assert math.allclose(
@@ -501,7 +501,7 @@ class TestIdentity:
             ],
         )
         assert math.allclose(rep2.b, np.zeros((1, 4)))
-        assert math.allclose(rep2.c, [1.0 + 0.0j])
+        assert math.allclose(rep2.c, [[1.0 + 0.0j]])
 
 
 class TestS2gate:
@@ -540,7 +540,7 @@ class TestS2gate:
         ]
         assert math.allclose(rep1.A, A_exp)
         assert math.allclose(rep1.b, np.zeros((1, 4)))
-        assert math.allclose(rep1.c, [1 / np.cosh(0.1)])
+        assert math.allclose(rep1.c, [[1 / np.cosh(0.1)]])
 
     def test_trainable_parameters(self):
         gate1 = S2gate([0, 1], 1, 1)
@@ -592,7 +592,7 @@ class TestAmplifier:
             rep1.A, [[[0, g1, g2, 0], [g1, 0, 0, 0], [g2, 0, 0, g1], [0, 0, g1, 0]]]
         )
         assert math.allclose(rep1.b, np.zeros((1, 4)))
-        assert math.allclose(rep1.c, [0.90909090])
+        assert math.allclose(rep1.c, [[0.90909090]])
 
     def test_trainable_parameters(self):
         gate1 = Amplifier([0], 1.2)
@@ -625,7 +625,7 @@ class TestAmplifier:
             ],
         )
         assert math.allclose(operation.representation.b, np.zeros((1, 4)))
-        assert math.allclose(operation.representation.c, [0.74074074 + 0.0j])
+        assert math.allclose(operation.representation.c, [[0.74074074 + 0.0j]])
 
     def test_circuit_identity(self):
         amp_channel = Amplifier(modes=[0], gain=2)
@@ -678,7 +678,7 @@ class TestAttenuator:
         e = 0.31622777
         assert math.allclose(rep1.A, [[[0, e, 0, 0], [e, 0, 0, 0.9], [0, 0, 0, e], [0, 0.9, e, 0]]])
         assert math.allclose(rep1.b, np.zeros((1, 4)))
-        assert math.allclose(rep1.c, [1.0])
+        assert math.allclose(rep1.c, [[1.0]])
 
     def test_trainable_parameters(self):
         gate1 = Attenuator([0], 0.1)

--- a/tests/test_physics/test_ansatz.py
+++ b/tests/test_physics/test_ansatz.py
@@ -151,16 +151,16 @@ class TestPolyExpAnsatz:
         ansatz = PolyExpAnsatz(
             A=[np.array([[0]]), np.array([[1]])],
             b=[np.array([1]), np.array([0])],
-            c=[1, 2],
+            c=[np.array([1]), np.array([2])],
         )
         ansatz._order_batch()  # pylint: disable=protected-access
 
         assert np.allclose(ansatz.A[0], np.array([[1]]))
         assert np.allclose(ansatz.b[0], np.array([0]))
-        assert ansatz.c[0] == 2
+        assert ansatz.c[0] == np.array([2])
         assert np.allclose(ansatz.A[1], np.array([[0]]))
         assert np.allclose(ansatz.b[1], np.array([1]))
-        assert ansatz.c[1] == 1
+        assert ansatz.c[1] == np.array([1])
 
 
 class TestArrayAnsatz:
@@ -319,7 +319,7 @@ class TestArrayAnsatz:
         ) = bargmann_Abc_to_phasespace_cov_means(A1, b1, c1)
         assert math.allclose(state_cov, new_state_cov[0])
         assert math.allclose(state_means, new_state_means[0])
-        assert math.allclose(1.0, new_state_coeff[0])
+        assert math.allclose(np.array([1.0]), new_state_coeff[0])
 
         state_cov = np.array(
             [
@@ -353,5 +353,5 @@ class TestArrayAnsatz:
         assert math.allclose(new_state_cov1[0], state_cov)
         assert math.allclose(new_state_means1[0], state_means)
         assert math.allclose(new_state_means22[0], state_means)
-        assert math.allclose(new_state_coeff1[0], 1.0)
-        assert math.allclose(new_state_coeff22[0], 1.0)
+        assert math.allclose(new_state_coeff1[0], np.array([1.0]))
+        assert math.allclose(new_state_coeff22[0], np.array([1.0]))

--- a/tests/test_physics/test_representations.py
+++ b/tests/test_physics/test_representations.py
@@ -76,7 +76,7 @@ class TestBargmannRepresentation:
 
         assert bargmann.A.shape == (1, 2 * n, 2 * n)
         assert bargmann.b.shape == (1, 2 * n)
-        assert bargmann.c.shape == (1,)
+        assert bargmann.c.shape == (1, 1)
 
     @pytest.mark.parametrize("scalar", [0.5, 1.2])
     @pytest.mark.parametrize("triple", [Abc_n1, Abc_n2, Abc_n3])


### PR DESCRIPTION
**Context:**
Making c in the Abc triple ready for polynomials
**Description of the Change:**
Updating the shape of c, such that the first index is always the batch dimension which is the same way that A and b are currently implemented. The following dimensions will be the (potentially multivariate) polynomial. 
If the shape of c is `(batch,1)`, it correspinds to c just being a scalar.
**Benefits:**
Prepares for the updated poly exp ansatz.
**Possible Drawbacks:**
Involves changes to a number of central mm functions, which may break some parts of mm.