### PR TITLE
Alternative solution to representation caching 

### DIFF
--- a/mrmustard/lab_dev/circuit_components_utils.py
+++ b/mrmustard/lab_dev/circuit_components_utils.py
@@ -67,7 +67,9 @@ class TraceOut(CircuitComponent):
         super().__init__(
             modes_in_ket=modes,
             modes_in_bra=modes,
-            representation=Bargmann(A=None, b=None, c=None, fn=triples.identity_Abc, n_modes=len(modes)),
+            representation=Bargmann(
+                A=None, b=None, c=None, fn=triples.identity_Abc, n_modes=len(modes)
+            ),
             name="Tr",
         )
 
@@ -112,7 +114,14 @@ class BtoPS(Map):
         super().__init__(
             modes_out=modes,
             modes_in=modes,
-            representation=Bargmann(A=None, b=None, c=None, fn=triples.displacement_map_s_parametrized_Abc, s=s, n_modes=len(modes)),
+            representation=Bargmann(
+                A=None,
+                b=None,
+                c=None,
+                fn=triples.displacement_map_s_parametrized_Abc,
+                s=s,
+                n_modes=len(modes),
+            ),
             name="BtoPS",
         )
         self.s = s
@@ -133,7 +142,14 @@ class BtoQ(Operation):
         modes: Sequence[int],
         phi: float,
     ):
-        repr = Bargmann(A=None, b=None, c=None, fn=triples.bargmann_to_quadrature_Abc, n_modes=len(modes), phi=phi)
+        repr = Bargmann(
+            A=None,
+            b=None,
+            c=None,
+            fn=triples.bargmann_to_quadrature_Abc,
+            n_modes=len(modes),
+            phi=phi,
+        )
         super().__init__(
             modes_out=modes,
             modes_in=modes,

--- a/mrmustard/lab_dev/circuit_components_utils.py
+++ b/mrmustard/lab_dev/circuit_components_utils.py
@@ -67,9 +67,7 @@ class TraceOut(CircuitComponent):
         super().__init__(
             modes_in_ket=modes,
             modes_in_bra=modes,
-            representation=Bargmann(
-                A=None, b=None, c=None, fn=triples.identity_Abc, n_modes=len(modes)
-            ),
+            representation=Bargmann.from_generator(fn=triples.identity_Abc, n_modes=len(modes)),
             name="Tr",
         )
 
@@ -114,14 +112,7 @@ class BtoPS(Map):
         super().__init__(
             modes_out=modes,
             modes_in=modes,
-            representation=Bargmann(
-                A=None,
-                b=None,
-                c=None,
-                fn=triples.displacement_map_s_parametrized_Abc,
-                s=s,
-                n_modes=len(modes),
-            ),
+            representation=Bargmann.from_generator(fn=triples.displacement_map_s_parametrized_Abc, s=s, n_modes=len(modes)),
             name="BtoPS",
         )
         self.s = s
@@ -142,14 +133,8 @@ class BtoQ(Operation):
         modes: Sequence[int],
         phi: float,
     ):
-        repr = Bargmann(
-            A=None,
-            b=None,
-            c=None,
-            fn=triples.bargmann_to_quadrature_Abc,
-            n_modes=len(modes),
-            phi=phi,
-        )
+        
+        repr = Bargmann.from_generator(fn=triples.bargmann_to_quadrature_Abc, n_modes=len(modes), phi=phi)
         super().__init__(
             modes_out=modes,
             modes_in=modes,

--- a/mrmustard/lab_dev/circuit_components_utils.py
+++ b/mrmustard/lab_dev/circuit_components_utils.py
@@ -112,7 +112,9 @@ class BtoPS(Map):
         super().__init__(
             modes_out=modes,
             modes_in=modes,
-            representation=Bargmann.from_generator(fn=triples.displacement_map_s_parametrized_Abc, s=s, n_modes=len(modes)),
+            representation=Bargmann.from_generator(
+                fn=triples.displacement_map_s_parametrized_Abc, s=s, n_modes=len(modes)
+            ),
             name="BtoPS",
         )
         self.s = s
@@ -133,8 +135,10 @@ class BtoQ(Operation):
         modes: Sequence[int],
         phi: float,
     ):
-        
-        repr = Bargmann.from_generator(fn=triples.bargmann_to_quadrature_Abc, n_modes=len(modes), phi=phi)
+
+        repr = Bargmann.from_generator(
+            fn=triples.bargmann_to_quadrature_Abc, n_modes=len(modes), phi=phi
+        )
         super().__init__(
             modes_out=modes,
             modes_in=modes,

--- a/mrmustard/lab_dev/circuit_components_utils.py
+++ b/mrmustard/lab_dev/circuit_components_utils.py
@@ -67,7 +67,7 @@ class TraceOut(CircuitComponent):
         super().__init__(
             modes_in_ket=modes,
             modes_in_bra=modes,
-            representation=Bargmann(*triples.identity_Abc(len(modes))),
+            representation=Bargmann(A=None, b=None, c=None, fn=triples.identity_Abc, n_modes=len(modes)),
             name="Tr",
         )
 
@@ -112,7 +112,7 @@ class BtoPS(Map):
         super().__init__(
             modes_out=modes,
             modes_in=modes,
-            representation=Bargmann(*triples.displacement_map_s_parametrized_Abc(s, len(modes))),
+            representation=Bargmann(A=None, b=None, c=None, fn=triples.displacement_map_s_parametrized_Abc, s=s, n_modes=len(modes)),
             name="BtoPS",
         )
         self.s = s
@@ -133,7 +133,7 @@ class BtoQ(Operation):
         modes: Sequence[int],
         phi: float,
     ):
-        repr = Bargmann(*triples.bargmann_to_quadrature_Abc(len(modes), phi))
+        repr = Bargmann(A=None, b=None, c=None, fn=triples.bargmann_to_quadrature_Abc, n_modes=len(modes), phi=phi)
         super().__init__(
             modes_out=modes,
             modes_in=modes,

--- a/mrmustard/lab_dev/states/base.py
+++ b/mrmustard/lab_dev/states/base.py
@@ -674,7 +674,7 @@ class DM(State):
         shape_check(cov, means, 2 * len(modes), "Phase space")
         return coeff * DM(
             modes,
-            Bargmann(A=None, b=None, c=None, fn=wigner_to_bargmann_rho, cov=cov, means=means),
+            Bargmann.from_generator(fn=wigner_to_bargmann_rho, cov=cov, means=means),
             name,
         )
 
@@ -850,8 +850,7 @@ class Ket(State):
                 raise ValueError(msg)
         return Ket(
             modes,
-            coeff
-            * Bargmann(A=None, b=None, c=None, fn=wigner_to_bargmann_psi, cov=cov, means=means),
+            coeff * Bargmann.from_generator(fn=wigner_to_bargmann_psi, cov=cov, means=means),
             name,
         )
 

--- a/mrmustard/lab_dev/states/base.py
+++ b/mrmustard/lab_dev/states/base.py
@@ -672,7 +672,7 @@ class DM(State):
         cov = math.astensor(cov)
         means = math.astensor(means)
         shape_check(cov, means, 2 * len(modes), "Phase space")
-        return coeff * DM(modes, Bargmann(*wigner_to_bargmann_rho(cov, means)), name)
+        return coeff * DM(modes, Bargmann(A=None, b=None, c=None, fn=wigner_to_bargmann_rho, cov=cov, means=means), name)
 
     @property
     def _probabilities(self) -> RealVector:
@@ -838,7 +838,7 @@ class Ket(State):
             if p < 1.0 - atol_purity:
                 msg = f"Cannot initialize a Ket: purity is {p:.5f} (must be at least 1.0-{atol_purity})."
                 raise ValueError(msg)
-        return Ket(modes, coeff * Bargmann(*wigner_to_bargmann_psi(cov, means)), name)
+        return Ket(modes, coeff * Bargmann(A=None, b=None, c=None, fn=wigner_to_bargmann_psi, cov=cov, means=means), name)
 
     @property
     def _probabilities(self) -> RealVector:

--- a/mrmustard/lab_dev/states/base.py
+++ b/mrmustard/lab_dev/states/base.py
@@ -672,7 +672,11 @@ class DM(State):
         cov = math.astensor(cov)
         means = math.astensor(means)
         shape_check(cov, means, 2 * len(modes), "Phase space")
-        return coeff * DM(modes, Bargmann(A=None, b=None, c=None, fn=wigner_to_bargmann_rho, cov=cov, means=means), name)
+        return coeff * DM(
+            modes,
+            Bargmann(A=None, b=None, c=None, fn=wigner_to_bargmann_rho, cov=cov, means=means),
+            name,
+        )
 
     @property
     def _probabilities(self) -> RealVector:
@@ -838,7 +842,12 @@ class Ket(State):
             if p < 1.0 - atol_purity:
                 msg = f"Cannot initialize a Ket: purity is {p:.5f} (must be at least 1.0-{atol_purity})."
                 raise ValueError(msg)
-        return Ket(modes, coeff * Bargmann(A=None, b=None, c=None, fn=wigner_to_bargmann_psi, cov=cov, means=means), name)
+        return Ket(
+            modes,
+            coeff
+            * Bargmann(A=None, b=None, c=None, fn=wigner_to_bargmann_psi, cov=cov, means=means),
+            name,
+        )
 
     @property
     def _probabilities(self) -> RealVector:

--- a/mrmustard/lab_dev/states/states.py
+++ b/mrmustard/lab_dev/states/states.py
@@ -163,7 +163,9 @@ class DisplacedSqueezed(Ket):
             n_modes, x=self.x.value, y=self.y.value, r=self.r.value, phi=self.phi.value
         )
         xs, ys, rs, phis = list(params)
-        return Bargmann.from_generator(fn=triples.displaced_squeezed_vacuum_state_Abc, x=xs, y=ys, r=rs, phi=phis)
+        return Bargmann.from_generator(
+            fn=triples.displaced_squeezed_vacuum_state_Abc, x=xs, y=ys, r=rs, phi=phis
+        )
 
 
 class Number(Ket):
@@ -327,7 +329,9 @@ class TwoModeSqueezedVacuum(Ket):
     def representation(self) -> Bargmann:
         n_modes = len(self.modes)
         rs, phis = list(reshape_params(int(n_modes / 2), r=self.r.value, phi=self.phi.value))
-        return Bargmann.from_generator(fn=triples.two_mode_squeezed_vacuum_state_Abc, r=rs, phi=phis)
+        return Bargmann.from_generator(
+            fn=triples.two_mode_squeezed_vacuum_state_Abc, r=rs, phi=phis
+        )
 
 
 class Vacuum(Ket):
@@ -414,4 +418,3 @@ class Thermal(DM):
         n_modes = len(self.modes)
         nbars = list(reshape_params(n_modes, nbar=self.nbar.value))[0]
         return Bargmann.from_generator(fn=triples.thermal_state_Abc, nbar=nbars)
-    

--- a/mrmustard/lab_dev/states/states.py
+++ b/mrmustard/lab_dev/states/states.py
@@ -100,7 +100,7 @@ class Coherent(Ket):
     def representation(self) -> Bargmann:
         n_modes = len(self.modes)
         xs, ys = list(reshape_params(n_modes, x=self.x.value, y=self.y.value))
-        return Bargmann(*triples.coherent_state_Abc(xs, ys))
+        return Bargmann(A=None, b=None, c=None, fn=triples.coherent_state_Abc, x=xs, y=ys)
 
 
 class DisplacedSqueezed(Ket):
@@ -163,7 +163,7 @@ class DisplacedSqueezed(Ket):
             n_modes, x=self.x.value, y=self.y.value, r=self.r.value, phi=self.phi.value
         )
         xs, ys, rs, phis = list(params)
-        return Bargmann(*triples.displaced_squeezed_vacuum_state_Abc(xs, ys, rs, phis))
+        return Bargmann(A=None, b=None, c=None, fn=triples.displaced_squeezed_vacuum_state_Abc, x=xs, y=ys, r=rs, phi=phis)
 
 
 class Number(Ket):
@@ -283,7 +283,7 @@ class SqueezedVacuum(Ket):
     def representation(self) -> Bargmann:
         n_modes = len(self.modes)
         rs, phis = list(reshape_params(n_modes, r=self.r.value, phi=self.phi.value))
-        return Bargmann(*triples.squeezed_vacuum_state_Abc(rs, phis))
+        return Bargmann(A=None, b=None, c=None, fn=triples.squeezed_vacuum_state_Abc, r=rs, phi=phis)
 
 
 class TwoModeSqueezedVacuum(Ket):
@@ -327,7 +327,7 @@ class TwoModeSqueezedVacuum(Ket):
     def representation(self) -> Bargmann:
         n_modes = len(self.modes)
         rs, phis = list(reshape_params(int(n_modes / 2), r=self.r.value, phi=self.phi.value))
-        return Bargmann(*triples.two_mode_squeezed_vacuum_state_Abc(rs, phis))
+        return Bargmann(A=None, b=None, c=None, fn=triples.two_mode_squeezed_vacuum_state_Abc, r=rs, phi=phis)
 
 
 class Vacuum(Ket):
@@ -368,7 +368,7 @@ class Vacuum(Ket):
     @property
     def representation(self) -> Bargmann:
         n_modes = len(self.modes)
-        return Bargmann(*triples.vacuum_state_Abc(n_modes))
+        return Bargmann(A=None, b=None, c=None, fn=triples.vacuum_state_Abc, n_modes=n_modes)
 
 
 #  ~~~~~~~~~~~~
@@ -413,4 +413,4 @@ class Thermal(DM):
     def representation(self) -> Bargmann:
         n_modes = len(self.modes)
         nbars = list(reshape_params(n_modes, nbar=self.nbar.value))[0]
-        return Bargmann(*triples.thermal_state_Abc(nbars))
+        return Bargmann(A=None, b=None, c=None, fn=triples.thermal_state_Abc, nbar=nbars)

--- a/mrmustard/lab_dev/states/states.py
+++ b/mrmustard/lab_dev/states/states.py
@@ -163,7 +163,16 @@ class DisplacedSqueezed(Ket):
             n_modes, x=self.x.value, y=self.y.value, r=self.r.value, phi=self.phi.value
         )
         xs, ys, rs, phis = list(params)
-        return Bargmann(A=None, b=None, c=None, fn=triples.displaced_squeezed_vacuum_state_Abc, x=xs, y=ys, r=rs, phi=phis)
+        return Bargmann(
+            A=None,
+            b=None,
+            c=None,
+            fn=triples.displaced_squeezed_vacuum_state_Abc,
+            x=xs,
+            y=ys,
+            r=rs,
+            phi=phis,
+        )
 
 
 class Number(Ket):
@@ -283,7 +292,9 @@ class SqueezedVacuum(Ket):
     def representation(self) -> Bargmann:
         n_modes = len(self.modes)
         rs, phis = list(reshape_params(n_modes, r=self.r.value, phi=self.phi.value))
-        return Bargmann(A=None, b=None, c=None, fn=triples.squeezed_vacuum_state_Abc, r=rs, phi=phis)
+        return Bargmann(
+            A=None, b=None, c=None, fn=triples.squeezed_vacuum_state_Abc, r=rs, phi=phis
+        )
 
 
 class TwoModeSqueezedVacuum(Ket):
@@ -327,7 +338,9 @@ class TwoModeSqueezedVacuum(Ket):
     def representation(self) -> Bargmann:
         n_modes = len(self.modes)
         rs, phis = list(reshape_params(int(n_modes / 2), r=self.r.value, phi=self.phi.value))
-        return Bargmann(A=None, b=None, c=None, fn=triples.two_mode_squeezed_vacuum_state_Abc, r=rs, phi=phis)
+        return Bargmann(
+            A=None, b=None, c=None, fn=triples.two_mode_squeezed_vacuum_state_Abc, r=rs, phi=phis
+        )
 
 
 class Vacuum(Ket):

--- a/mrmustard/lab_dev/states/states.py
+++ b/mrmustard/lab_dev/states/states.py
@@ -100,7 +100,7 @@ class Coherent(Ket):
     def representation(self) -> Bargmann:
         n_modes = len(self.modes)
         xs, ys = list(reshape_params(n_modes, x=self.x.value, y=self.y.value))
-        return Bargmann(A=None, b=None, c=None, fn=triples.coherent_state_Abc, x=xs, y=ys)
+        return Bargmann.from_generator(fn=triples.coherent_state_Abc, x=xs, y=ys)
 
 
 class DisplacedSqueezed(Ket):
@@ -163,16 +163,7 @@ class DisplacedSqueezed(Ket):
             n_modes, x=self.x.value, y=self.y.value, r=self.r.value, phi=self.phi.value
         )
         xs, ys, rs, phis = list(params)
-        return Bargmann(
-            A=None,
-            b=None,
-            c=None,
-            fn=triples.displaced_squeezed_vacuum_state_Abc,
-            x=xs,
-            y=ys,
-            r=rs,
-            phi=phis,
-        )
+        return Bargmann.from_generator(fn=triples.displaced_squeezed_vacuum_state_Abc, x=xs, y=ys, r=rs, phi=phis)
 
 
 class Number(Ket):
@@ -292,9 +283,7 @@ class SqueezedVacuum(Ket):
     def representation(self) -> Bargmann:
         n_modes = len(self.modes)
         rs, phis = list(reshape_params(n_modes, r=self.r.value, phi=self.phi.value))
-        return Bargmann(
-            A=None, b=None, c=None, fn=triples.squeezed_vacuum_state_Abc, r=rs, phi=phis
-        )
+        return Bargmann.from_generator(fn=triples.squeezed_vacuum_state_Abc, r=rs, phi=phis)
 
 
 class TwoModeSqueezedVacuum(Ket):
@@ -338,9 +327,7 @@ class TwoModeSqueezedVacuum(Ket):
     def representation(self) -> Bargmann:
         n_modes = len(self.modes)
         rs, phis = list(reshape_params(int(n_modes / 2), r=self.r.value, phi=self.phi.value))
-        return Bargmann(
-            A=None, b=None, c=None, fn=triples.two_mode_squeezed_vacuum_state_Abc, r=rs, phi=phis
-        )
+        return Bargmann.from_generator(fn=triples.two_mode_squeezed_vacuum_state_Abc, r=rs, phi=phis)
 
 
 class Vacuum(Ket):
@@ -381,7 +368,7 @@ class Vacuum(Ket):
     @property
     def representation(self) -> Bargmann:
         n_modes = len(self.modes)
-        return Bargmann(A=None, b=None, c=None, fn=triples.vacuum_state_Abc, n_modes=n_modes)
+        return Bargmann.from_generator(fn=triples.vacuum_state_Abc, n_modes=n_modes)
 
 
 #  ~~~~~~~~~~~~
@@ -426,4 +413,5 @@ class Thermal(DM):
     def representation(self) -> Bargmann:
         n_modes = len(self.modes)
         nbars = list(reshape_params(n_modes, nbar=self.nbar.value))[0]
-        return Bargmann(A=None, b=None, c=None, fn=triples.thermal_state_Abc, nbar=nbars)
+        return Bargmann.from_generator(fn=triples.thermal_state_Abc, nbar=nbars)
+    

--- a/mrmustard/lab_dev/transformations/transformations.py
+++ b/mrmustard/lab_dev/transformations/transformations.py
@@ -106,7 +106,7 @@ class BSgate(Unitary):
 
     @property
     def representation(self) -> Bargmann:
-        return Bargmann(*triples.beamsplitter_gate_Abc(self.theta.value, self.phi.value))
+        return Bargmann(A=None, b=None, c=None, fn=triples.beamsplitter_gate_Abc, theta=self.theta.value, phi=self.phi.value)
 
 
 class Dgate(Unitary):
@@ -176,7 +176,7 @@ class Dgate(Unitary):
     def representation(self) -> Bargmann:
         n_modes = len(self.modes)
         xs, ys = list(reshape_params(n_modes, x=self.x.value, y=self.y.value))
-        return Bargmann(*triples.displacement_gate_Abc(xs, ys))
+        return Bargmann(A=None, b=None, c=None, fn=triples.displacement_gate_Abc, x=xs, y=ys)
 
 
 class Rgate(Unitary):
@@ -217,7 +217,7 @@ class Rgate(Unitary):
     def representation(self) -> Bargmann:
         n_modes = len(self.modes)
         phis = list(reshape_params(n_modes, phi=self.phi.value))[0]
-        return Bargmann(*triples.rotation_gate_Abc(phis))
+        return Bargmann(A=None, b=None, c=None, fn=triples.rotation_gate_Abc, theta=phis)
 
 
 class Sgate(Unitary):
@@ -290,7 +290,7 @@ class Sgate(Unitary):
     def representation(self) -> Bargmann:
         n_modes = len(self.modes)
         rs, phis = list(reshape_params(n_modes, r=self.r.value, phi=self.phi.value))
-        return Bargmann(*triples.squeezing_gate_Abc(rs, phis))
+        return Bargmann(A=None, b=None, c=None, fn=triples.squeezing_gate_Abc, r=rs, delta=phis)
 
 
 class Identity(Unitary):
@@ -322,7 +322,7 @@ class Identity(Unitary):
     @property
     def representation(self) -> Bargmann:
         n_modes = len(self.modes)
-        return Bargmann(*triples.identity_Abc(n_modes))
+        return Bargmann(A=None, b=None, c=None, fn=triples.identity_Abc, n_modes=n_modes)
 
 
 class S2gate(Unitary):
@@ -386,7 +386,7 @@ class S2gate(Unitary):
 
     @property
     def representation(self) -> Bargmann:
-        return Bargmann(*triples.twomode_squeezing_gate_Abc(self.r.value, self.phi.value))
+        return Bargmann(A=None, b=None, c=None, fn=triples.twomode_squeezing_gate_Abc, r=self.r.value, phi=self.phi.value)
 
 
 class Amplifier(Channel):
@@ -457,7 +457,7 @@ class Amplifier(Channel):
     @property
     def representation(self) -> Bargmann:
         g = list(reshape_params(len(self.modes), g=self.gain.value))[0]
-        return Bargmann(*triples.amplifier_Abc(g))
+        return Bargmann(A=None, b=None, c=None, fn=triples.amplifier_Abc, g=g)
 
 
 class Attenuator(Channel):

--- a/mrmustard/lab_dev/transformations/transformations.py
+++ b/mrmustard/lab_dev/transformations/transformations.py
@@ -106,7 +106,9 @@ class BSgate(Unitary):
 
     @property
     def representation(self) -> Bargmann:
-        return Bargmann.from_generator(fn=triples.beamsplitter_gate_Abc, theta=self.theta.value, phi=self.phi.value)
+        return Bargmann.from_generator(
+            fn=triples.beamsplitter_gate_Abc, theta=self.theta.value, phi=self.phi.value
+        )
 
 
 class Dgate(Unitary):
@@ -386,7 +388,9 @@ class S2gate(Unitary):
 
     @property
     def representation(self) -> Bargmann:
-        return Bargmann.from_generator(fn=triples.twomode_squeezing_gate_Abc, r=self.r.value, phi=self.phi.value)
+        return Bargmann.from_generator(
+            fn=triples.twomode_squeezing_gate_Abc, r=self.r.value, phi=self.phi.value
+        )
 
 
 class Amplifier(Channel):

--- a/mrmustard/lab_dev/transformations/transformations.py
+++ b/mrmustard/lab_dev/transformations/transformations.py
@@ -530,4 +530,4 @@ class Attenuator(Channel):
     def representation(self) -> Bargmann:
         n_modes = len(self.modes)
         eta = list(reshape_params(n_modes, eta=self.transmissivity.value))[0]
-        return Bargmann(*triples.attenuator_Abc(eta))
+        return Bargmann(A=None, b=None, c=None, fn=triples.attenuator_Abc, eta=eta)

--- a/mrmustard/lab_dev/transformations/transformations.py
+++ b/mrmustard/lab_dev/transformations/transformations.py
@@ -106,14 +106,7 @@ class BSgate(Unitary):
 
     @property
     def representation(self) -> Bargmann:
-        return Bargmann(
-            A=None,
-            b=None,
-            c=None,
-            fn=triples.beamsplitter_gate_Abc,
-            theta=self.theta.value,
-            phi=self.phi.value,
-        )
+        return Bargmann.from_generator(fn=triples.beamsplitter_gate_Abc, theta=self.theta.value, phi=self.phi.value)
 
 
 class Dgate(Unitary):
@@ -183,7 +176,7 @@ class Dgate(Unitary):
     def representation(self) -> Bargmann:
         n_modes = len(self.modes)
         xs, ys = list(reshape_params(n_modes, x=self.x.value, y=self.y.value))
-        return Bargmann(A=None, b=None, c=None, fn=triples.displacement_gate_Abc, x=xs, y=ys)
+        return Bargmann.from_generator(fn=triples.displacement_gate_Abc, x=xs, y=ys)
 
 
 class Rgate(Unitary):
@@ -224,7 +217,7 @@ class Rgate(Unitary):
     def representation(self) -> Bargmann:
         n_modes = len(self.modes)
         phis = list(reshape_params(n_modes, phi=self.phi.value))[0]
-        return Bargmann(A=None, b=None, c=None, fn=triples.rotation_gate_Abc, theta=phis)
+        return Bargmann.from_generator(fn=triples.rotation_gate_Abc, theta=phis)
 
 
 class Sgate(Unitary):
@@ -297,7 +290,7 @@ class Sgate(Unitary):
     def representation(self) -> Bargmann:
         n_modes = len(self.modes)
         rs, phis = list(reshape_params(n_modes, r=self.r.value, phi=self.phi.value))
-        return Bargmann(A=None, b=None, c=None, fn=triples.squeezing_gate_Abc, r=rs, delta=phis)
+        return Bargmann.from_generator(fn=triples.squeezing_gate_Abc, r=rs, delta=phis)
 
 
 class Identity(Unitary):
@@ -329,7 +322,7 @@ class Identity(Unitary):
     @property
     def representation(self) -> Bargmann:
         n_modes = len(self.modes)
-        return Bargmann(A=None, b=None, c=None, fn=triples.identity_Abc, n_modes=n_modes)
+        return Bargmann.from_generator(fn=triples.identity_Abc, n_modes=n_modes)
 
 
 class S2gate(Unitary):
@@ -393,14 +386,7 @@ class S2gate(Unitary):
 
     @property
     def representation(self) -> Bargmann:
-        return Bargmann(
-            A=None,
-            b=None,
-            c=None,
-            fn=triples.twomode_squeezing_gate_Abc,
-            r=self.r.value,
-            phi=self.phi.value,
-        )
+        return Bargmann.from_generator(fn=triples.twomode_squeezing_gate_Abc, r=self.r.value, phi=self.phi.value)
 
 
 class Amplifier(Channel):
@@ -471,7 +457,7 @@ class Amplifier(Channel):
     @property
     def representation(self) -> Bargmann:
         g = list(reshape_params(len(self.modes), g=self.gain.value))[0]
-        return Bargmann(A=None, b=None, c=None, fn=triples.amplifier_Abc, g=g)
+        return Bargmann.from_generator(fn=triples.amplifier_Abc, g=g)
 
 
 class Attenuator(Channel):
@@ -544,4 +530,4 @@ class Attenuator(Channel):
     def representation(self) -> Bargmann:
         n_modes = len(self.modes)
         eta = list(reshape_params(n_modes, eta=self.transmissivity.value))[0]
-        return Bargmann(A=None, b=None, c=None, fn=triples.attenuator_Abc, eta=eta)
+        return Bargmann.from_generator(fn=triples.attenuator_Abc, eta=eta)

--- a/mrmustard/lab_dev/transformations/transformations.py
+++ b/mrmustard/lab_dev/transformations/transformations.py
@@ -106,7 +106,14 @@ class BSgate(Unitary):
 
     @property
     def representation(self) -> Bargmann:
-        return Bargmann(A=None, b=None, c=None, fn=triples.beamsplitter_gate_Abc, theta=self.theta.value, phi=self.phi.value)
+        return Bargmann(
+            A=None,
+            b=None,
+            c=None,
+            fn=triples.beamsplitter_gate_Abc,
+            theta=self.theta.value,
+            phi=self.phi.value,
+        )
 
 
 class Dgate(Unitary):
@@ -386,7 +393,14 @@ class S2gate(Unitary):
 
     @property
     def representation(self) -> Bargmann:
-        return Bargmann(A=None, b=None, c=None, fn=triples.twomode_squeezing_gate_Abc, r=self.r.value, phi=self.phi.value)
+        return Bargmann(
+            A=None,
+            b=None,
+            c=None,
+            fn=triples.twomode_squeezing_gate_Abc,
+            r=self.r.value,
+            phi=self.phi.value,
+        )
 
 
 class Amplifier(Channel):

--- a/mrmustard/physics/ansatze.py
+++ b/mrmustard/physics/ansatze.py
@@ -155,11 +155,8 @@ class PolyExpBase(Ansatz):
     def _compute_abc(self):
         A,b,c = self._fn(**self._kwargs)
         self._mat = A
-        self._backend_mat = A
         self._vec = b
-        self._backend_vec = b
         self._array = c
-        self._backend_array = c
 
     @property
     def batch_size(self):

--- a/mrmustard/physics/ansatze.py
+++ b/mrmustard/physics/ansatze.py
@@ -393,7 +393,7 @@ class PolyExpAnsatz(PolyExpBase):
         The array of coefficients for the polynomial terms in the ansatz.
         """
         return self.array
-    
+
     @classmethod
     def from_generator(cls, fn: Callable, **kwargs: Any) -> PolyExpAnsatz:
         r"""

--- a/mrmustard/physics/ansatze.py
+++ b/mrmustard/physics/ansatze.py
@@ -140,7 +140,14 @@ class PolyExpBase(Ansatz):
         **kwargs: arguments for ``fn``.
     """
 
-    def __init__(self, mat: Batch[Matrix], vec: Batch[Vector], array: Batch[Tensor], fn: Optional[Callable] = None, **kwargs: Any):
+    def __init__(
+        self,
+        mat: Batch[Matrix],
+        vec: Batch[Vector],
+        array: Batch[Tensor],
+        fn: Optional[Callable] = None,
+        **kwargs: Any,
+    ):
         self._mat = mat
         self._vec = vec
         self._array = array
@@ -293,10 +300,10 @@ class PolyExpBase(Ansatz):
 
     def _compute_abc(self):
         r"""
-        This method computes and sets the matrix, vector and array given a function 
+        This method computes and sets the matrix, vector and array given a function
         and some kwargs.
         """
-        A,b,c = self._fn(**self._kwargs)
+        A, b, c = self._fn(**self._kwargs)
         self._mat = A
         self._vec = b
         self._array = c
@@ -366,12 +373,12 @@ class PolyExpAnsatz(PolyExpBase):
         c: Batch[Tensor | Scalar] = 1.0,
         name: str = "",
         fn: Optional[Callable] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ):
         self.name = name
 
         if A is None and b is None and fn is None:
-            print (fn)
+            print(fn)
             raise ValueError("Please provide either A or b or a function to generate (A, b, c).")
         super().__init__(mat=A, vec=b, array=c, fn=fn, **kwargs)
 

--- a/mrmustard/physics/ansatze.py
+++ b/mrmustard/physics/ansatze.py
@@ -378,7 +378,6 @@ class PolyExpAnsatz(PolyExpBase):
         self.name = name
 
         if A is None and b is None and fn is None:
-            print(fn)
             raise ValueError("Please provide either A or b or a function to generate (A, b, c).")
         super().__init__(mat=A, vec=b, array=c, fn=fn, **kwargs)
 

--- a/mrmustard/physics/ansatze.py
+++ b/mrmustard/physics/ansatze.py
@@ -139,12 +139,48 @@ class PolyExpBase(Ansatz):
     """
 
     def __init__(self, mat: Batch[Matrix], vec: Batch[Vector], array: Batch[Tensor]):
-        self.mat = math.atleast_3d(math.astensor(mat))
-        self.vec = math.atleast_2d(math.astensor(vec))
-        self.array = math.atleast_1d(math.astensor(array))
-        self.batch_size = self.mat.shape[0]
-        self.num_vars = self.mat.shape[-1]
+        self._mat = mat
+        self._vec = vec
+        self._array = array
         self._simplified = False
+
+    @property
+    def batch_size(self):
+        return self.mat.shape[0]
+
+    @property
+    def num_vars(self):
+        return self.mat.shape[-1]
+
+    @property
+    def mat(self) -> Batch[ComplexMatrix]:
+        r"""
+        """
+        return math.atleast_3d(self._mat)
+
+    @mat.setter
+    def mat(self, array):
+        self._mat = array 
+
+    @property
+    def vec(self) -> Batch[ComplexMatrix]:
+        r"""
+        """
+        return math.atleast_2d(self._vec)
+
+    @vec.setter
+    def vec(self, array):
+        self._vec = array
+
+    @property
+    def array(self) -> Batch[ComplexMatrix]:
+        r"""
+        """
+        return math.atleast_1d(self._array)
+
+    @array.setter
+    def array(self, array):
+        self._array = array
 
     def __neg__(self) -> PolyExpBase:
         return self.__class__(self.mat, self.vec, -self.array)
@@ -423,11 +459,19 @@ class ArrayAnsatz(Ansatz):
     """
 
     def __init__(self, array: Batch[Tensor], batched: bool = True):
-        array = math.astensor(array)
-        if not batched:
-            array = array[None, ...]
-        self.array = array
-        self.num_vars = len(self.array.shape) - 1
+        self._array = array if batched else [array]
+
+    @property
+    def array(self) -> Batch[Tensor]:
+        r"""
+        """
+        return math.astensor(self._array)
+
+    @property
+    def num_vars(self) -> int:
+        r"""
+        """
+        return len(self.array.shape) - 1
 
     def __neg__(self) -> ArrayAnsatz:
         r"""

--- a/mrmustard/physics/representations.py
+++ b/mrmustard/physics/representations.py
@@ -312,7 +312,7 @@ class Bargmann(Representation):
         The scalar part of the representation.
         """
         return self.c
-    
+
     @classmethod
     def from_generator(cls, fn: Callable, **kwargs: Any) -> Bargmann:
         r"""

--- a/mrmustard/physics/representations.py
+++ b/mrmustard/physics/representations.py
@@ -249,8 +249,8 @@ class Bargmann(Representation):
         A: Batch[ComplexMatrix],
         b: Batch[ComplexVector],
         c: Batch[ComplexTensor] = 1.0,
-        fn = None,
-        **kwargs
+        fn=None,
+        **kwargs,
     ):
         self._contract_idxs: tuple[int, ...] = ()
         self._ansatz = PolyExpAnsatz(A=A, b=b, c=c, fn=fn, **kwargs)

--- a/mrmustard/physics/representations.py
+++ b/mrmustard/physics/representations.py
@@ -249,9 +249,11 @@ class Bargmann(Representation):
         A: Batch[ComplexMatrix],
         b: Batch[ComplexVector],
         c: Batch[ComplexTensor] = 1.0,
+        fn = None,
+        **kwargs
     ):
         self._contract_idxs: tuple[int, ...] = ()
-        self._ansatz = PolyExpAnsatz(A, b, c)
+        self._ansatz = PolyExpAnsatz(A=A, b=b, c=c, fn=fn, **kwargs)
 
     @property
     def ansatz(self) -> PolyExpAnsatz:

--- a/mrmustard/physics/representations.py
+++ b/mrmustard/physics/representations.py
@@ -20,7 +20,7 @@ This module contains the classes for the available representations.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Iterable, Union
+from typing import Any, Callable, Iterable, Union
 import os
 from matplotlib import colors
 import matplotlib.pyplot as plt
@@ -249,11 +249,9 @@ class Bargmann(Representation):
         A: Batch[ComplexMatrix],
         b: Batch[ComplexVector],
         c: Batch[ComplexTensor] = 1.0,
-        fn=None,
-        **kwargs,
     ):
         self._contract_idxs: tuple[int, ...] = ()
-        self._ansatz = PolyExpAnsatz(A=A, b=b, c=c, fn=fn, **kwargs)
+        self._ansatz = PolyExpAnsatz(A=A, b=b, c=c)
 
     @property
     def ansatz(self) -> PolyExpAnsatz:
@@ -314,6 +312,16 @@ class Bargmann(Representation):
         The scalar part of the representation.
         """
         return self.c
+    
+    @classmethod
+    def from_generator(cls, fn: Callable, **kwargs: Any) -> Bargmann:
+        r"""
+        Returns a Bargmann object from a generator function.
+        """
+        ret = cls(None, None, None)
+        ansatz = PolyExpAnsatz.from_generator(fn, **kwargs)
+        ret._ansatz = ansatz
+        return ret
 
     def conj(self):
         r"""

--- a/mrmustard/physics/triples.py
+++ b/mrmustard/physics/triples.py
@@ -465,7 +465,7 @@ def attenuator_Abc(eta: Union[float, Iterable[float]]) -> Union[Matrix, Vector, 
 
     O_n = math.zeros((n_modes, n_modes), math.complex128)
     eta1 = math.reshape(math.diag(math.sqrt(eta)), (n_modes, n_modes))
-    eta2 = math.eye(n_modes) - math.reshape(math.diag(eta), (n_modes, n_modes))
+    eta2 = math.eye(n_modes, math.complex128) - math.reshape(math.diag(eta), (n_modes, n_modes))
     A = math.block(
         [
             [O_n, eta1, O_n, O_n],

--- a/mrmustard/physics/triples.py
+++ b/mrmustard/physics/triples.py
@@ -464,9 +464,8 @@ def attenuator_Abc(eta: Union[float, Iterable[float]]) -> Union[Matrix, Vector, 
             raise ValueError(msg)
 
     O_n = math.zeros((n_modes, n_modes), math.complex128)
-    eta1 = math.diag(math.sqrt(eta)).reshape((n_modes, n_modes))
-    eta2 = math.eye(n_modes) - math.diag(eta).reshape((n_modes, n_modes))
-
+    eta1 = math.reshape(math.diag(math.sqrt(eta)), (n_modes, n_modes))
+    eta2 = math.eye(n_modes) - math.reshape(math.diag(eta), (n_modes, n_modes))
     A = math.block(
         [
             [O_n, eta1, O_n, O_n],


### PR DESCRIPTION
Opening for discussion 

**Context:** This PR is meant as a proposed alternative to representation caching. By using 'lazy evaluation' in representation/ansatz we can avoid having potentially costly computations just to initialize the representation for calls such as `obj.representation.__class__`. 

**Description of the Change:** Ansatz no longer calls backend methods in the init. Instead, the original parameters are stored (`mat`, `vec`, `array` for `PolyExpAnsatz` or  `array` for `ArrayAnsatz`) and backend methods such as `astensor` and `at_least3d` are only called when the property itself is called (then subsequently stored to avoid repeat calls). In addition to this the representation/ansatz can now also accept a function and some kwargs in substitution of specifying an `(A, b, c)`. 

**Benefits:** Based on some initial profiling initializing a representation/ansatz is more efficient. 
