### PR TITLE
fix type hint for python 3.9

### DIFF
--- a/mrmustard/utils/settings.py
+++ b/mrmustard/utils/settings.py
@@ -14,9 +14,9 @@
 
 """A module containing global settings."""
 
-from pathlib import Path
-from typing import Union
+from __future__ import annotations
 
+from pathlib import Path
 from rich import print
 import rich.table
 import numpy as np
@@ -211,7 +211,7 @@ class Settings:
         return self._cache_dir
 
     @CACHE_DIR.setter
-    def CACHE_DIR(self, path: Union[str, Path]):
+    def CACHE_DIR(self, path: str | Path):
         self._cache_dir = Path(path)
         self._cache_dir.mkdir(exist_ok=True, parents=True)
 

--- a/mrmustard/utils/settings.py
+++ b/mrmustard/utils/settings.py
@@ -15,6 +15,8 @@
 """A module containing global settings."""
 
 from pathlib import Path
+from typing import Union
+
 from rich import print
 import rich.table
 import numpy as np
@@ -209,7 +211,7 @@ class Settings:
         return self._cache_dir
 
     @CACHE_DIR.setter
-    def CACHE_DIR(self, path: str | Path):
+    def CACHE_DIR(self, path: Union[str, Path]):
         self._cache_dir = Path(path)
         self._cache_dir.mkdir(exist_ok=True, parents=True)
 


### PR DESCRIPTION
you can't type-hint with `|` in python 3.9, so I'm righting my wrong