### PR TITLE
Various improvements for visualizations

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -20,7 +20,7 @@
 * Replace IPython `_repr_html_` `mako`-based implementations
   with `ipywidgets` and improve the aesthetics.
   [(#425)](https://github.com/XanaduAI/MrMustard/pull/425)
-  [(#4xx)](https://github.com/XanaduAI/MrMustard/pull/4xx)
+  [(#450)](https://github.com/XanaduAI/MrMustard/pull/450)
 
 ### Bug fixes
 * Fix the bug in the order of indices of the triples for DsMap CircuitComponent.

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -19,7 +19,8 @@
 
 * Replace IPython `_repr_html_` `mako`-based implementations
   with `ipywidgets` and improve the aesthetics.
-  [(#425)]https://github.com/XanaduAI/MrMustard/pull/425
+  [(#425)](https://github.com/XanaduAI/MrMustard/pull/425)
+  [(#4xx)](https://github.com/XanaduAI/MrMustard/pull/4xx)
 
 ### Bug fixes
 * Fix the bug in the order of indices of the triples for DsMap CircuitComponent.
@@ -31,7 +32,7 @@
   [(#406)](https://github.com/XanaduAI/MrMustard/pull/406)
 
 * Fix object visualizations in VS Code Notebooks by using the built-in display tools.
-  [(#425)]https://github.com/XanaduAI/MrMustard/pull/425
+  [(#425)](https://github.com/XanaduAI/MrMustard/pull/425)
 
 ### Documentation
 

--- a/mrmustard/lab_dev/states/base.py
+++ b/mrmustard/lab_dev/states/base.py
@@ -338,7 +338,7 @@ class State(CircuitComponent):
         xbounds: tuple[int, int] = (-6, 6),
         pbounds: tuple[int, int] = (-6, 6),
         resolution: int = 200,
-        colorscale: str = "viridis",
+        colorscale: str = "RdBu",
         return_fig: bool = False,
     ) -> Union[go.Figure, None]:
         r"""
@@ -409,12 +409,12 @@ class State(CircuitComponent):
             x=xs,
             y=-ps,
             z=math.transpose(z),
-            colorscale=colorscale,
+            coloraxis="coloraxis",
             name="Wigner function",
             autocolorscale=False,
         )
         fig.add_trace(fig_21, row=2, col=1)
-        fig.update_traces(row=2, col=1, showscale=False)
+        fig.update_traces(row=2, col=1)
         fig.update_xaxes(range=xbounds, title_text="x", row=2, col=1)
         fig.update_yaxes(range=pbounds, title_text="p", row=2, col=1)
 
@@ -436,6 +436,7 @@ class State(CircuitComponent):
             plot_bgcolor="aliceblue",
             margin=dict(l=20, r=20, t=30, b=20),
             showlegend=False,
+            coloraxis={"colorscale": colorscale, "cmid": 0, "showscale": False},
         )
         fig.update_xaxes(
             showline=True,
@@ -461,7 +462,7 @@ class State(CircuitComponent):
         xbounds: tuple[int] = (-6, 6),
         pbounds: tuple[int] = (-6, 6),
         resolution: int = 200,
-        colorscale: str = "viridis",
+        colorscale: str = "RdBu",
         return_fig: bool = False,
     ) -> Union[go.Figure, None]:
         r"""
@@ -499,7 +500,7 @@ class State(CircuitComponent):
                 x=xs,
                 y=ps,
                 z=z,
-                colorscale=colorscale,
+                coloraxis="coloraxis",
                 hovertemplate="x: %{x:.3f}"
                 + "<br>p: %{y:.3f}"
                 + "<br>W(x, p): %{z:.3f}<extra></extra>",
@@ -512,6 +513,7 @@ class State(CircuitComponent):
             height=500,
             margin=dict(l=0, r=0, b=0, t=0),
             scene_camera_eye=dict(x=-2.1, y=0.88, z=0.64),
+            coloraxis={"colorscale": colorscale, "cmid": 0},
         )
         fig.update_traces(
             contours_z=dict(

--- a/mrmustard/lab_dev/states/base.py
+++ b/mrmustard/lab_dev/states/base.py
@@ -395,7 +395,7 @@ class State(CircuitComponent):
         fig = make_subplots(
             rows=2,
             cols=2,
-            column_widths=[2, 1],
+            column_widths=[5, 3],
             row_heights=[1, 2],
             vertical_spacing=0.05,
             horizontal_spacing=0.05,
@@ -432,7 +432,7 @@ class State(CircuitComponent):
 
         fig.update_layout(
             height=500,
-            width=500,
+            width=580,
             plot_bgcolor="aliceblue",
             margin=dict(l=20, r=20, t=30, b=20),
             showlegend=False,

--- a/mrmustard/lab_dev/states/base.py
+++ b/mrmustard/lab_dev/states/base.py
@@ -436,7 +436,7 @@ class State(CircuitComponent):
             plot_bgcolor="aliceblue",
             margin=dict(l=20, r=20, t=30, b=20),
             showlegend=False,
-            coloraxis={"colorscale": colorscale, "cmid": 0, "showscale": False},
+            coloraxis={"colorscale": colorscale, "cmid": 0},
         )
         fig.update_xaxes(
             showline=True,

--- a/mrmustard/physics/fock.py
+++ b/mrmustard/physics/fock.py
@@ -819,7 +819,7 @@ def estimate_quadrature_axis(cutoff, minimum=5, period_resolution=20):
 def quadrature_distribution(
     state: Tensor,
     quadrature_angle: float = 0.0,
-    x: Vector = None,
+    x: Optional[Vector] = None,
 ):
     r"""Given the ket or density matrix of a single-mode state, it generates the probability
     density distribution :math:`\tr [ \rho |x_\phi><x_\phi| ]`  where `\rho` is the
@@ -837,7 +837,7 @@ def quadrature_distribution(
     dims = len(state.shape)
     if dims > 2:
         raise ValueError(
-            "Input state has dimension {state.shape}. Make sure is either a single-mode ket or dm."
+            f"Input state has dimension {state.shape}. Make sure is either a single-mode ket or dm."
         )
 
     is_dm = dims == 2

--- a/mrmustard/widgets/__init__.py
+++ b/mrmustard/widgets/__init__.py
@@ -38,8 +38,8 @@ def _batch_widget(obj, batch_size, widget_fn, *widget_args):
 
 def fock_1d(array):
     """Return a plot widget for a 2D Fock representation."""
-    layout = {"margin": NO_MARGIN, "height": 200, "width": 430}
-    mag_plot = go.Scatter(y=abs(array))
+    layout = {"margin": NO_MARGIN, "height": 200, "width": 250}
+    mag_plot = go.Bar(y=abs(array))
     phase_plot = go.Scatter(y=np.angle(array))
     plots = [go.FigureWidget(p, layout=layout) for p in [mag_plot, phase_plot]]
     return widgets.Tab(plots, titles=["Magnitude", "Phase"])
@@ -47,7 +47,7 @@ def fock_1d(array):
 
 def fock_2d(array):
     """Return a plot widget for a 1D Fock representation."""
-    layout = {"height": 200, "width": 430, "margin": NO_MARGIN, "yaxis": {"autorange": "reversed"}}
+    layout = {"height": 200, "width": 250, "margin": NO_MARGIN, "yaxis": {"autorange": "reversed"}}
     mag_plot = go.Heatmap(z=abs(array), colorscale="viridis", showscale=False)
     phase_plot = go.Heatmap(z=np.angle(array), colorscale="agsunset", showscale=False)
     plots = [go.FigureWidget(data=p, layout=layout) for p in [mag_plot, phase_plot]]

--- a/mrmustard/widgets/__init__.py
+++ b/mrmustard/widgets/__init__.py
@@ -40,7 +40,7 @@ def fock_1d(array):
     """Return a plot widget for a 2D Fock representation."""
     layout = {"margin": NO_MARGIN, "height": 200, "width": 250}
     mag_plot = go.Bar(y=abs(array))
-    phase_plot = go.Scatter(y=np.angle(array))
+    phase_plot = go.Bar(y=np.angle(array))
     plots = [go.FigureWidget(p, layout=layout) for p in [mag_plot, phase_plot]]
     return widgets.Tab(plots, titles=["Magnitude", "Phase"])
 


### PR DESCRIPTION
**Context:**
Now that the visualization improvements have been added to MrMustard, there's some feedback that needs addressing. This PR does that.

**Description of the Change:**
- Change the default colour scheme in the 2D/3D Wigner plots from `viridis` to `RdBu` to distinguish from the density matrix plot as suggested in #418. I definitely agree with the choice - negative is red, zero is white, and positive is blue. Felt semi-intuitive. If you'd prefer another one from [plotly's list](https://plotly.com/python/builtin-colorscales/), lmk!
- Force the mid-point of the colour axis in those Wigner plots to always be 0 instead of auto-scaling, and show the scale
- Change the widget in the Fock repr to be kinda-square
- Change the 2D Fock magnitude plot to be a bar graph

**Benefits:**
- Things look more how we want them to
- Wigner color scale is consistent between plots to avoid confusion, and scale is shown now
- Fock magnitude plot no longer falsely suggest that it represents continuous information

**Possible Drawbacks:**
- Maybe you don't like RdBu?
- Maybe you'd prefer the colour scale to be hidden like before?

**Related GitHub Issues:**
Fixes #417, Fixes #418