### PR TITLE
Fixes to triples.py

### DIFF
--- a/mrmustard/physics/triples.py
+++ b/mrmustard/physics/triples.py
@@ -465,7 +465,7 @@ def attenuator_Abc(eta: Union[float, Iterable[float]]) -> Union[Matrix, Vector, 
 
     O_n = math.zeros((n_modes, n_modes), math.complex128)
     eta1 = math.reshape(math.diag(math.sqrt(eta)), (n_modes, n_modes))
-    eta2 = math.eye(n_modes, dtype=math.complex128) - math.reshape(math.diag(eta), (n_modes, n_modes))
+    eta2 = math.eye(n_modes, math.complex128) - math.reshape(math.diag(eta), (n_modes, n_modes))
 
     A = math.block(
         [

--- a/mrmustard/physics/triples.py
+++ b/mrmustard/physics/triples.py
@@ -464,8 +464,8 @@ def attenuator_Abc(eta: Union[float, Iterable[float]]) -> Union[Matrix, Vector, 
             raise ValueError(msg)
 
     O_n = math.zeros((n_modes, n_modes), math.complex128)
-    eta1 = math.diag(math.sqrt(eta)).reshape((n_modes, n_modes))
-    eta2 = math.eye(n_modes) - math.diag(eta).reshape((n_modes, n_modes))
+    eta1 = math.reshape(math.diag(math.sqrt(eta)), (n_modes, n_modes))
+    eta2 = math.eye(n_modes, dtype=math.complex128) - math.reshape(math.diag(eta), (n_modes, n_modes))
 
     A = math.block(
         [

--- a/mrmustard/physics/triples.py
+++ b/mrmustard/physics/triples.py
@@ -506,9 +506,8 @@ def amplifier_Abc(g: Union[float, Iterable[float]]) -> Union[Matrix, Vector, Sca
             raise ValueError(msg)
 
     O_n = math.zeros((n_modes, n_modes), math.complex128)
-    g1 = math.diag(math.astensor([1 / math.sqrt(g)])).reshape((n_modes, n_modes))
-    g2 = math.diag(math.astensor([1 - 1 / g])).reshape((n_modes, n_modes))
-
+    g1 = math.reshape(math.diag(1 / math.sqrt(g)), (n_modes, n_modes))
+    g2 = math.reshape(math.diag(1 - 1 / g), (n_modes, n_modes))
     A = math.block(
         [
             [O_n, g1, g2, O_n],


### PR DESCRIPTION
**Context:** Some calls in triples.py were relying on a call to `tf.experimental.numpy.experimental_enable_numpy_behavior()` when using a tensorflow backend. This would only be triggered when calling `math.kron`. As a result, the full test suite would pass but individual tests would fail.

**Description of the Change:** Changed some `.reshape` calls to `math.reshape`.