### PR TITLE
manual_shape on Number bug fix

### DIFF
--- a/mrmustard/lab_dev/states/number.py
+++ b/mrmustard/lab_dev/states/number.py
@@ -72,7 +72,7 @@ class Number(Ket):
         self._add_parameter(make_parameter(False, cs, "cutoffs", (None, None)))
         self.short_name = [str(int(n)) for n in self.n.value]
         for i, cutoff in enumerate(self.cutoffs.value):
-            self.manual_shape[i] = cutoff + 1
+            self.manual_shape[i] = int(cutoff) + 1
         self._representation = Fock.from_function(
             fock_state, n=self.n.value, cutoffs=self.cutoffs.value
         )

--- a/tests/test_lab_dev/test_states/test_number.py
+++ b/tests/test_lab_dev/test_states/test_number.py
@@ -38,6 +38,7 @@ class TestNumber:
 
         assert state.name == "N"
         assert state.modes == [modes] if not isinstance(modes, list) else sorted(modes)
+        assert all(isinstance(x, int) for x in state.manual_shape)
 
     def test_init_error(self):
         with pytest.raises(ValueError, match="n"):


### PR DESCRIPTION
**Context:** This PR fixes a bug where `manual_shape` on `Number` could be a tensorflow object rather than an `int` causing issues.

**Description of the Change:** `int(cutoff)` and a test 