### PR TITLE
try to reduce complexity of circuits.py

### DIFF
--- a/mrmustard/lab_dev/circuit_components_utils/circuit_drawing.py
+++ b/mrmustard/lab_dev/circuit_components_utils/circuit_drawing.py
@@ -1,0 +1,61 @@
+# Copyright 2024 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Helpers for drawing components as part of a circuit.
+"""
+
+from mrmustard import math, settings
+from mrmustard.lab_dev.circuit_components import CircuitComponent
+
+# update this when new controlled gates are added
+control_gates = ["BSgate", "MZgate", "CZgate", "CXgate"]
+
+
+def component_to_str(comp: CircuitComponent) -> list[str]:
+    r"""
+    Generates a list string-based representation for the given component.
+
+    If ``comp`` is not a controlled gate, the list contains as many elements modes as in
+    ``comp.modes``. For example, if ``comp=Sgate([0, 1, 5], r=[0.1, 0.2, 0.5])``, it returns
+    ``['Sgate(0.1,0.0)', 'Sgate(0.2,0.0)', 'Sgate(0.5,0.0)']``.
+
+    If ``comp`` is a controlled gate, the list contains the string that needs to be added to
+    the target mode. For example, if``comp=BSgate([0, 1], 1, 2)``, it returns
+    ``['BSgate(0.0,0.0)']``.
+
+    Args:
+        comp: A circuit component.
+    """
+    cc_name = comp.short_name
+    parallel = isinstance(cc_name, list)
+    if not comp.wires.input:
+        cc_names = [f"◖{cc_name[i] if parallel else cc_name}◗" for i in range(len(comp.modes))]
+    elif not comp.wires.output:
+        cc_names = [f"|{cc_name[i] if parallel else cc_name})=" for i in range(len(comp.modes))]
+    elif cc_name not in control_gates:
+        cc_names = [f"{cc_name[i] if parallel else cc_name}" for i in range(len(comp.modes))]
+    else:
+        cc_names = [f"{cc_name}"]
+
+    if comp.parameter_set.names and settings.DRAW_CIRCUIT_PARAMS:
+        values = []
+        for name in comp.parameter_set.names:
+            param = comp.parameter_set.constants.get(name) or comp.parameter_set.variables.get(name)
+            new_values = math.atleast_1d(param.value)
+            if len(new_values) == 1 and cc_name not in control_gates:
+                new_values = math.tile(new_values, (len(comp.modes),))
+            values.append(math.asnumpy(new_values))
+        return [cc_names[i] + str(val).replace(" ", "") for i, val in enumerate(zip(*values))]
+    return cc_names

--- a/mrmustard/lab_dev/circuits_utils/__init__.py
+++ b/mrmustard/lab_dev/circuits_utils/__init__.py
@@ -13,11 +13,9 @@
 # limitations under the License.
 
 """
-A set of components that do not correspond to physical elements of a circuit, but can be used to
-perform useful mathematical calculations.
+Convenience and helper functions for working with circuits.
 """
 
-from .b_to_ps import *
-from .b_to_q import *
-from .trace_out import *
-from .circuit_drawing import *
+from .indices_dict import indices_dict
+from .graph import build_graph
+from .shapes import propagate_component_shapes

--- a/mrmustard/lab_dev/circuits_utils/graph.py
+++ b/mrmustard/lab_dev/circuits_utils/graph.py
@@ -1,0 +1,50 @@
+# Copyright 2024 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Create the circuit graph.
+"""
+
+from mrmustard.lab_dev.wires import Wires
+
+
+def build_graph(wires: Wires):
+    graph = {}
+    # a dictionary to store the ``ids`` of the dangling wires
+    ids_dangling_wires = {m: {"ket": None, "bra": None} for w in wires for m in w.modes}
+
+    # populate the graph
+    for w in wires:
+        # if there is a dangling wire, add a contraction
+        for m in w.input.ket.modes:  # ket side
+            if ids_dangling_wires[m]["ket"]:
+                graph[ids_dangling_wires[m]["ket"]] = w.input.ket[m].ids[0]
+                ids_dangling_wires[m]["ket"] = None
+        for m in w.input.bra.modes:  # bra side
+            if ids_dangling_wires[m]["bra"]:
+                graph[ids_dangling_wires[m]["bra"]] = w.input.bra[m].ids[0]
+                ids_dangling_wires[m]["bra"] = None
+
+        # update the dangling wires
+        for m in w.output.ket.modes:  # ket side
+            if w.output.ket[m].ids:
+                if ids_dangling_wires[m]["ket"]:
+                    raise ValueError("Dangling wires cannot be overwritten.")
+                ids_dangling_wires[m]["ket"] = w.output.ket[m].ids[0]
+        for m in w.output.bra.modes:  # bra side
+            if w.output.bra[m].ids:
+                if ids_dangling_wires[m]["bra"]:
+                    raise ValueError("Dangling wires cannot be overwritten.")
+                ids_dangling_wires[m]["bra"] = w.output.bra[m].ids[0]
+    return graph

--- a/mrmustard/lab_dev/circuits_utils/indices_dict.py
+++ b/mrmustard/lab_dev/circuits_utils/indices_dict.py
@@ -1,0 +1,39 @@
+# Copyright 2024 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Helper to compute the indices_dict for a circuit.
+"""
+
+
+def indices_dict(components):
+    res = {}
+    for i, opA in enumerate(components):
+        out_idx = set(opA.wires.output.indices)
+        indices: dict[int, dict[int, int]] = {}
+        for j, opB in enumerate(components[i + 1 :]):
+            ovlp_bra = opA.wires.output.bra.modes & opB.wires.input.bra.modes
+            ovlp_ket = opA.wires.output.ket.modes & opB.wires.input.ket.modes
+            if not (ovlp_bra or ovlp_ket):
+                continue
+            iA = opA.wires.output.bra[ovlp_bra].indices + opA.wires.output.ket[ovlp_ket].indices
+            iB = opB.wires.input.bra[ovlp_bra].indices + opB.wires.input.ket[ovlp_ket].indices
+            if not out_idx.intersection(iA):
+                continue
+            indices[i + j + 1] = dict(zip(iA, iB))
+            out_idx -= set(iA)
+            if not out_idx:
+                break
+        res[i] = indices
+    return res

--- a/mrmustard/lab_dev/circuits_utils/shapes.py
+++ b/mrmustard/lab_dev/circuits_utils/shapes.py
@@ -1,0 +1,81 @@
+# Copyright 2024 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Propagate shapes through a list of components.
+"""
+
+from mrmustard.lab_dev.transformations import BSgate
+
+
+def propagate_component_shapes(components, indices_dict):
+    r"""Propagates the shape information so that the shapes of the components are better
+    than those provided by the auto_shape attribute.
+
+    .. code-block:: python
+
+        >>> from mrmustard.lab_dev import BSgate, Dgate, Coherent, Circuit, SqueezedVacuum
+
+        >>> circ = Circuit([Coherent([0], x=1.0), Dgate([0], 0.1)])
+        >>> assert [op.auto_shape() for op in circ] == [(5,), (50,50)]
+        >>> circ.propagate_shapes()
+        >>> assert [op.auto_shape() for op in circ] == [(5,), (50, 5)]
+
+        >>> circ = Circuit([SqueezedVacuum([0,1], r=[0.5,-0.5]), BSgate([0,1], 0.9)])
+        >>> assert [op.auto_shape() for op in circ] == [(6, 6), (50, 50, 50, 50)]
+        >>> circ.propagate_shapes()
+        >>> assert [op.auto_shape() for op in circ] == [(6, 6), (12, 12, 6, 6)]
+    """
+
+    for component in components:
+        component.manual_shape = list(component.auto_shape())
+
+    # update the manual_shapes until convergence
+    changes = True
+    while changes:
+        changes = False
+        # get shapes from neighbors if needed
+        for i, component in enumerate(components):
+            for j, indices in indices_dict[i].items():
+                for a, b in indices.items():
+                    s_ia = components[i].manual_shape[a]
+                    s_jb = components[j].manual_shape[b]
+                    s = min(s_ia or 1e42, s_jb or 1e42) if (s_ia or s_jb) else None
+                    if components[j].manual_shape[b] != s:
+                        components[j].manual_shape[b] = s
+                        changes = True
+                    if components[i].manual_shape[a] != s:
+                        components[i].manual_shape[a] = s
+                        changes = True
+
+        # propagate through BSgates
+        for i, component in enumerate(components):
+            if isinstance(component, BSgate):
+                a, b, c, d = component.manual_shape
+                if c and d:
+                    if not a or a > c + d:
+                        a = c + d
+                        changes = True
+                    if not b or b > c + d:
+                        b = c + d
+                        changes = True
+                if a and b:
+                    if not c or c > a + b:
+                        c = a + b
+                        changes = True
+                    if not d or d > a + b:
+                        d = a + b
+                        changes = True
+
+                components[i].manual_shape = [a, b, c, d]

--- a/tests/test_lab_dev/test_circuits.py
+++ b/tests/test_lab_dev/test_circuits.py
@@ -19,7 +19,7 @@
 import pytest
 
 from mrmustard.lab_dev.circuit_components import CircuitComponent
-from mrmustard.lab_dev.circuits import Circuit
+from mrmustard.lab_dev.circuits import Circuit, lookup_path
 from mrmustard.lab_dev.states import Vacuum, Number, Coherent, SqueezedVacuum
 from mrmustard.lab_dev.transformations import (
     BSgate,
@@ -85,7 +85,7 @@ class TestCircuit:
         bs12 = BSgate([1, 2])
 
         circ = Circuit([vac, s01, bs01, bs12])
-        circ.lookup_path()
+        lookup_path(circ)
         out1, _ = capfd.readouterr()
         exp1 = "\n"
         exp1 += "→ index: 0\n"
@@ -104,7 +104,7 @@ class TestCircuit:
         assert out1 == exp1
 
         circ.path += [(0, 1)]
-        circ.lookup_path()
+        lookup_path(circ)
         out2, _ = capfd.readouterr()
         exp2 = "\n"
         exp2 += "→ index: 0\n"


### PR DESCRIPTION
Codefactor always complains of complex code due to circuits.py - I've made 3 changes:
- inline the `_ixdict` builder, it's only used in that once place
- inline the `propagate_shapes` helper, again, only used in that one place
- move `lookup_path` to a function that takes a Circuit, instead of it being an instance method