### PR TITLE
Multi representation

### DIFF
--- a/mrmustard/lab_dev/circuit_components.py
+++ b/mrmustard/lab_dev/circuit_components.py
@@ -261,10 +261,11 @@ class CircuitComponent:
         A representation of this circuit component.
         """
         from .circuit_components_utils import BtoQ
+
         copy_of_self = self
         for mode in self.modes:
-            if self.multi_rep[mode] == 'Q':
-                copy_of_self = (copy_of_self @ BtoQ([mode]).inverse())
+            if self.multi_rep[mode] == "Q":
+                copy_of_self = copy_of_self @ BtoQ([mode]).inverse()
         return copy_of_self._representation
 
     @property
@@ -814,17 +815,18 @@ class CircuitComponent:
                 msg = f"``>>`` not supported between {self} and {other} because it's not clear "
                 msg += "whether or where to add bra wires. Use ``@`` instead and specify all the components."
                 raise ValueError(msg)
-
+            
+            ret._multi_rep = {mode: None for mode in ret.modes}
             for mode in ret.modes:
                 if mode in list(set(self.modes) & set(other.modes)):
                     if not self.multi_rep[mode]:
-                        ret.multi_rep[mode] = self.multi_rep[mode]
+                        ret._multi_rep[mode] = self.multi_rep[mode]
                     elif not other.multi_rep[mode]:
-                        ret.multi_rep[mode] = self.multi_rep[mode]
+                        ret._multi_rep[mode] = self.multi_rep[mode]
                 elif mode in self.modes:
-                    ret.multi_rep[mode] = self.multi_rep[mode]
+                    ret._multi_rep[mode] = self.multi_rep[mode]
                 else:
-                    ret.multi_rep[mode] = other.multi_rep[mode]
+                    ret._multi_rep[mode] = other.multi_rep[mode]
 
             return self._rshift_return(ret)
         else:

--- a/mrmustard/lab_dev/circuit_components.py
+++ b/mrmustard/lab_dev/circuit_components.py
@@ -160,6 +160,15 @@ class CircuitComponent:
         return cls(**data)
 
     @property
+    def multi_rep(self) -> dict:
+        r"""
+        The multirepresentation of the object, is a dictionary from modes to either None,
+        'Q', or 'PS'.
+        None = Bargman, Q = Quandrature, PS = Phase Space
+        """
+        return self._multi_rep
+    
+    @property
     def adjoint(self) -> CircuitComponent:
         r"""
         The adjoint of this component obtained by conjugating the representation and swapping

--- a/mrmustard/lab_dev/circuit_components.py
+++ b/mrmustard/lab_dev/circuit_components.py
@@ -60,6 +60,7 @@ class CircuitComponent:
             a ``(modes_out_bra, modes_in_bra, modes_out_ket, modes_in_ket)``
             where if any of the modes are out of order the representation
             will be reordered.
+        multi_rep: A dictionary indicating what 
         name: The name of this component.
     """
 
@@ -69,12 +70,13 @@ class CircuitComponent:
         self,
         representation: Bargmann | Fock | None = None,
         wires: Wires | Sequence[tuple[int]] | None = None,
-        name: str | None = None,
+        multi_rep: dict | None = None,
+        name: str | None = None
     ) -> None:
         self._name = name
         self._parameter_set = ParameterSet()
         self._representation = representation
-
+        
         if isinstance(wires, Wires):
             self._wires = wires
         else:
@@ -107,6 +109,11 @@ class CircuitComponent:
                 )
                 if self._representation:
                     self._representation = self._representation.reorder(tuple(perm))
+
+        if multi_rep:
+            self._multi_rep = multi_rep
+        else:
+            self._multi_rep = {key: None for key in self.wires.modes}
 
     def _serialize(self) -> tuple[dict[str, Any], dict[str, ArrayLike]]:
         """

--- a/mrmustard/lab_dev/circuit_components.py
+++ b/mrmustard/lab_dev/circuit_components.py
@@ -558,7 +558,7 @@ class CircuitComponent:
             ret = self._getitem_builtin(self.modes)
             ret._representation = fock
         except TypeError:
-            ret = self._from_attributes(fock, self.wires, self.name)
+            ret = self._from_attributes(fock, wires = self.wires, multi_rep = self.multi_rep, name = self.name)
         if "manual_shape" in ret.__dict__:
             del ret.manual_shape
         return ret
@@ -831,7 +831,10 @@ class CircuitComponent:
             return self._rshift_return(ret)
         else:
             for mode in other.modes:
-                self._multi_rep[mode] = BtoQ_mult_table(self._multi_rep[mode])
+                if self.multi_rep[mode] == 'Q':
+                    self._multi_rep[mode] = None
+                else:
+                    self._multi_rep[mode] = 'Q'
             return self
 
     def __sub__(self, other: CircuitComponent) -> CircuitComponent:

--- a/mrmustard/lab_dev/circuit_components.py
+++ b/mrmustard/lab_dev/circuit_components.py
@@ -43,48 +43,11 @@ from mrmustard.math.parameter_set import ParameterSet
 from mrmustard.math.parameters import Constant, Variable
 from mrmustard.lab_dev.wires import Wires
 from mrmustard.physics.triples import identity_Abc
+from mrmustard.lab_dev.utils import multi_rep_contraction
 
 __all__ = ["CircuitComponent"]
 
 
-def multi_rep_contraction(str1, str2):
-    r"""
-    A representation's name in multi_rep can be either of the following:
-        None: Bargmann
-        Q: quadrature
-        PS: phase space
-        BtoQ: Bargmann to quadrature
-        BtoPS: Bargmann to phase space
-        QtoB: quadrature to Bargmann
-        PStoB: phase space to Bargmann
-
-    This function's goal is to compute the multiplication between any of these objects.
-
-        Args:
-            str1: The representation of the first object (on the input side)
-            str2: The representation of the second object (on the output side)
-
-    We have the following multiplication table implemented:
-    None * None = None
-    Q * Q = Q
-    PS * PS = PS
-
-    None * BtoQ = Q
-    None * BtoPS = PS
-
-    anything else raises an error.
-    """
-
-    if str1 == str2:
-        return str1
-    elif str1 == None and str2 == "BtoQ":
-        return "Q"
-    elif str1 == None and str2 == "BtoPS":
-        return "PS"
-    else:
-        raise ValueError(
-            f"Trying to multiply objects of inconsistant representation i.e., rep1={str1} and rep2={str2}"
-        )
 
 
 class CircuitComponent:

--- a/mrmustard/lab_dev/circuit_components.py
+++ b/mrmustard/lab_dev/circuit_components.py
@@ -709,13 +709,30 @@ class CircuitComponent:
 
         multi_rep = {mode: None for mode in wires_result.modes}
 
-        for mode in wires_result.modes:
-            if mode in list(set(self.modes) & set(other.modes)):
-                multi_rep[mode] = multi_rep_contraction(self.multi_rep[mode], other.multi_rep[mode])
-            elif mode in self.modes:
-                multi_rep[mode] = self.multi_rep[mode]
-            else:
-                multi_rep[mode] = other.multi_rep[mode]
+        # for mode in wires_result.modes:
+        #     if mode in list(set(self.modes) & set(other.modes)):
+        #         multi_rep[mode] = multi_rep_contraction(self.multi_rep[mode], other.multi_rep[mode])
+        #     elif mode in self.modes:
+        #         multi_rep[mode] = self.multi_rep[mode]
+        #     else:
+        #         multi_rep[mode] = other.multi_rep[mode]
+
+        if other.name == 'BtoQ':
+            for mode in other.modes:
+                multi_rep[mode] = 'Q'
+        else:
+            for mode in wires_result.modes:
+
+                if mode in list(set(self.modes) & set(other.modes)):
+                    if self.multi_rep[mode] == other.multi_rep[mode]:
+                        multi_rep[mode] = self.multi_rep[mode]
+                    else:
+                        raise ValueError(f"The objects with representations {self.multi_rep[mode]} and {other.multi_rep[mode]} cannot be contracted")
+                elif mode in self.modes:
+                        multi_rep[mode] = self.multi_rep[mode]
+                        
+                else:
+                    multi_rep[mode] = other.multi_rep[mode]
 
         return CircuitComponent._from_attributes(
             rep, wires=wires_result, multi_rep=multi_rep, name=None

--- a/mrmustard/lab_dev/circuit_components.py
+++ b/mrmustard/lab_dev/circuit_components.py
@@ -831,7 +831,7 @@ class CircuitComponent:
             return self._rshift_return(ret)
         else:
             for mode in other.modes:
-                self.multi_rep[mode] = BtoQ_mult_table(self.multi_rep[mode])
+                self._multi_rep[mode] = BtoQ_mult_table(self._multi_rep[mode])
             return self
 
     def __sub__(self, other: CircuitComponent) -> CircuitComponent:

--- a/mrmustard/lab_dev/circuit_components_utils/b_to_ps.py
+++ b/mrmustard/lab_dev/circuit_components_utils/b_to_ps.py
@@ -49,7 +49,7 @@ class BtoPS(Map):
             representation=Bargmann.from_function(
                 fn=triples.displacement_map_s_parametrized_Abc, s=s, n_modes=len(modes)
             ),
-            multi_rep = {mode: "BtoPS" for mode in modes},
+            multi_rep={mode: "BtoPS" for mode in modes},
             name="BtoPS",
         )
         self._add_parameter(Constant(s, "s"))

--- a/mrmustard/lab_dev/circuit_components_utils/b_to_ps.py
+++ b/mrmustard/lab_dev/circuit_components_utils/b_to_ps.py
@@ -49,6 +49,7 @@ class BtoPS(Map):
             representation=Bargmann.from_function(
                 fn=triples.displacement_map_s_parametrized_Abc, s=s, n_modes=len(modes)
             ),
+            multi_rep = {mode: "BtoPS" for mode in modes},
             name="BtoPS",
         )
         self._add_parameter(Constant(s, "s"))

--- a/mrmustard/lab_dev/circuit_components_utils/b_to_q.py
+++ b/mrmustard/lab_dev/circuit_components_utils/b_to_q.py
@@ -51,6 +51,7 @@ class BtoQ(Operation):
             modes_out=modes,
             modes_in=modes,
             representation=repr,
+            multi_rep={mode: "BtoQ" for mode in modes},
             name="BtoQ",
         )
         self._add_parameter(Constant(phi, "phi"))

--- a/mrmustard/lab_dev/states/base.py
+++ b/mrmustard/lab_dev/states/base.py
@@ -845,10 +845,11 @@ class DM(State):
 
         idxz = [i for i, m in enumerate(self.modes) if m not in modes]
         idxz_conj = [i + len(self.modes) for i, m in enumerate(self.modes) if m not in modes]
+        new_multi_rep = {mode: self.multi_rep[mode] for mode in modes}
         representation = self.representation.trace(idxz, idxz_conj)
 
         return self.__class__._from_attributes(
-            representation, wires, self.name
+            representation, wires = wires, multi_rep=new_multi_rep ,name = self.name
         )  # pylint: disable=protected-access
 
     def __rshift__(self, other: CircuitComponent) -> CircuitComponent:
@@ -1038,7 +1039,7 @@ class Ket(State):
         The ``DM`` object obtained from this ``Ket``.
         """
         dm = self @ self.adjoint
-        ret = DM._from_attributes(dm.representation, dm.wires, self.name)
+        ret = DM._from_attributes(dm._representation, wires = dm.wires, multi_rep=dm.multi_rep ,name = self.name)
         ret.manual_shape = self.manual_shape + self.manual_shape
         return ret
 

--- a/mrmustard/lab_dev/states/base.py
+++ b/mrmustard/lab_dev/states/base.py
@@ -867,7 +867,7 @@ class DM(State):
 
         w = result.wires
         if not w.input and w.bra.modes == w.ket.modes:
-            return DM(w.modes, result.representation)
+            return DM(w.modes, result._representation)
         return result
 
 

--- a/mrmustard/lab_dev/states/base.py
+++ b/mrmustard/lab_dev/states/base.py
@@ -601,6 +601,7 @@ class DM(State):
         self,
         modes: Sequence[int] = (),
         representation: Bargmann | Fock | None = None,
+        multi_rep: dict | None = None,
         name: str | None = None,
     ):
         if representation and representation.ansatz.num_vars != 2 * len(modes):
@@ -609,6 +610,7 @@ class DM(State):
             )
         super().__init__(
             wires=[modes, (), modes, ()],
+            multi_rep=multi_rep,
             name=name,
         )
         if representation is not None:
@@ -883,6 +885,7 @@ class Ket(State):
         self,
         modes: Sequence[int] = (),
         representation: Bargmann | Fock | None = None,
+        multi_rep: dict | None = None,
         name: str | None = None,
     ):
         if representation and representation.ansatz.num_vars != len(modes):
@@ -891,6 +894,7 @@ class Ket(State):
             )
         super().__init__(
             wires=[(), (), modes, ()],
+            multi_rep=multi_rep,
             name=name,
         )
         if representation is not None:

--- a/mrmustard/lab_dev/states/base.py
+++ b/mrmustard/lab_dev/states/base.py
@@ -203,7 +203,8 @@ class State(CircuitComponent):
             ValueError: If the ``A`` or ``b`` have a shape that is inconsistent with
                 the number of modes.
         """
-        return cls(modes, Bargmann(*triple), name)
+        multi_rep = {mode: None for mode in modes}
+        return cls(modes, Bargmann(*triple), multi_rep=multi_rep , name=name)
 
     @classmethod
     def from_fock(
@@ -310,7 +311,8 @@ class State(CircuitComponent):
         """
         QtoB = BtoQ(modes, phi).inverse()
         Q = cls(modes, Bargmann(*triple))
-        return cls(modes, (Q >> QtoB).representation, name)
+        multi_rep = {mode: 'Q' for mode in modes}
+        return cls(modes, (Q >> QtoB).representation, multi_rep=multi_rep ,name = name)
 
     def phase_space(self, s: float) -> tuple:
         r"""
@@ -885,7 +887,7 @@ class Ket(State):
         self,
         modes: Sequence[int] = (),
         representation: Bargmann | Fock | None = None,
-        multi_rep: dict | None = None,
+        multi_rep : dict | None = None,
         name: str | None = None,
     ):
         if representation and representation.ansatz.num_vars != len(modes):
@@ -894,8 +896,8 @@ class Ket(State):
             )
         super().__init__(
             wires=[(), (), modes, ()],
-            multi_rep=multi_rep,
             name=name,
+            multi_rep=multi_rep
         )
         if representation is not None:
             self._representation = representation
@@ -948,10 +950,12 @@ class Ket(State):
             if p < 1.0 - atol_purity:
                 msg = f"Cannot initialize a Ket: purity is {p:.5f} (must be at least 1.0-{atol_purity})."
                 raise ValueError(msg)
+        multi_rep = {mode: 'PS' for mode in modes}
         return Ket(
             modes,
             coeff * Bargmann.from_function(fn=wigner_to_bargmann_psi, cov=cov, means=means),
-            name,
+            multi_rep=multi_rep,
+            name = name,
         )
 
     @classmethod

--- a/mrmustard/lab_dev/states/base.py
+++ b/mrmustard/lab_dev/states/base.py
@@ -204,7 +204,7 @@ class State(CircuitComponent):
                 the number of modes.
         """
         multi_rep = {mode: None for mode in modes}
-        return cls(modes, Bargmann(*triple), multi_rep=multi_rep , name=name)
+        return cls(modes, Bargmann(*triple), multi_rep=multi_rep, name=name)
 
     @classmethod
     def from_fock(
@@ -311,8 +311,8 @@ class State(CircuitComponent):
         """
         QtoB = BtoQ(modes, phi).inverse()
         Q = cls(modes, Bargmann(*triple))
-        multi_rep = {mode: 'Q' for mode in modes}
-        return cls(modes, (Q >> QtoB).representation, multi_rep=multi_rep ,name = name)
+        multi_rep = {mode: "Q" for mode in modes}
+        return cls(modes, (Q >> QtoB).representation, multi_rep=multi_rep, name=name)
 
     def phase_space(self, s: float) -> tuple:
         r"""
@@ -887,18 +887,14 @@ class Ket(State):
         self,
         modes: Sequence[int] = (),
         representation: Bargmann | Fock | None = None,
-        multi_rep : dict | None = None,
+        multi_rep: dict | None = None,
         name: str | None = None,
     ):
         if representation and representation.ansatz.num_vars != len(modes):
             raise ValueError(
                 f"Expected a representation with {len(modes)} variables, found {representation.ansatz.num_vars}."
             )
-        super().__init__(
-            wires=[(), (), modes, ()],
-            name=name,
-            multi_rep=multi_rep
-        )
+        super().__init__(wires=[(), (), modes, ()], name=name, multi_rep=multi_rep)
         if representation is not None:
             self._representation = representation
 
@@ -950,12 +946,12 @@ class Ket(State):
             if p < 1.0 - atol_purity:
                 msg = f"Cannot initialize a Ket: purity is {p:.5f} (must be at least 1.0-{atol_purity})."
                 raise ValueError(msg)
-        multi_rep = {mode: 'PS' for mode in modes}
+        multi_rep = {mode: "PS" for mode in modes}
         return Ket(
             modes,
             coeff * Bargmann.from_function(fn=wigner_to_bargmann_psi, cov=cov, means=means),
             multi_rep=multi_rep,
-            name = name,
+            name=name,
         )
 
     @classmethod
@@ -993,6 +989,7 @@ class Ket(State):
         A = S_2 @ math.conj(math.inv(S_1))  # use solve for inverse
         b = math.zeros(m, dtype=A.dtype)
         psi = cls.from_bargmann(modes, [[A], [b], [complex(1)]])
+
         return psi.normalize()
 
     def auto_shape(

--- a/mrmustard/lab_dev/transformations/base.py
+++ b/mrmustard/lab_dev/transformations/base.py
@@ -126,12 +126,14 @@ class Operation(Transformation):
         modes_out: tuple[int, ...] = (),
         modes_in: tuple[int, ...] = (),
         representation: Bargmann | Fock | None = None,
+        multi_rep: dict | None = None,
         name: str | None = None,
     ):
         super().__init__(
             representation=representation,
             wires=[(), (), modes_out, modes_in],
             name=name,
+            multi_rep=multi_rep
         )
 
 

--- a/mrmustard/lab_dev/transformations/base.py
+++ b/mrmustard/lab_dev/transformations/base.py
@@ -99,7 +99,7 @@ class Transformation(CircuitComponent):
             raise NotImplementedError("Batched transformations are not supported.")
 
         # compute the inverse
-        A, b, _ = self.dual.representation.conj().triple  # apply X(.)X
+        A, b, _ = self.dual._representation.conj().triple  # apply X(.)X
         almost_inverse = self._from_attributes(
             Bargmann(math.inv(A[0]), -math.inv(A[0]) @ b[0], 1 + 0j), self.wires
         )
@@ -233,13 +233,13 @@ class Map(Transformation):
         modes_out: tuple[int, ...] = (),
         modes_in: tuple[int, ...] = (),
         representation: Bargmann | Fock | None = None,
-        multi_rep : dict | None = None,
+        multi_rep: dict | None = None,
         name: str | None = None,
     ):
         super().__init__(
             representation=representation,
             wires=[modes_out, modes_in, modes_out, modes_in],
-            multi_rep = multi_rep,
+            multi_rep=multi_rep,
             name=name or self.__class__.__name__,
         )
 

--- a/mrmustard/lab_dev/transformations/base.py
+++ b/mrmustard/lab_dev/transformations/base.py
@@ -101,14 +101,15 @@ class Transformation(CircuitComponent):
         # compute the inverse
         A, b, _ = self.dual._representation.conj().triple  # apply X(.)X
         almost_inverse = self._from_attributes(
-            Bargmann(math.inv(A[0]), -math.inv(A[0]) @ b[0], 1 + 0j), self.wires
+            Bargmann(math.inv(A[0]), -math.inv(A[0]) @ b[0], 1 + 0j), wires = self.wires, multi_rep = self.multi_rep
         )
         almost_identity = self @ almost_inverse
         invert_this_c = almost_identity.representation.c
         actual_inverse = self._from_attributes(
             Bargmann(math.inv(A[0]), -math.inv(A[0]) @ b[0], 1 / invert_this_c),
-            self.wires,
-            self.name + "_inv",
+            wires = self.wires,
+            multi_rep = self.multi_rep,
+            name = self.name + "_inv",
         )
         return actual_inverse
 

--- a/mrmustard/lab_dev/transformations/base.py
+++ b/mrmustard/lab_dev/transformations/base.py
@@ -133,7 +133,7 @@ class Operation(Transformation):
             representation=representation,
             wires=[(), (), modes_out, modes_in],
             name=name,
-            multi_rep=multi_rep
+            multi_rep=multi_rep,
         )
 
 
@@ -233,11 +233,13 @@ class Map(Transformation):
         modes_out: tuple[int, ...] = (),
         modes_in: tuple[int, ...] = (),
         representation: Bargmann | Fock | None = None,
+        multi_rep : dict | None = None,
         name: str | None = None,
     ):
         super().__init__(
             representation=representation,
             wires=[modes_out, modes_in, modes_out, modes_in],
+            multi_rep = multi_rep,
             name=name or self.__class__.__name__,
         )
 

--- a/mrmustard/lab_dev/utils.py
+++ b/mrmustard/lab_dev/utils.py
@@ -135,6 +135,7 @@ def multi_rep_contraction(str1, str2):
 
 
 def BtoQ_mult_table(s: str) -> str:
-    if s:
+    if s == 'Q':
         return None
-    return "Q"
+    else:
+        return 'Q'

--- a/mrmustard/lab_dev/utils.py
+++ b/mrmustard/lab_dev/utils.py
@@ -92,3 +92,43 @@ def shape_check(mat, vec, dim: int, name: str):
         msg = f"{name} representation is incompatible with the required dimension {dim}: "
         msg += f"{mat.shape[-2:]}!=({dim},{dim}) or {vec.shape[-1:]} != ({dim},)."
         raise ValueError(msg)
+
+
+def multi_rep_contraction(str1, str2):
+    r"""
+    A representation's name in multi_rep can be either of the following:
+        None: Bargmann
+        Q: quadrature
+        PS: phase space
+        BtoQ: Bargmann to quadrature
+        BtoPS: Bargmann to phase space
+        QtoB: quadrature to Bargmann
+        PStoB: phase space to Bargmann
+
+    This function's goal is to compute the multiplication between any of these objects.
+
+        Args:
+            str1: The representation of the first object (on the input side)
+            str2: The representation of the second object (on the output side)
+
+    We have the following multiplication table implemented:
+    None * None = None
+    Q * Q = Q
+    PS * PS = PS
+
+    None * BtoQ = Q
+    None * BtoPS = PS
+
+    anything else raises an error.
+    """
+
+    if str1 == str2:
+        return str1
+    elif str1 == None and str2 == "BtoQ":
+        return "Q"
+    elif str1 == None and str2 == "BtoPS":
+        return "PS"
+    else:
+        raise ValueError(
+            f"Trying to multiply objects of inconsistant representation i.e., rep1={str1} and rep2={str2}"
+        )

--- a/mrmustard/lab_dev/utils.py
+++ b/mrmustard/lab_dev/utils.py
@@ -132,3 +132,9 @@ def multi_rep_contraction(str1, str2):
         raise ValueError(
             f"Trying to multiply objects of inconsistant representation i.e., rep1={str1} and rep2={str2}"
         )
+
+
+def BtoQ_mult_table(s: str) -> str:
+    if s:
+        return None
+    return "Q"

--- a/tests/test_lab_dev/test_transformations/test_transformations_base.py
+++ b/tests/test_lab_dev/test_transformations/test_transformations_base.py
@@ -81,7 +81,7 @@ class TestUnitary:
     def test_repr(self):
         unitary1 = Dgate([0, 1], 1)
         u_component = CircuitComponent._from_attributes(
-            unitary1.representation, unitary1.wires, unitary1.name
+            representation = unitary1.representation, wires = unitary1.wires, name = unitary1.name
         )  # pylint: disable=protected-access
         assert repr(unitary1) == "Dgate(modes=[0, 1], name=Dgate, repr=Bargmann)"
         assert repr(unitary1.to_fock(5)) == "Dgate(modes=[0, 1], name=Dgate, repr=Fock)"


### PR DESCRIPTION
### **User description**
**Context:**
This is the first try at allowing multi representations for our objects. Every `CircuitComponent` has a dictionary called `multi_rep` that contains information about representation of each mode. 

**Description of the Change:**
`.representation` computes in the desired rep, while `._representation` computes the Bargmann rep always. We sort of delay the evaluation of `BtoQ` on our representation to the end of the circuit.

**Benefits:**
Allows contracting any objects even if there is `BtoQ` in the middle.

**Possible Drawbacks:**
Contractions always occur in Bargmann.

**Related GitHub Issues:**
To be determined


___

### **PR Type**
enhancement


___

### **Description**
- Introduced a `multi_rep` attribute to `CircuitComponent` to support multiple representations.
- Updated `CircuitComponent` methods to handle `multi_rep`, allowing dynamic representation conversion.
- Enhanced state and transformation classes to initialize and manage `multi_rep`.
- Added utility functions to facilitate operations involving multiple representations.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>circuit_components.py</strong><dd><code>Add multi-representation support to CircuitComponent class</code></dd></summary>
<hr>

mrmustard/lab_dev/circuit_components.py

<li>Introduced <code>multi_rep</code> attribute to <code>CircuitComponent</code>.<br> <li> Modified methods to incorporate <code>multi_rep</code> handling.<br> <li> Added logic for representation conversion in <code>representation</code> property.<br> <li> Updated arithmetic operations to consider <code>multi_rep</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/488/files#diff-05cc8f1f470b3eab23b8a8b1b1a628a97c87852722ea6b5408e1bb70efd4ab72">+98/-43</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>b_to_ps.py</strong><dd><code>Initialize multi_rep for BtoPS components</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mrmustard/lab_dev/circuit_components_utils/b_to_ps.py

- Added `multi_rep` initialization for `BtoPS`.



</details>


  </td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/488/files#diff-c530e576cf8965a0634d76cdd9dc2775fd218ee94278d8ea1f0bc7f9a65f28c2">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>b_to_q.py</strong><dd><code>Initialize multi_rep for BtoQ components</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mrmustard/lab_dev/circuit_components_utils/b_to_q.py

- Added `multi_rep` initialization for `BtoQ`.



</details>


  </td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/488/files#diff-ca88d1b44cdc56cd9f74c0a100800ae36547c5d76a3db2af91c9c8bd33565d6c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>base.py</strong><dd><code>Integrate multi_rep in state initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mrmustard/lab_dev/states/base.py

<li>Incorporated <code>multi_rep</code> in state initialization.<br> <li> Adjusted state creation methods to set <code>multi_rep</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/488/files#diff-782e8b404915d7267d5cc991ba0b8c52926808d9005e7b45fdb98da00dfa9f00">+13/-8</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>base.py</strong><dd><code>Support multi_rep in transformation initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mrmustard/lab_dev/transformations/base.py

- Added `multi_rep` handling in transformation initialization.



</details>


  </td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/488/files#diff-6ed510de4b8b2084645a6cdda8f1109ff4d32e1cf47b73a7510425e3274ed470">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>utils.py</strong><dd><code>Add utility functions for multi_rep operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mrmustard/lab_dev/utils.py

<li>Added utility functions for multi_rep contraction and BtoQ <br>multiplication.<br>


</details>


  </td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/488/files#diff-54ff581230aae203705a4edad699ab8b2a28cbe9977f8df54948e28d6cbefaf8">+46/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

