### PR TITLE
QuadratureEigenstate Fixes 

### DIFF
--- a/mrmustard/lab_dev/states/base.py
+++ b/mrmustard/lab_dev/states/base.py
@@ -50,8 +50,6 @@ from mrmustard.utils.typing import (
 from mrmustard.physics.bargmann import (
     wigner_to_bargmann_psi,
     wigner_to_bargmann_rho,
-    norm_ket,
-    trace_dm,
 )
 from mrmustard.math.lattice.strategies.vanilla import autoshape_numba
 from mrmustard.physics.gaussian import purity
@@ -656,7 +654,7 @@ class DM(State):
             except AttributeError:  # bargmann
                 repr = self.representation
                 A, b, c = repr.A[0], repr.b[0], repr.c[0]
-                repr = repr / trace_dm(A, b, c)
+                repr = repr / self.probability
                 shape = autoshape_numba(
                     math.asnumpy(A),
                     math.asnumpy(b),
@@ -929,7 +927,7 @@ class Ket(State):
             except AttributeError:  # bargmann
                 repr = self.representation.conj() & self.representation
                 A, b, c = repr.A[0], repr.b[0], repr.c[0]
-                repr = repr / norm_ket(A, b, c)
+                repr = repr / self.probability
                 shape = autoshape_numba(
                     math.asnumpy(A),
                     math.asnumpy(b),

--- a/mrmustard/lab_dev/states/quadrature_eigenstate.py
+++ b/mrmustard/lab_dev/states/quadrature_eigenstate.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-The class representing a squeezed vacuum state.
+The class representing a quadrature eigenstate.
 """
 
 from __future__ import annotations

--- a/mrmustard/lab_dev/states/quadrature_eigenstate.py
+++ b/mrmustard/lab_dev/states/quadrature_eigenstate.py
@@ -32,7 +32,7 @@ __all__ = ["QuadratureEigenstate"]
 
 class QuadratureEigenstate(Ket):
     r"""
-    The `N`-mode Quadrature eigenstate .
+    The `N`-mode Quadrature eigenstate.
 
     .. code-block ::
 
@@ -71,6 +71,11 @@ class QuadratureEigenstate(Ket):
             fn=triples.quadrature_eigenstates_Abc, x=self.x, phi=self.phi
         )
 
+        self.manual_shape = (50,)
+
     @property
     def L2_norm(self):
+        r"""
+        The L2 norm of this quadrature eigenstate.
+        """
         return np.inf

--- a/mrmustard/lab_dev/states/quadrature_eigenstate.py
+++ b/mrmustard/lab_dev/states/quadrature_eigenstate.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 
 from typing import Sequence, Tuple
 
+import numpy as np
+
 from mrmustard.physics.representations import Bargmann
 from mrmustard.physics import triples
 from .base import Ket
@@ -68,3 +70,7 @@ class QuadratureEigenstate(Ket):
         self._representation = Bargmann.from_function(
             fn=triples.quadrature_eigenstates_Abc, x=self.x, phi=self.phi
         )
+
+    @property
+    def L2_norm(self):
+        return np.inf

--- a/mrmustard/physics/gaussian_integrals.py
+++ b/mrmustard/physics/gaussian_integrals.py
@@ -132,9 +132,15 @@ def complex_gaussian_integral(
     M = math.gather(math.gather(A, idx, axis=-1), idx, axis=-2) + X * measure
     bM = math.gather(b, idx, axis=-1)
 
-    c_post = (
-        c * math.sqrt((-1) ** n / math.det(M)) * math.exp(-0.5 * math.sum(bM * math.solve(M, bM)))
-    )
+    determinant = math.det(M)
+    if determinant != 0:
+        c_post = (
+            c
+            * math.sqrt((-1) ** n / determinant)
+            * math.exp(-0.5 * math.sum(bM * math.solve(M, bM)))
+        )
+    else:
+        c_post = c * np.inf
 
     if math.asnumpy(not_idx).shape != (0,):
         D = math.gather(math.gather(A, idx, axis=-1), not_idx, axis=-2)

--- a/mrmustard/physics/gaussian_integrals.py
+++ b/mrmustard/physics/gaussian_integrals.py
@@ -140,7 +140,7 @@ def complex_gaussian_integral(
             * math.exp(-0.5 * math.sum(bM * math.solve(M, bM)))
         )
     else:
-        c_post = c * np.inf
+        c_post = math.real(c) * np.inf
 
     if math.asnumpy(not_idx).shape != (0,):
         D = math.gather(math.gather(A, idx, axis=-1), not_idx, axis=-2)

--- a/tests/test_lab_dev/test_states/test_quadrature_eigenstate.py
+++ b/tests/test_lab_dev/test_states/test_quadrature_eigenstate.py
@@ -37,6 +37,10 @@ class TestQuadratureEigenstate:
         state = QuadratureEigenstate([0], x=1, phi=0)
         assert state.auto_shape() == state.manual_shape
 
+    def test_dual(self):
+        state = QuadratureEigenstate([0], x=0, phi=0)
+        assert state >> state.dual == np.inf
+
     @pytest.mark.parametrize("modes,x,phi", zip(modes, x, phi))
     def test_init(self, modes, x, phi):
         state = QuadratureEigenstate(modes, x, phi)

--- a/tests/test_lab_dev/test_states/test_quadrature_eigenstate.py
+++ b/tests/test_lab_dev/test_states/test_quadrature_eigenstate.py
@@ -33,12 +33,17 @@ class TestQuadratureEigenstate:
     phi = [3, [4], 1]
     hbar = [3.0, 4.0]
 
+    def test_auto_shape(self):
+        state = QuadratureEigenstate([0], x=1, phi=0)
+        assert state.auto_shape() == state.manual_shape
+
     @pytest.mark.parametrize("modes,x,phi", zip(modes, x, phi))
-    def test_init1(self, modes, x, phi):
+    def test_init(self, modes, x, phi):
         state = QuadratureEigenstate(modes, x, phi)
 
         assert state.name == "QuadratureEigenstate"
         assert state.modes == [modes] if not isinstance(modes, list) else sorted(modes)
+        assert state.L2_norm == np.inf
         assert np.allclose(state.x.value, x)
         assert np.allclose(state.phi.value, phi)
 
@@ -48,29 +53,6 @@ class TestQuadratureEigenstate:
 
         with pytest.raises(ValueError, match="phi"):
             QuadratureEigenstate(modes=[0, 1], x=1, phi=[2, 3, 4])
-
-    def test_trainable_parameters(self):
-        state1 = QuadratureEigenstate([0, 1], 1, 1)
-        state2 = QuadratureEigenstate([0, 1], 1, 1, x_trainable=True, x_bounds=(0, 2))
-        state3 = QuadratureEigenstate([0, 1], 1, 1, phi_trainable=True, phi_bounds=(-2, 2))
-
-        with pytest.raises(AttributeError):
-            state1.x.value = 3
-
-        state2.x.value = 2
-        assert state2.x.value == 2
-
-        state3.phi.value = 2
-        assert state3.phi.value == 2
-
-    def test_representation_error(self):
-        with pytest.raises(ValueError):
-            QuadratureEigenstate(modes=[0], x=[0.1, 0.2]).representation
-
-    def test_with_coherent(self):
-        val0 = Coherent([0], 0, 0) >> QuadratureEigenstate([0], 0, 0).dual
-        val1 = Coherent([0], 1, 0) >> QuadratureEigenstate([0], 2, 0).dual
-        assert np.allclose(val0, val1)
 
     @pytest.mark.parametrize("hbar", hbar)
     def test_probability_hbar(self, hbar):
@@ -89,4 +71,26 @@ class TestQuadratureEigenstate:
 
         settings._hbar_locked = False
         settings.HBAR = 2.0
-        settings._hbar_locked = True
+
+    def test_representation_error(self):
+        with pytest.raises(ValueError):
+            QuadratureEigenstate(modes=[0], x=[0.1, 0.2]).representation
+
+    def test_trainable_parameters(self):
+        state1 = QuadratureEigenstate([0, 1], 1, 1)
+        state2 = QuadratureEigenstate([0, 1], 1, 1, x_trainable=True, x_bounds=(0, 2))
+        state3 = QuadratureEigenstate([0, 1], 1, 1, phi_trainable=True, phi_bounds=(-2, 2))
+
+        with pytest.raises(AttributeError):
+            state1.x.value = 3
+
+        state2.x.value = 2
+        assert state2.x.value == 2
+
+        state3.phi.value = 2
+        assert state3.phi.value == 2
+
+    def test_with_coherent(self):
+        val0 = Coherent([0], 0, 0) >> QuadratureEigenstate([0], 0, 0).dual
+        val1 = Coherent([0], 1, 0) >> QuadratureEigenstate([0], 2, 0).dual
+        assert np.allclose(val0, val1)


### PR DESCRIPTION
**Context:** QuadratureEigenstate `__repr__` currently fails due to an L2 norm calculation. Solution is to override the L2_norm. Additionally, set manual shape on QuadratureEigenstate for visualization purposes. 

**Description of the Change:** L2_norm on QuadratureEigenstate returns np.inf, manual_shape is set to (50,), some additional cleanup. 
