### PR TITLE
Minor cleanup to some docstrings + miscellaneous 

### DIFF
--- a/mrmustard/lab_dev/circuit_components.py
+++ b/mrmustard/lab_dev/circuit_components.py
@@ -186,7 +186,8 @@ class CircuitComponent:
 
     @property
     def bargmann(self) -> tuple:
-        r"""The Bargmann parametrization of this component, if available.
+        r"""
+        The Bargmann parametrization of this component, if available.
         It returns a triple (A, b, c) such that the Bargmann function of this component is
         :math:`F(z) = c \exp\left(\frac{1}{2} z^T A z + b^T z\right)`
 
@@ -216,7 +217,8 @@ class CircuitComponent:
         phi: float = 0.0,
         name: Optional[str] = None,
     ) -> CircuitComponent:
-        r"""Returns a circuit component from the given triple (A,b,c) that parametrizes the
+        r"""
+        Returns a circuit component from the given triple (A,b,c) that parametrizes the
         quadrature wavefunction of this component in the form :math:`c * exp(1/2 x^T A x + b^T x)`.
 
         Args:
@@ -578,7 +580,8 @@ class CircuitComponent:
 
 
 class CCView(CircuitComponent):
-    r"""A base class for views of circuit components. It allows for a more efficient
+    r"""
+    A base class for views of circuit components. It allows for a more efficient
     use of components when we need the same component on different wires.
 
     Args:
@@ -588,10 +591,6 @@ class CCView(CircuitComponent):
     def __init__(self, component: CircuitComponent) -> None:
         self.__dict__ = component.__dict__.copy()
         self._component = component._light_copy()
-
-    def __getattr__(self, name):
-        r"""send calls to the component"""
-        return getattr(self._component, name)
 
     def __repr__(self) -> str:
         return repr(self._component)
@@ -610,7 +609,9 @@ class AdjointView(CCView):
 
     @property
     def short_name(self) -> str:
-        "short name that appears in the circuit"
+        r"""
+        Returns a short name that appears in the circuit.
+        """
         return self._component.short_name + "_adj"
 
     @property
@@ -623,8 +624,8 @@ class AdjointView(CCView):
     @property
     def representation(self):
         r"""
-        A representation of this circuit component. Note that ket and bra indices
-        have been swapped.
+        Returns a representation of this circuit component. Note that ket and bra
+        indices have been swapped.
         """
         bras = self._component.wires.bra.indices
         kets = self._component.wires.ket.indices
@@ -633,7 +634,7 @@ class AdjointView(CCView):
     @property
     def wires(self):
         r"""
-        The ``Wires`` in this component.
+        Returns the ``Wires`` in this component.
         """
         return self._component.wires.adjoint
 
@@ -651,7 +652,9 @@ class DualView(CCView):
 
     @property
     def short_name(self) -> str:
-        "short name that appears in the circuit"
+        r"""
+        Returns a short name that appears in the circuit.
+        """
         return self._component.short_name + "_dual"
 
     @property
@@ -664,8 +667,8 @@ class DualView(CCView):
     @property
     def representation(self):
         r"""
-        A representation of this circuit component. Note that input and output indices
-        have been swapped.
+        Returns a representation of this circuit component. Note that input and
+        output indices have been swapped.
         """
         ok = self._component.wires.ket.output.indices
         ik = self._component.wires.ket.input.indices
@@ -676,6 +679,6 @@ class DualView(CCView):
     @property
     def wires(self):
         r"""
-        The ``Wires`` in this component.
+        Returns the ``Wires`` in this component.
         """
         return self._component.wires.dual

--- a/mrmustard/math/tensor_networks/networks.py
+++ b/mrmustard/math/tensor_networks/networks.py
@@ -27,7 +27,8 @@ from .tensors import Wire, Tensor
 
 
 def connect(wire1: Wire, wire2: Wire, dim: Optional[int] = None):
-    r"""Connects two wires in a tensor network.
+    r"""
+    Connects two wires in a tensor network.
 
     Args:
         wire1: The first wire.
@@ -52,7 +53,8 @@ def connect(wire1: Wire, wire2: Wire, dim: Optional[int] = None):
 
 
 def contract(tensors: list[Tensor], default_dim: int):
-    r"""Contract a list of tensors.
+    r"""
+    Contract a list of tensors.
 
     Args:
         tensors: The tensors to contract.
@@ -69,13 +71,20 @@ def contract(tensors: list[Tensor], default_dim: int):
     return opt_contract(*opt_einsum_args)
 
 
-def draw(tensors: list[Tensor], layout: str = "spring_layout", figsize: tuple[int, int] = (10, 6)):
-    r"""Draws a tensor network.
+def draw(
+    tensors: list[Tensor],
+    layout: str = "spring_layout",
+    figsize: tuple[int, int] = (10, 6),
+    block: bool = True,
+):
+    r"""
+    Draws a tensor network.
 
     Args:
         tensors: The tensors to draw.
         layout: The layout method. Must be one of the methods in ``nx.drawing.layout``.
         figsize: The size of the returned figure.
+        block: Whether to have the figure block execution.
 
     Returns:
         A figure showing the tensor network.
@@ -165,5 +174,5 @@ def draw(tensors: list[Tensor], layout: str = "spring_layout", figsize: tuple[in
     )
 
     plt.title("Mr Mustard Network")
-    plt.show()
+    plt.show(block=block)
     return fig

--- a/mrmustard/physics/ansatze.py
+++ b/mrmustard/physics/ansatze.py
@@ -419,7 +419,7 @@ class ArrayAnsatz(Ansatz):
         batched: Whether the array input has a batch dimension.
 
     Note: The args can be passed non-batched, as they will be automatically broadcasted to the
-    correct batch shape if `batched` is set to `False`.
+    correct batch shape if ``batched`` is set to ``False``.
     """
 
     def __init__(self, array: Batch[Tensor], batched: bool = True):

--- a/mrmustard/physics/ansatze.py
+++ b/mrmustard/physics/ansatze.py
@@ -359,7 +359,7 @@ class PolyExpAnsatz(PolyExpBase):
 
     def __truediv__(self, other: Union[Scalar, PolyExpAnsatz]) -> PolyExpAnsatz:
         r"""
-        Divides this ansatz by a scalar or another ansatz or a plain scalar.
+        Divides this ansatz by a scalar or another ansatz.
 
         Args:
             other: A scalar or another ansatz.

--- a/mrmustard/physics/ansatze.py
+++ b/mrmustard/physics/ansatze.py
@@ -422,7 +422,6 @@ class ArrayAnsatz(Ansatz):
     correct batch shape.
     """
 
-
     def __init__(self, array: Batch[Tensor], batched: bool = True):
         array = math.astensor(array)
         if not batched:

--- a/mrmustard/physics/ansatze.py
+++ b/mrmustard/physics/ansatze.py
@@ -407,7 +407,7 @@ class ArrayAnsatz(Ansatz):
 
     Represents the ansatz as a multidimensional array.
 
-    code-block ::
+    .. code-block::
 
           >>> from mrmustard.physics.ansatze import ArrayAnsatz
 

--- a/mrmustard/physics/ansatze.py
+++ b/mrmustard/physics/ansatze.py
@@ -419,7 +419,7 @@ class ArrayAnsatz(Ansatz):
         batched: Whether the array input has a batch dimension.
 
     Note: The args can be passed non-batched, as they will be automatically broadcasted to the
-    correct batch shape.
+    correct batch shape if `batched` is set to `False`.
     """
 
     def __init__(self, array: Batch[Tensor], batched: bool = True):

--- a/mrmustard/physics/ansatze.py
+++ b/mrmustard/physics/ansatze.py
@@ -222,10 +222,12 @@ class PolyExpBase(Ansatz):
         self._simplified = True
 
     def _order_batch(self):
-        r"""This method orders the batch dimension by the lexicographical order of the
+        r"""
+        This method orders the batch dimension by the lexicographical order of the
         flattened arrays (mat, vec, array). This is a very cheap way to enforce
         an ordering of the batch dimension, which is useful for simplification and for
-        determining (in)equality between two Bargmann representations."""
+        determining (in)equality between two Bargmann representations.
+        """
         generators = [
             itertools.chain(
                 math.asnumpy(self.vec[i]).flat,
@@ -287,9 +289,6 @@ class PolyExpAnsatz(PolyExpBase):
 
         if A is None and b is None:
             raise ValueError("Please provide either A or b.")
-        A = math.astensor(A)
-        b = math.astensor(b)
-        c = math.astensor(c)
         super().__init__(mat=A, vec=b, array=c)
 
     @property
@@ -335,7 +334,8 @@ class PolyExpAnsatz(PolyExpBase):
         return val
 
     def __mul__(self, other: Union[Scalar, PolyExpAnsatz]) -> PolyExpAnsatz:
-        r"""Multiplies this ansatz by a scalar or another ansatz or a plain scalar.
+        r"""
+        Multiplies this ansatz by a scalar or another ansatz or a plain scalar.
 
         Args:
             other: A scalar or another ansatz.
@@ -358,7 +358,8 @@ class PolyExpAnsatz(PolyExpBase):
                 raise TypeError(f"Cannot multiply {self.__class__} and {other.__class__}.") from e
 
     def __truediv__(self, other: Union[Scalar, PolyExpAnsatz]) -> PolyExpAnsatz:
-        r"""Divides this ansatz by a scalar or another ansatz or a plain scalar.
+        r"""
+        Divides this ansatz by a scalar or another ansatz or a plain scalar.
 
         Args:
             other: A scalar or another ansatz.
@@ -381,7 +382,8 @@ class PolyExpAnsatz(PolyExpBase):
                 raise TypeError(f"Cannot divide {self.__class__} and {other.__class__}.") from e
 
     def __and__(self, other: PolyExpAnsatz) -> PolyExpAnsatz:
-        r"""Tensor product of this ansatz with another ansatz.
+        r"""
+        Tensor product of this ansatz with another ansatz.
         Equivalent to :math:`F(a) * G(b)` (with different arguments, that is).
         As it distributes over addition on both self and other,
         the batch size of the result is the product of the batch
@@ -510,7 +512,8 @@ class ArrayAnsatz(Ansatz):
             return self.__class__(array=self.array * other)
 
     def __and__(self, other: ArrayAnsatz) -> ArrayAnsatz:
-        r"""Tensor product of this ansatz with another ansatz.
+        r"""
+        Tensor product of this ansatz with another ansatz.
 
         Args:
             other: Another ansatz.
@@ -533,7 +536,8 @@ class ArrayAnsatz(Ansatz):
 def bargmann_Abc_to_phasespace_cov_means(
     A: Matrix, b: Vector, c: Scalar
 ) -> tuple[Matrix, Vector, Scalar]:
-    r"""Function to derive the covariance matrix and mean vector of a Gaussian state from its Wigner characteristic function in ABC form.
+    r"""
+    Function to derive the covariance matrix and mean vector of a Gaussian state from its Wigner characteristic function in ABC form.
 
     The covariance matrix and mean vector can be used to write the characteristic function of a Gaussian state
     :math:

--- a/mrmustard/physics/ansatze.py
+++ b/mrmustard/physics/ansatze.py
@@ -403,12 +403,9 @@ class PolyExpAnsatz(PolyExpBase):
 
 class ArrayAnsatz(Ansatz):
     r"""
-      The ansatz of the Fock-Bargmann representation.
+    The ansatz of the Fock-Bargmann representation.
 
-      Represents the ansatz as a multidimensional array.
-
-      Args:
-          array: A batched array.
+    Represents the ansatz as a multidimensional array.
 
     code-block ::
 
@@ -416,10 +413,21 @@ class ArrayAnsatz(Ansatz):
 
           >>> array = np.random.random((2, 4, 5))
           >>> ansatz = ArrayAnsatz(array)
+
+    Args:
+        array: A (potentially) batched array.
+        batched: Whether the array input has a batch dimension.
+
+    Note: The args can be passed non-batched, as they will be automatically broadcasted to the
+    correct batch shape.
     """
 
-    def __init__(self, array: Batch[Tensor]):
-        self.array = math.astensor(array)
+
+    def __init__(self, array: Batch[Tensor], batched: bool = True):
+        array = math.astensor(array)
+        if not batched:
+            array = array[None, ...]
+        self.array = array
         self.num_vars = len(self.array.shape) - 1
 
     def __neg__(self) -> ArrayAnsatz:

--- a/mrmustard/physics/ansatze.py
+++ b/mrmustard/physics/ansatze.py
@@ -335,7 +335,7 @@ class PolyExpAnsatz(PolyExpBase):
 
     def __mul__(self, other: Union[Scalar, PolyExpAnsatz]) -> PolyExpAnsatz:
         r"""
-        Multiplies this ansatz by a scalar or another ansatz or a plain scalar.
+        Multiplies this ansatz by a scalar or another ansatz.
 
         Args:
             other: A scalar or another ansatz.

--- a/mrmustard/physics/representations.py
+++ b/mrmustard/physics/representations.py
@@ -558,10 +558,7 @@ class Fock(Representation):
     def __init__(self, array: Batch[Tensor], batched=False):
         self._contract_idxs: tuple[int, ...] = ()
         self._original_bargmann_data = None
-        array = math.astensor(array)
-        if not batched:
-            array = array[None, ...]
-        self._ansatz = ArrayAnsatz(array=array)
+        self._ansatz = ArrayAnsatz(array=array, batched=batched)
 
     @property
     def ansatz(self) -> ArrayAnsatz:

--- a/mrmustard/physics/representations.py
+++ b/mrmustard/physics/representations.py
@@ -558,8 +558,6 @@ class Fock(Representation):
     def __init__(self, array: Batch[Tensor], batched=False):
         self._contract_idxs: tuple[int, ...] = ()
         self._original_bargmann_data = None
-
-        array = math.astensor(array)
         if not batched:
             array = array[None, ...]
         self._ansatz = ArrayAnsatz(array=array)
@@ -703,7 +701,8 @@ class Fock(Representation):
         return self.from_ansatz(ArrayAnsatz(new_array))
 
     def trace(self, idxs1: tuple[int, ...], idxs2: tuple[int, ...]) -> Fock:
-        r"""Implements the partial trace over the given index pairs.
+        r"""
+        Implements the partial trace over the given index pairs.
 
         Args:
             idxs1: The first part of the pairs of indices to trace over.

--- a/mrmustard/physics/representations.py
+++ b/mrmustard/physics/representations.py
@@ -558,6 +558,7 @@ class Fock(Representation):
     def __init__(self, array: Batch[Tensor], batched=False):
         self._contract_idxs: tuple[int, ...] = ()
         self._original_bargmann_data = None
+        array = math.astensor(array)
         if not batched:
             array = array[None, ...]
         self._ansatz = ArrayAnsatz(array=array)

--- a/tests/test_lab_dev/test_circuit_components.py
+++ b/tests/test_lab_dev/test_circuit_components.py
@@ -455,6 +455,7 @@ class TestAdjointView:
         d1_adj = AdjointView(d1)
 
         assert d1_adj.name == d1.name
+        assert d1_adj.short_name == d1.short_name + "_adj"
         assert d1_adj.wires == d1.wires.adjoint
         assert d1_adj.representation == d1.representation.conj()
 

--- a/tests/test_math/test_tensor_networks/test_networks.py
+++ b/tests/test_math/test_tensor_networks/test_networks.py
@@ -107,5 +107,5 @@ class TestDraw:
         connect(t1.output.ket[2], t3.input.ket[2])
         connect(t1.output.ket[1], t2.input.ket[1])
 
-        fig = draw([t1, t2, t3], layout, figsize)
+        fig = draw([t1, t2, t3], layout, figsize, block=False)
         assert isinstance(fig, Figure)


### PR DESCRIPTION
**Context:** A small cleanup PR.

**Description of the Change:** 

- Minor documentation updates/ formatting for consistency. 
- Removed `__getattr__` on `CCView` as it can cause undocumented behaviour.
- Added a `block` option on `draw` such that blocking plots do not display when running the testing suite. 
- Some unnecessary calls to `math.astensor` 
- Moved the batched array logic from `Fock` to `ArrayAnsatz`
