### PR TITLE
add juliapkg.json to package data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,9 @@ sphinxcontrib-bibtex = "^2.5.0"
 mistune = "0.8.4"
 xanadu-sphinx-theme = "0.1.0"
 
+[tool.setuptools.package-data]
+MrMustard = ["juliapkg.json"]
+
 [tool.black]
 line-length = 100
 


### PR DESCRIPTION
**Context:**
If you installed from a clone of the repo, you'll have `juliapkg.json` present. If you install from PyPI... not the case. This means that if a dependent project (eg. MrKite) tries to use MrMustard's Julia features, the Julia deps will not be auto-managed because this file won't exist in that venv!

**Description of the Change:**
Add `juliapkg.json` to `tool.setuptools.package-data` so dependent projects use Julia correctly.

**Benefits:**
Places that install `MrMustard` from PyPI can use the Julia features

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
XanaduAI/MrKite#196