### PR TITLE
Move reduce to ArrayAnsatz and include calls in dunder methods

### DIFF
--- a/mrmustard/physics/ansatze.py
+++ b/mrmustard/physics/ansatze.py
@@ -1247,7 +1247,15 @@ class ArrayAnsatz(Ansatz):
         """
         if isinstance(other, ArrayAnsatz):
             try:
-                new_array = [a / b for a in self.array for b in other.array]
+                diff = sum(self.array.shape[1:]) - sum(other.array.shape[1:])
+                if diff < 0:
+                    new_array = [
+                        a / b for a in self.reduce(other.array.shape[1:]).array for b in other.array
+                    ]
+                else:
+                    new_array = [
+                        a / b for a in self.array for b in other.reduce(self.array.shape[1:]).array
+                    ]
                 return self.__class__(array=new_array)
             except Exception as e:
                 raise TypeError(f"Cannot divide {self.__class__} and {other.__class__}.") from e

--- a/mrmustard/physics/ansatze.py
+++ b/mrmustard/physics/ansatze.py
@@ -20,7 +20,8 @@ from __future__ import annotations
 
 import itertools
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Union, Optional
+from typing import Any, Callable, Union, Optional, Sequence
+from warnings import warn
 
 import numpy as np
 
@@ -1053,13 +1054,6 @@ class ArrayAnsatz(Ansatz):
         self._backend_array = False
 
     @property
-    def batch_size(self):
-        r"""
-        The batch size of this ansatz.
-        """
-        return self.array.shape[0]
-
-    @property
     def array(self) -> Batch[Tensor]:
         r"""
         The array of this ansatz.
@@ -1074,6 +1068,20 @@ class ArrayAnsatz(Ansatz):
     def array(self, value):
         self._array = value
         self._backend_array = False
+
+    @property
+    def batch_size(self):
+        r"""
+        The batch size of this ansatz.
+        """
+        return self.array.shape[0]
+
+    @property
+    def conj(self):
+        r"""
+        The conjugate of this ansatz.
+        """
+        return self.__class__(math.conj(self.array))
 
     @property
     def num_vars(self) -> int:
@@ -1092,6 +1100,33 @@ class ArrayAnsatz(Ansatz):
         ret._kwargs = kwargs
         return ret
 
+    def reduce(self, shape: int | Sequence[int]) -> ArrayAnsatz:
+        r"""
+        Returns a new ``ArrayAnsatz`` with a sliced array.
+
+        Args:
+            shape: The shape of the array of the returned ``ArrayAnsatz``.
+        """
+        length = len(self.array.shape) - 1
+        shape = (shape,) * length if isinstance(shape, int) else shape
+        if len(shape) != length:
+            msg = f"Expected shape of length {length}, "
+            msg += f"given shape has length {len(shape)}."
+            raise ValueError(msg)
+
+        if any(s > t for s, t in zip(shape, self.array.shape[1:])):
+            warn(
+                "Warning: the fock array is being padded with zeros. If possible slice the arrays this one will contract with instead."
+            )
+            padded = math.pad(
+                self.array,
+                [(0, 0)] + [(0, s - t) for s, t in zip(shape, self.array.shape[1:])],
+            )
+            return ArrayAnsatz(padded)
+
+        ret = self.array[(slice(0, None),) + tuple(slice(0, s) for s in shape)]
+        return ArrayAnsatz(array=ret, batched=True)
+
     def _generate_ansatz(self):
         r"""
         This method computes and sets the array given a function
@@ -1099,24 +1134,6 @@ class ArrayAnsatz(Ansatz):
         """
         if self._array is None:
             self.array = [self._fn(**self._kwargs)]
-
-    def __neg__(self) -> ArrayAnsatz:
-        r"""
-        Negates the values in the array.
-        """
-        return self.__class__(array=-self.array)
-
-    def __eq__(self, other: Ansatz) -> bool:
-        r"""
-        Whether this ansatz's array is equal to another ansatz's array.
-
-        Note that the comparison is done by numpy allclose with numpy's default rtol and atol.
-
-        """
-        slices = (slice(0, None),) + tuple(
-            slice(0, min(si, oi)) for si, oi in zip(self.array.shape[1:], other.array.shape[1:])
-        )
-        return np.allclose(self.array[slices], other.array[slices], atol=1e-10)
 
     def __add__(self, other: ArrayAnsatz) -> ArrayAnsatz:
         r"""
@@ -1137,33 +1154,37 @@ class ArrayAnsatz(Ansatz):
         except Exception as e:
             raise TypeError(f"Cannot add {self.__class__} and {other.__class__}.") from e
 
+    def __and__(self, other: ArrayAnsatz) -> ArrayAnsatz:
+        r"""
+        Tensor product of this ansatz with another ansatz.
+
+        Args:
+            other: Another ansatz.
+
+        Returns:
+            The tensor product of this ansatz and other.
+            Batch size is the product of two batches.
+        """
+        new_array = [math.outer(a, b) for a in self.array for b in other.array]
+        return self.__class__(array=new_array)
+
     def __call__(self, point: Any) -> Scalar:
         r"""
         Evaluates this ansatz at a given point in the domain.
         """
         raise AttributeError("Cannot plot ArrayAnsatz.")
 
-    def __truediv__(self, other: Union[Scalar, ArrayAnsatz]) -> ArrayAnsatz:
+    def __eq__(self, other: Ansatz) -> bool:
         r"""
-        Divides this ansatz by another ansatz.
+        Whether this ansatz's array is equal to another ansatz's array.
 
-        Args:
-            other: A scalar or another ansatz.
+        Note that the comparison is done by numpy allclose with numpy's default rtol and atol.
 
-        Raises:
-            ValueError: If the arrays don't have the same shape.
-
-        Returns:
-            ArrayAnsatz: The division of this ansatz and other.
         """
-        if isinstance(other, ArrayAnsatz):
-            try:
-                new_array = [a / b for a in self.array for b in other.array]
-                return self.__class__(array=new_array)
-            except Exception as e:
-                raise TypeError(f"Cannot divide {self.__class__} and {other.__class__}.") from e
-        else:
-            return self.__class__(array=self.array / other)
+        slices = (slice(0, None),) + tuple(
+            slice(0, min(si, oi)) for si, oi in zip(self.array.shape[1:], other.array.shape[1:])
+        )
+        return np.allclose(self.array[slices], other.array[slices], atol=1e-10)
 
     def __mul__(self, other: Union[Scalar, ArrayAnsatz]) -> ArrayAnsatz:
         r"""
@@ -1187,26 +1208,33 @@ class ArrayAnsatz(Ansatz):
         else:
             return self.__class__(array=self.array * other)
 
-    def __and__(self, other: ArrayAnsatz) -> ArrayAnsatz:
+    def __neg__(self) -> ArrayAnsatz:
         r"""
-        Tensor product of this ansatz with another ansatz.
+        Negates the values in the array.
+        """
+        return self.__class__(array=-self.array)
+
+    def __truediv__(self, other: Union[Scalar, ArrayAnsatz]) -> ArrayAnsatz:
+        r"""
+        Divides this ansatz by another ansatz.
 
         Args:
-            other: Another ansatz.
+            other: A scalar or another ansatz.
+
+        Raises:
+            ValueError: If the arrays don't have the same shape.
 
         Returns:
-            The tensor product of this ansatz and other.
-            Batch size is the product of two batches.
+            ArrayAnsatz: The division of this ansatz and other.
         """
-        new_array = [math.outer(a, b) for a in self.array for b in other.array]
-        return self.__class__(array=new_array)
-
-    @property
-    def conj(self):
-        r"""
-        The conjugate of this ansatz.
-        """
-        return self.__class__(math.conj(self.array))
+        if isinstance(other, ArrayAnsatz):
+            try:
+                new_array = [a / b for a in self.array for b in other.array]
+                return self.__class__(array=new_array)
+            except Exception as e:
+                raise TypeError(f"Cannot divide {self.__class__} and {other.__class__}.") from e
+        else:
+            return self.__class__(array=self.array / other)
 
 
 def bargmann_Abc_to_phasespace_cov_means(

--- a/mrmustard/physics/ansatze.py
+++ b/mrmustard/physics/ansatze.py
@@ -1107,7 +1107,9 @@ class ArrayAnsatz(Ansatz):
         Args:
             shape: The shape of the array of the returned ``ArrayAnsatz``.
         """
-        length = len(self.array.shape) - 1
+        if shape == self.array.shape[1:]:
+            return self
+        length = self.num_vars
         shape = (shape,) * length if isinstance(shape, int) else shape
         if len(shape) != length:
             msg = f"Expected shape of length {length}, "
@@ -1149,7 +1151,15 @@ class ArrayAnsatz(Ansatz):
             ArrayAnsatz: The addition of this ansatz and other.
         """
         try:
-            new_array = [a + b for a in self.array for b in other.array]
+            diff = sum(self.array.shape[1:]) - sum(other.array.shape[1:])
+            if diff < 0:
+                new_array = [
+                    a + b for a in self.reduce(other.array.shape[1:]).array for b in other.array
+                ]
+            else:
+                new_array = [
+                    a + b for a in self.array for b in other.reduce(self.array.shape[1:]).array
+                ]
             return self.__class__(array=new_array)
         except Exception as e:
             raise TypeError(f"Cannot add {self.__class__} and {other.__class__}.") from e
@@ -1201,7 +1211,15 @@ class ArrayAnsatz(Ansatz):
         """
         if isinstance(other, ArrayAnsatz):
             try:
-                new_array = [a * b for a in self.array for b in other.array]
+                diff = sum(self.array.shape[1:]) - sum(other.array.shape[1:])
+                if diff < 0:
+                    new_array = [
+                        a * b for a in self.reduce(other.array.shape[1:]).array for b in other.array
+                    ]
+                else:
+                    new_array = [
+                        a * b for a in self.array for b in other.reduce(self.array.shape[1:]).array
+                    ]
                 return self.__class__(array=new_array)
             except Exception as e:
                 raise TypeError(f"Cannot multiply {self.__class__} and {other.__class__}.") from e

--- a/mrmustard/physics/representations.py
+++ b/mrmustard/physics/representations.py
@@ -18,7 +18,6 @@ This module contains the classes for the available representations.
 """
 
 from __future__ import annotations
-from warnings import warn
 from abc import ABC, abstractmethod
 from typing import Any, Callable, Iterable, Union
 from matplotlib import colors
@@ -63,10 +62,20 @@ class Representation(ABC):
         The ansatz of the representation.
         """
 
+    @property
     @abstractmethod
-    def reorder(self, order: tuple[int, ...] | list[int]) -> Representation:
+    def data(self) -> tuple | Tensor:
         r"""
-        Reorders the representation indices.
+        The data of the representation.
+        For now, it's the triple for Bargmann and the array for Fock.
+        """
+
+    @property
+    @abstractmethod
+    def scalar(self) -> Scalar:
+        r"""
+        The scalar part of the representation.
+        For now it's ``c`` for Bargmann and the array for Fock.
         """
 
     @classmethod
@@ -82,20 +91,10 @@ class Representation(ABC):
         Returns a representation from a function and kwargs.
         """
 
-    @property
     @abstractmethod
-    def data(self) -> tuple | Tensor:
+    def reorder(self, order: tuple[int, ...] | list[int]) -> Representation:
         r"""
-        The data of the representation.
-        For now, it's the triple for Bargmann and the array for Fock.
-        """
-
-    @property
-    @abstractmethod
-    def scalar(self) -> Scalar:
-        r"""
-        The scalar part of the representation.
-        For now it's ``c`` for Bargmann and the array for Fock.
+        Reorders the representation indices.
         """
 
     def __eq__(self, other: Representation) -> bool:
@@ -266,13 +265,6 @@ class Bargmann(Representation):
         """
         return self._ansatz
 
-    @classmethod
-    def from_ansatz(cls, ansatz: PolyExpAnsatz) -> Bargmann:  # pylint: disable=arguments-differ
-        r"""
-        Returns a Bargmann object from an ansatz object.
-        """
-        return cls(ansatz.A, ansatz.b, ansatz.c)
-
     @property
     def A(self) -> Batch[ComplexMatrix]:
         r"""
@@ -295,15 +287,6 @@ class Bargmann(Representation):
         return self.ansatz.c
 
     @property
-    def triple(
-        self,
-    ) -> tuple[Batch[ComplexMatrix], Batch[ComplexVector], Batch[ComplexTensor]]:
-        r"""
-        The batch of triples :math:`(A_i, b_i, c_i)`.
-        """
-        return self.A, self.b, self.c
-
-    @property
     def data(
         self,
     ) -> tuple[Batch[ComplexMatrix], Batch[ComplexVector], Batch[ComplexTensor]]:
@@ -319,6 +302,22 @@ class Bargmann(Representation):
         """
         return self.c
 
+    @property
+    def triple(
+        self,
+    ) -> tuple[Batch[ComplexMatrix], Batch[ComplexVector], Batch[ComplexTensor]]:
+        r"""
+        The batch of triples :math:`(A_i, b_i, c_i)`.
+        """
+        return self.A, self.b, self.c
+
+    @classmethod
+    def from_ansatz(cls, ansatz: PolyExpAnsatz) -> Bargmann:  # pylint: disable=arguments-differ
+        r"""
+        Returns a Bargmann object from an ansatz object.
+        """
+        return cls(ansatz.A, ansatz.b, ansatz.c)
+
     @classmethod
     def from_function(cls, fn: Callable, **kwargs: Any) -> Bargmann:
         r"""
@@ -333,53 +332,6 @@ class Bargmann(Representation):
         new = self.__class__(math.conj(self.A), math.conj(self.b), math.conj(self.c))
         new._contract_idxs = self._contract_idxs  # pylint: disable=protected-access
         return new
-
-    def trace(self, idx_z: tuple[int, ...], idx_zconj: tuple[int, ...]) -> Bargmann:
-        r"""
-        The partial trace over the given index pairs.
-
-        Args:
-            idx_z: The first part of the pairs of indices to trace over.
-            idx_zconj: The second part.
-
-        Returns:
-            Bargmann: the ansatz with the given indices traced over
-        """
-        if self.ansatz.degree > 0:
-            raise NotImplementedError(
-                "Partial trace is only supported for ansatze with polynomial of degree ``0``."
-            )
-        A, b, c = [], [], []
-        for Abc in zip(self.A, self.b, self.c):
-            Aij, bij, cij = complex_gaussian_integral(Abc, idx_z, idx_zconj, measure=-1.0)
-            A.append(Aij)
-            b.append(bij)
-            c.append(cij)
-        return Bargmann(A, b, c)
-
-    def reorder(self, order: tuple[int, ...] | list[int]) -> Bargmann:
-        r"""
-        Reorders the indices of the ``A`` matrix and ``b`` vector of the ``(A, b, c)`` triple in
-        this Bargmann object.
-
-        .. code-block::
-
-            >>> from mrmustard.physics.representations import Bargmann
-            >>> from mrmustard.physics.triples import displacement_gate_Abc
-
-            >>> rep_dgate1 = Bargmann(*displacement_gate_Abc([0.1, 0.2, 0.3]))
-            >>> rep_dgate2 = Bargmann(*displacement_gate_Abc([0.2, 0.3, 0.1]))
-
-            >>> assert rep_dgate1.reorder([1, 2, 0, 4, 5, 3]) == rep_dgate2
-
-        Args:
-            order: The new order.
-
-        Returns:
-            The reordered Bargmann object.
-        """
-        A, b, c = reorder_abc((self.A, self.b, self.c), order)
-        return self.__class__(A, b, c)
 
     def plot(
         self,
@@ -439,6 +391,53 @@ class Bargmann(Representation):
         ax.set_title(f"${title}$")
         plt.show(block=False)
         return fig, ax
+
+    def reorder(self, order: tuple[int, ...] | list[int]) -> Bargmann:
+        r"""
+        Reorders the indices of the ``A`` matrix and ``b`` vector of the ``(A, b, c)`` triple in
+        this Bargmann object.
+
+        .. code-block::
+
+            >>> from mrmustard.physics.representations import Bargmann
+            >>> from mrmustard.physics.triples import displacement_gate_Abc
+
+            >>> rep_dgate1 = Bargmann(*displacement_gate_Abc([0.1, 0.2, 0.3]))
+            >>> rep_dgate2 = Bargmann(*displacement_gate_Abc([0.2, 0.3, 0.1]))
+
+            >>> assert rep_dgate1.reorder([1, 2, 0, 4, 5, 3]) == rep_dgate2
+
+        Args:
+            order: The new order.
+
+        Returns:
+            The reordered Bargmann object.
+        """
+        A, b, c = reorder_abc((self.A, self.b, self.c), order)
+        return self.__class__(A, b, c)
+
+    def trace(self, idx_z: tuple[int, ...], idx_zconj: tuple[int, ...]) -> Bargmann:
+        r"""
+        The partial trace over the given index pairs.
+
+        Args:
+            idx_z: The first part of the pairs of indices to trace over.
+            idx_zconj: The second part.
+
+        Returns:
+            Bargmann: the ansatz with the given indices traced over
+        """
+        if self.ansatz.degree > 0:
+            raise NotImplementedError(
+                "Partial trace is only supported for ansatze with polynomial of degree ``0``."
+            )
+        A, b, c = [], [], []
+        for Abc in zip(self.A, self.b, self.c):
+            Aij, bij, cij = complex_gaussian_integral(Abc, idx_z, idx_zconj, measure=-1.0)
+            A.append(Aij)
+            b.append(bij)
+            c.append(cij)
+        return Bargmann(A, b, c)
 
     def __call__(self, z: ComplexTensor) -> ComplexTensor:
         r"""
@@ -578,13 +577,6 @@ class Fock(Representation):
         """
         return self._ansatz
 
-    @classmethod
-    def from_ansatz(cls, ansatz: ArrayAnsatz) -> Fock:  # pylint: disable=arguments-differ
-        r"""
-        Returns a Fock object from an ansatz object.
-        """
-        return cls(ansatz.array, batched=True)
-
     @property
     def array(self) -> Batch[Tensor]:
         r"""
@@ -600,6 +592,15 @@ class Fock(Representation):
         return self.array
 
     @property
+    def scalar(self) -> Scalar:
+        r"""
+        The scalar part of the representation.
+        I.e. the vacuum component of the Fock object, whatever it may be.
+        Given that the first axis of the array is the batch axis, this is the first element of the array.
+        """
+        return self.array[(slice(None),) + (0,) * self.ansatz.num_vars]
+
+    @property
     def triple(self) -> tuple:
         r"""
         The data of the original Bargmann representation if it exists
@@ -610,14 +611,12 @@ class Fock(Representation):
             )
         return self._original_bargmann_data
 
-    @property
-    def scalar(self) -> Scalar:
+    @classmethod
+    def from_ansatz(cls, ansatz: ArrayAnsatz) -> Fock:  # pylint: disable=arguments-differ
         r"""
-        The scalar part of the representation.
-        I.e. the vacuum component of the Fock object, whatever it may be.
-        Given that the first axis of the array is the batch axis, this is the first element of the array.
+        Returns a Fock object from an ansatz object.
         """
-        return self.array[(slice(None),) + (0,) * self.ansatz.num_vars]
+        return cls(ansatz.array, batched=True)
 
     @classmethod
     def from_function(cls, fn: Callable, **kwargs: Any) -> Fock:
@@ -633,6 +632,82 @@ class Fock(Representation):
         new = self.from_ansatz(self.ansatz.conj)
         new._contract_idxs = self._contract_idxs  # pylint: disable=protected-access
         return new
+
+    def reduce(self, shape: Union[int, Iterable[int]]) -> Fock:
+        r"""
+        Returns a new ``Fock`` with a sliced array.
+
+        .. code-block::
+
+            >>> from mrmustard import math
+            >>> from mrmustard.physics.representations import Fock
+
+            >>> array1 = math.arange(27).reshape((3, 3, 3))
+            >>> fock1 = Fock(array1)
+
+            >>> fock2 = fock1.reduce(3)
+            >>> assert fock1 == fock2
+
+            >>> fock3 = fock1.reduce(2)
+            >>> array3 = [[[0, 1], [3, 4]], [[9, 10], [12, 13]]]
+            >>> assert fock3 == Fock(array3)
+
+            >>> fock4 = fock1.reduce((1, 3, 1))
+            >>> array4 = [[[0], [3], [6]]]
+            >>> assert fock4 == Fock(array4)
+
+        Args:
+            shape: The shape of the array of the returned ``Fock``.
+        """
+        return self.from_ansatz(self.ansatz.reduce(shape))
+
+    def reorder(self, order: tuple[int, ...] | list[int]) -> Fock:
+        r"""
+        Reorders the indices of the array with the given order.
+
+        Args:
+            order: The order. Does not need to refer to the batch dimension.
+
+        Returns:
+            The reordered Fock.
+        """
+        return self.from_ansatz(
+            ArrayAnsatz(math.transpose(self.array, [0] + [i + 1 for i in order]))
+        )
+
+    def sum_batch(self) -> Fock:
+        r"""
+        Sums over the batch dimension of the array. Turns an object with any batch size to a batch size of 1.
+
+        Returns:
+            The collapsed Fock object.
+        """
+        return self.from_ansatz(ArrayAnsatz(math.expand_dims(math.sum(self.array, axes=[0]), 0)))
+
+    def trace(self, idxs1: tuple[int, ...], idxs2: tuple[int, ...]) -> Fock:
+        r"""
+        Implements the partial trace over the given index pairs.
+
+        Args:
+            idxs1: The first part of the pairs of indices to trace over.
+            idxs2: The second part.
+
+        Returns:
+            The traced-over Fock object.
+        """
+        if len(idxs1) != len(idxs2) or not set(idxs1).isdisjoint(idxs2):
+            raise ValueError("idxs must be of equal length and disjoint")
+        order = (
+            [0]
+            + [i + 1 for i in range(len(self.array.shape) - 1) if i not in idxs1 + idxs2]
+            + [i + 1 for i in idxs1]
+            + [i + 1 for i in idxs2]
+        )
+        new_array = math.transpose(self.array, order)
+        n = np.prod(new_array.shape[-len(idxs2) :])
+        new_array = math.reshape(new_array, new_array.shape[: -2 * len(idxs1)] + (n, n))
+        trace = math.trace(new_array)
+        return self.from_ansatz(ArrayAnsatz([trace] if trace.shape == () else trace))
 
     def __getitem__(self, idx: int | tuple[int, ...]) -> Fock:
         r"""
@@ -699,103 +774,9 @@ class Fock(Representation):
                 batched_array.append(math.tensordot(reduced_s.array[i], reduced_o.array[j], axes))
         return self.from_ansatz(ArrayAnsatz(batched_array))
 
-    def trace(self, idxs1: tuple[int, ...], idxs2: tuple[int, ...]) -> Fock:
-        r"""
-        Implements the partial trace over the given index pairs.
-
-        Args:
-            idxs1: The first part of the pairs of indices to trace over.
-            idxs2: The second part.
-
-        Returns:
-            The traced-over Fock object.
-        """
-        if len(idxs1) != len(idxs2) or not set(idxs1).isdisjoint(idxs2):
-            raise ValueError("idxs must be of equal length and disjoint")
-        order = (
-            [0]
-            + [i + 1 for i in range(len(self.array.shape) - 1) if i not in idxs1 + idxs2]
-            + [i + 1 for i in idxs1]
-            + [i + 1 for i in idxs2]
-        )
-        new_array = math.transpose(self.array, order)
-        n = np.prod(new_array.shape[-len(idxs2) :])
-        new_array = math.reshape(new_array, new_array.shape[: -2 * len(idxs1)] + (n, n))
-        trace = math.trace(new_array)
-        return self.from_ansatz(ArrayAnsatz([trace] if trace.shape == () else trace))
-
-    def reorder(self, order: tuple[int, ...] | list[int]) -> Fock:
-        r"""
-        Reorders the indices of the array with the given order.
-
-        Args:
-            order: The order. Does not need to refer to the batch dimension.
-
-        Returns:
-            The reordered Fock.
-        """
-        return self.from_ansatz(
-            ArrayAnsatz(math.transpose(self.array, [0] + [i + 1 for i in order]))
-        )
-
-    def reduce(self, shape: Union[int, Iterable[int]]) -> Fock:
-        r"""
-        Returns a new ``Fock`` with a sliced array.
-
-        .. code-block::
-
-            >>> from mrmustard import math
-            >>> from mrmustard.physics.representations import Fock
-
-            >>> array1 = math.arange(27).reshape((3, 3, 3))
-            >>> fock1 = Fock(array1)
-
-            >>> fock2 = fock1.reduce(3)
-            >>> assert fock1 == fock2
-
-            >>> fock3 = fock1.reduce(2)
-            >>> array3 = [[[0, 1], [3, 4]], [[9, 10], [12, 13]]]
-            >>> assert fock3 == Fock(array3)
-
-            >>> fock4 = fock1.reduce((1, 3, 1))
-            >>> array4 = [[[0], [3], [6]]]
-            >>> assert fock4 == Fock(array4)
-
-        Args:
-            shape: The shape of the array of the returned ``Fock``.
-        """
-        length = len(self.array.shape) - 1
-        shape = (shape,) * length if isinstance(shape, int) else shape
-        if len(shape) != length:
-            msg = f"Expected shape of length {length}, "
-            msg += f"given shape has length {len(shape)}."
-            raise ValueError(msg)
-
-        if any(s > t for s, t in zip(shape, self.array.shape[1:])):
-            warn(
-                "Warning: the fock array is being padded with zeros. If possible slice the arrays this one will contract with instead."
-            )
-            padded = math.pad(
-                self.array,
-                [(0, 0)] + [(0, s - t) for s, t in zip(shape, self.array.shape[1:])],
-            )
-            return self.from_ansatz(ArrayAnsatz(padded))
-
-        ret = self.array[(slice(0, None),) + tuple(slice(0, s) for s in shape)]
-        return Fock(array=ret, batched=True)
-
     def _ipython_display_(self):
         w = widgets.fock(self)
         if w is None:
             print(repr(self))
             return
         display(w)
-
-    def sum_batch(self) -> Fock:
-        r"""
-        Sums over the batch dimension of the array. Turns an object with any batch size to a batch size of 1.
-
-        Returns:
-            The collapsed Fock object.
-        """
-        return self.from_ansatz(ArrayAnsatz(math.expand_dims(math.sum(self.array, axes=[0]), 0)))

--- a/tests/test_physics/test_ansatz.py
+++ b/tests/test_physics/test_ansatz.py
@@ -321,6 +321,24 @@ class TestArrayAnsatz:
         assert np.allclose(aa1_div_aa2.array[2], np.array([[5.0, 3.0], [2.33333333, 2.0]]))
         assert np.allclose(aa1_div_aa2.array[3], np.array([[1.0, 1.0], [1.0, 1.0]]))
 
+        array3 = np.arange(3)[1:].reshape(2, 1, 1)
+        aa3 = ArrayAnsatz(array=array3)
+        aa3_div_aa2 = aa3 / aa2
+        assert isinstance(aa3_div_aa2, ArrayAnsatz)
+        assert aa3_div_aa2.array.shape == (4, 2, 2)
+        assert np.allclose(aa3_div_aa2.array[0], np.array([[1, 0], [0, 0]]))
+        assert np.allclose(aa3_div_aa2.array[1], np.array([[0.2, 0], [0, 0]]))
+        assert np.allclose(aa3_div_aa2.array[2], np.array([[2, 0], [0, 0]]))
+        assert np.allclose(aa3_div_aa2.array[3], np.array([[0.4, 0], [0, 0]]))
+
+        array4 = np.array([2]).reshape(1, 1, 1)
+        aa4 = ArrayAnsatz(array=array4)
+        aa4_div_aa2 = aa4 / aa2
+
+        assert isinstance(aa4_div_aa2, ArrayAnsatz)
+        assert np.allclose(aa4_div_aa2.array[0], np.array([[2, 0], [0, 0]]))
+        assert np.allclose(aa4_div_aa2.array[1], np.array([[0.4, 0], [0, 0]]))
+
     def test_algebra_with_different_shape_of_array_raise_errors(self):
         array = np.random.random((2, 4, 5))
         array2 = np.random.random((3, 4, 8, 9))

--- a/tests/test_physics/test_ansatz.py
+++ b/tests/test_physics/test_ansatz.py
@@ -200,6 +200,24 @@ class TestArrayAnsatz:
         assert np.allclose(aa1_add_aa2.array[2], np.array([[4, 6], [8, 10]]))
         assert np.allclose(aa1_add_aa2.array[3], np.array([[8, 10], [12, 14]]))
 
+        array3 = np.arange(2).reshape(2, 1, 1)
+        aa3 = ArrayAnsatz(array=array3)
+        aa2_add_aa3 = aa2 + aa3
+
+        assert isinstance(aa2_add_aa3, ArrayAnsatz)
+        assert np.allclose(aa2_add_aa3.array[0], np.array([[0, 1], [2, 3]]))
+        assert np.allclose(aa2_add_aa3.array[1], np.array([[1, 1], [2, 3]]))
+        assert np.allclose(aa2_add_aa3.array[2], np.array([[4, 5], [6, 7]]))
+        assert np.allclose(aa2_add_aa3.array[3], np.array([[5, 5], [6, 7]]))
+
+        array4 = np.array([1]).reshape(1, 1, 1)
+        aa4 = ArrayAnsatz(array=array4)
+        aa2_add_aa4 = aa2 + aa4
+
+        assert isinstance(aa2_add_aa4, ArrayAnsatz)
+        assert np.allclose(aa2_add_aa4.array[0], np.array([[1, 1], [2, 3]]))
+        assert np.allclose(aa2_add_aa4.array[1], np.array([[5, 5], [6, 7]]))
+
     def test_and(self):
         array = np.arange(8).reshape(2, 2, 2)
         array2 = np.arange(8).reshape(2, 2, 2)
@@ -264,6 +282,24 @@ class TestArrayAnsatz:
         assert np.allclose(aa1_mul_aa2.array[1], np.array([[0, 5], [12, 21]]))
         assert np.allclose(aa1_mul_aa2.array[2], np.array([[0, 5], [12, 21]]))
         assert np.allclose(aa1_mul_aa2.array[3], np.array([[16, 25], [36, 49]]))
+
+        array3 = np.arange(2).reshape(2, 1, 1)
+        aa3 = ArrayAnsatz(array=array3)
+        aa2_mul_aa3 = aa2 * aa3
+        assert isinstance(aa2_mul_aa3, ArrayAnsatz)
+        assert aa2_mul_aa3.array.shape == (4, 2, 2)
+        assert np.allclose(aa2_mul_aa3.array[0], np.array([[0, 0], [0, 0]]))
+        assert np.allclose(aa2_mul_aa3.array[1], np.array([[0, 0], [0, 0]]))
+        assert np.allclose(aa2_mul_aa3.array[2], np.array([[0, 0], [0, 0]]))
+        assert np.allclose(aa2_mul_aa3.array[3], np.array([[4, 0], [0, 0]]))
+
+        array4 = np.array([1]).reshape(1, 1, 1)
+        aa4 = ArrayAnsatz(array=array4)
+        aa2_mul_aa4 = aa2 * aa4
+
+        assert isinstance(aa2_mul_aa4, ArrayAnsatz)
+        assert np.allclose(aa2_mul_aa4.array[0], np.array([[0, 0], [0, 0]]))
+        assert np.allclose(aa2_mul_aa4.array[1], np.array([[4, 0], [0, 0]]))
 
     def test_truediv_a_scalar(self):
         array = np.random.random((2, 4, 5))


### PR DESCRIPTION
**Context:** Dunder methods on ArrayAnsatz such as `__add__` currently fail if the shapes of the arrays do not match (e.g. adding a `(1, 2, 2)` and a `(1, 3, 3)` array). This PR includes calls to reduce in these dunder methods exploiting the fact we can just pad the smaller array with zeros making them compatible.

**Description of the Change:** `reduce` has been moved to `ArrayAnsatz` and `__add__`, `__mul__` and `__truediv__` make use of calls to `reduce`. Additionally, some cleanup such as reordering methods alphabetically. 

**Benefits:** Interactions between ArrayAnsatz of different fock cutoffs are more flexible
