### PR TITLE
Autoshape poly

### DIFF
--- a/mrmustard/lab_dev/circuit_components.py
+++ b/mrmustard/lab_dev/circuit_components.py
@@ -415,14 +415,14 @@ class CircuitComponent:
             shape = (shape,) * num_vars
         try:
             As, bs, cs = self.bargmann_triple(batched=True)
+            shape = shape or self.auto_shape()
+            if len(shape) != num_vars:
+                raise ValueError(
+                    f"Expected Fock shape of length {num_vars}, got length {len(shape)}"
+                )
             if self.representation.ansatz.polynomial_shape[0] == 0:
-                shape = shape or self.auto_shape()
-                if len(shape) != num_vars:
-                    raise ValueError(
-                        f"Expected Fock shape of length {num_vars}, got length {len(shape)}"
-                    )
                 arrays = [math.hermite_renormalized(A, b, c, shape) for A, b, c in zip(As, bs, cs)]
-            elif self.representation.ansatz.polynomial_shape[0] > 0:
+            else:
                 arrays = [
                     math.sum(
                         math.hermite_renormalized(A, b, 1, shape + c.shape) * c,

--- a/mrmustard/lab_dev/states/base.py
+++ b/mrmustard/lab_dev/states/base.py
@@ -908,16 +908,19 @@ class Ket(State):
             try:  # fock
                 shape = self._representation.array.shape[1:]
             except AttributeError:  # bargmann
-                repr = self.representation.conj() & self.representation
-                A, b, c = repr.A[0], repr.b[0], repr.c[0]
-                repr = repr / self.probability
-                shape = autoshape_numba(
-                    math.asnumpy(A),
-                    math.asnumpy(b),
-                    math.asnumpy(c),
-                    max_prob or settings.AUTOSHAPE_PROBABILITY,
-                    max_shape or settings.AUTOSHAPE_MAX,
-                )
+                if self.representation.ansatz.polynomial_shape[0]==0:
+                    repr = self.representation.conj() & self.representation
+                    A, b, c = repr.A[0], repr.b[0], repr.c[0]
+                    repr = repr / self.probability
+                    shape = autoshape_numba(
+                        math.asnumpy(A),
+                        math.asnumpy(b),
+                        math.asnumpy(c),
+                        max_prob or settings.AUTOSHAPE_PROBABILITY,
+                        max_shape or settings.AUTOSHAPE_MAX,
+                    )
+                else:
+                    shape = (settings.AUTOSHAPE_MAX,)
         else:
             warnings.warn("auto_shape only looks at the shape of the first element of the batch.")
             shape = [settings.AUTOSHAPE_MAX] * len(self.modes)

--- a/mrmustard/lab_dev/states/base.py
+++ b/mrmustard/lab_dev/states/base.py
@@ -370,7 +370,7 @@ class State(CircuitComponent):
         if self.n_modes > 1:
             raise ValueError("2D visualization not available for multi-mode states.")
         shape = [max(min_shape, d) for d in self.auto_shape()]
-        state = self.to_fock(shape)
+        state = self.to_fock(tuple(shape))
         state = state if isinstance(state, DM) else state.dm()
         dm = math.sum(state.representation.array, axes=[0])
 

--- a/mrmustard/lab_dev/states/base.py
+++ b/mrmustard/lab_dev/states/base.py
@@ -486,7 +486,7 @@ class State(CircuitComponent):
         if self.n_modes != 1:
             raise ValueError("3D visualization not available for multi-mode states.")
         shape = [max(min_shape, d) for d in self.auto_shape()]
-        state = self.to_fock(shape)
+        state = self.to_fock(tuple(shape))
         state = state if isinstance(state, DM) else state.dm()
         dm = math.sum(state.representation.array, axes=[0])
 

--- a/mrmustard/lab_dev/states/base.py
+++ b/mrmustard/lab_dev/states/base.py
@@ -648,7 +648,7 @@ class DM(State):
                     )
                     shape = tuple(shape) + tuple(shape)
                 else:
-                    shape = (settings.AUTOSHAPE_MAX,)
+                    shape = [settings.AUTOSHAPE_MAX] * 2 * len(self.modes)
         else:
             warnings.warn("auto_shape only looks at the shape of the first element of the batch.")
             shape = [settings.AUTOSHAPE_MAX] * 2 * len(self.modes)
@@ -923,7 +923,7 @@ class Ket(State):
                         max_shape or settings.AUTOSHAPE_MAX,
                     )
                 else:
-                    shape = (settings.AUTOSHAPE_MAX,)
+                    shape = [settings.AUTOSHAPE_MAX] * len(self.modes)
         else:
             warnings.warn("auto_shape only looks at the shape of the first element of the batch.")
             shape = [settings.AUTOSHAPE_MAX] * len(self.modes)

--- a/mrmustard/lab_dev/states/base.py
+++ b/mrmustard/lab_dev/states/base.py
@@ -635,7 +635,7 @@ class DM(State):
             try:  # fock
                 shape = self._representation.array.shape[1:]
             except AttributeError:  # bargmann
-                if self.representation.ansatz.polynomial_shape[0]==0:
+                if self.representation.ansatz.polynomial_shape[0] == 0:
                     repr = self.representation
                     A, b, c = repr.A[0], repr.b[0], repr.c[0]
                     repr = repr / self.probability
@@ -911,7 +911,7 @@ class Ket(State):
             try:  # fock
                 shape = self._representation.array.shape[1:]
             except AttributeError:  # bargmann
-                if self.representation.ansatz.polynomial_shape[0]==0:
+                if self.representation.ansatz.polynomial_shape[0] == 0:
                     repr = self.representation.conj() & self.representation
                     A, b, c = repr.A[0], repr.b[0], repr.c[0]
                     repr = repr / self.probability

--- a/mrmustard/lab_dev/states/base.py
+++ b/mrmustard/lab_dev/states/base.py
@@ -635,17 +635,20 @@ class DM(State):
             try:  # fock
                 shape = self._representation.array.shape[1:]
             except AttributeError:  # bargmann
-                repr = self.representation
-                A, b, c = repr.A[0], repr.b[0], repr.c[0]
-                repr = repr / self.probability
-                shape = autoshape_numba(
-                    math.asnumpy(A),
-                    math.asnumpy(b),
-                    math.asnumpy(c),
-                    max_prob or settings.AUTOSHAPE_PROBABILITY,
-                    max_shape or settings.AUTOSHAPE_MAX,
-                )
-                shape = tuple(shape) + tuple(shape)
+                if self.representation.ansatz.polynomial_shape[0]==0:
+                    repr = self.representation
+                    A, b, c = repr.A[0], repr.b[0], repr.c[0]
+                    repr = repr / self.probability
+                    shape = autoshape_numba(
+                        math.asnumpy(A),
+                        math.asnumpy(b),
+                        math.asnumpy(c),
+                        max_prob or settings.AUTOSHAPE_PROBABILITY,
+                        max_shape or settings.AUTOSHAPE_MAX,
+                    )
+                    shape = tuple(shape) + tuple(shape)
+                else:
+                    shape = (settings.AUTOSHAPE_MAX,)
         else:
             warnings.warn("auto_shape only looks at the shape of the first element of the batch.")
             shape = [settings.AUTOSHAPE_MAX] * 2 * len(self.modes)

--- a/tests/test_lab_dev/test_states/test_states_base.py
+++ b/tests/test_lab_dev/test_states/test_states_base.py
@@ -438,7 +438,7 @@ class TestDM:  # pylint:disable=too-many-public-methods
         assert dm.auto_shape() == (1, 15, 8, 15)
 
         dm = Coherent([0, 1], x=1).dm() >> Number([1], 10).dual
-        assert dm.auto_shape() == (settings.AUTOSHAPE_MAX, settings.AUTOSHAPE_MAX) 
+        assert dm.auto_shape() == (settings.AUTOSHAPE_MAX, settings.AUTOSHAPE_MAX)
 
     @pytest.mark.parametrize("modes", [[0], [0, 1], [3, 19, 2]])
     def test_to_from_bargmann(self, modes):

--- a/tests/test_lab_dev/test_states/test_states_base.py
+++ b/tests/test_lab_dev/test_states/test_states_base.py
@@ -74,6 +74,9 @@ class TestKet:  # pylint: disable=too-many-public-methods
         ket.manual_shape[0] = 19
         assert ket.auto_shape() == (19, 15)
 
+        ket = Coherent([0,1],x=1) >> Number([1],10).dual
+        assert ket.auto_shape() == (settings.AUTOSHAPE_MAX,)
+
     @pytest.mark.parametrize("modes", [[0], [0, 1], [3, 19, 2]])
     def test_to_from_bargmann(self, modes):
         x = 1

--- a/tests/test_lab_dev/test_states/test_states_base.py
+++ b/tests/test_lab_dev/test_states/test_states_base.py
@@ -437,6 +437,9 @@ class TestDM:  # pylint:disable=too-many-public-methods
         dm.manual_shape[0] = 1
         assert dm.auto_shape() == (1, 15, 8, 15)
 
+        dm = Coherent([0,1],x=1).dm() >> Number([1],10).dual
+        assert dm.auto_shape() == (settings.AUTOSHAPE_MAX,)
+
     @pytest.mark.parametrize("modes", [[0], [0, 1], [3, 19, 2]])
     def test_to_from_bargmann(self, modes):
         state_in = Coherent(modes, 1, 2) >> Attenuator([modes[0]], 0.7)

--- a/tests/test_lab_dev/test_states/test_states_base.py
+++ b/tests/test_lab_dev/test_states/test_states_base.py
@@ -438,7 +438,7 @@ class TestDM:  # pylint:disable=too-many-public-methods
         assert dm.auto_shape() == (1, 15, 8, 15)
 
         dm = Coherent([0, 1], x=1).dm() >> Number([1], 10).dual
-        assert dm.auto_shape() == (settings.AUTOSHAPE_MAX,)
+        assert dm.auto_shape() == (settings.AUTOSHAPE_MAX, settings.AUTOSHAPE_MAX) 
 
     @pytest.mark.parametrize("modes", [[0], [0, 1], [3, 19, 2]])
     def test_to_from_bargmann(self, modes):

--- a/tests/test_lab_dev/test_states/test_states_base.py
+++ b/tests/test_lab_dev/test_states/test_states_base.py
@@ -74,7 +74,7 @@ class TestKet:  # pylint: disable=too-many-public-methods
         ket.manual_shape[0] = 19
         assert ket.auto_shape() == (19, 15)
 
-        ket = Coherent([0,1],x=1) >> Number([1],10).dual
+        ket = Coherent([0, 1], x=1) >> Number([1], 10).dual
         assert ket.auto_shape() == (settings.AUTOSHAPE_MAX,)
 
     @pytest.mark.parametrize("modes", [[0], [0, 1], [3, 19, 2]])
@@ -437,7 +437,7 @@ class TestDM:  # pylint:disable=too-many-public-methods
         dm.manual_shape[0] = 1
         assert dm.auto_shape() == (1, 15, 8, 15)
 
-        dm = Coherent([0,1],x=1).dm() >> Number([1],10).dual
+        dm = Coherent([0, 1], x=1).dm() >> Number([1], 10).dual
         assert dm.auto_shape() == (settings.AUTOSHAPE_MAX,)
 
     @pytest.mark.parametrize("modes", [[0], [0, 1], [3, 19, 2]])


### PR DESCRIPTION
**Context:**
Update autoshape for `ket` and `dm` if they have a polynomial.
**Description of the Change:**
Adding a check to see if the bargmann representation has a polynomial and set the `autoshape_max` as shape if that is the case.