### PR TITLE
join_Abc cast b to complex128

### DIFF
--- a/mrmustard/physics/gaussian_integrals.py
+++ b/mrmustard/physics/gaussian_integrals.py
@@ -116,6 +116,10 @@ def complex_gaussian_integral(
         ValueError: If ``idx_z`` and ``idx_zconj`` have different lengths.
     """
     A, b, c = Abc
+
+    print(A)
+    print(b)
+
     if len(idx_z) != len(idx_zconj):
         raise ValueError(
             f"idx_z and idx_zconj must have the same length, got {len(idx_z)} and {len(idx_zconj)}"
@@ -174,7 +178,7 @@ def join_Abc(
     c1 = math.astensor(c1)
     c2 = math.astensor(c2)
     A12 = math.block_diag(math.cast(A1, "complex128"), math.cast(A2, "complex128"))
-    b12 = math.concat([b1, b2], axis=-1)
+    b12 = math.concat([math.cast(b1, "complex128"), math.cast(b2, "complex128")], axis=-1)
     c12 = math.reshape(math.outer(c1, c2), c1.shape + c2.shape)
     return A12, b12, c12
 

--- a/tests/test_physics/test_gaussian_integrals.py
+++ b/tests/test_physics/test_gaussian_integrals.py
@@ -156,7 +156,9 @@ def test_complex_gaussian_integral():
     assert np.allclose(res2[1], b3)
     assert np.allclose(res2[2], c3)
 
-    res3 = complex_gaussian_integral(join_Abc((A1, b1, c1), (A1, b1, c1)), [0, 1], [2, 3])
+    res3 = complex_gaussian_integral(
+        join_Abc((A1, math.cast(b1, "float64"), c1), (A1, b1, c1)), [0, 1], [2, 3]
+    )
     assert np.allclose(res3[0], 0)
     assert np.allclose(res3[1], 0)
     assert np.allclose(res3[2], 1)


### PR DESCRIPTION
**Context:** `join_Abc` can return `tf.Tensors` of different dtypes which can cause issues later on. In this PR, `b` is cast to `complex128` like `A` so the return types match. One question that remains is should we also cast `c`? 

**Description of the Change:** `join_Abc` casts `b` now to `complex128`