### PR TITLE
Avoid storing original_abc_data when c is not a scalar 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.venv
+
 .DS_Store
 .vscode
 *.egg-info*

--- a/mrmustard/lab_dev/circuit_components.py
+++ b/mrmustard/lab_dev/circuit_components.py
@@ -572,7 +572,8 @@ class CircuitComponent:
         """
         fock = Fock(self.fock(shape, batched=True), batched=True)
         try:
-            fock.ansatz._original_abc_data = self.representation.triple
+            if self.representation.ansatz.polynomial_shape[0] == 0:
+                fock.ansatz._original_abc_data = self.representation.triple
         except AttributeError:
             fock.ansatz._original_abc_data = None
         try:

--- a/tests/test_lab_dev/test_circuit_components.py
+++ b/tests/test_lab_dev/test_circuit_components.py
@@ -196,15 +196,17 @@ class TestCircuitComponent:
         d = Dgate([1], x=0.1, y=0.1)
         d_fock = d.to_fock(shape=(4, 6))
         d_barg = d_fock.to_bargmann()
+        assert d_fock.representation.ansatz._original_abc_data == d.representation.triple
         assert d_barg == d
 
     def test_to_fock_poly_exp(self):
         A, b, _ = Abc_triple(3)
         c = np.random.random((1, 5))
         barg = Bargmann(A, b, c)
-        cc = CircuitComponent(barg, wires=[(), (), (0, 1), ()]).to_fock(shape=(10, 10))
+        fock_cc = CircuitComponent(barg, wires=[(), (), (0, 1), ()]).to_fock(shape=(10, 10))
         poly = math.hermite_renormalized(A, b, 1, (10, 10, 5))
-        assert np.allclose(cc.representation.data, np.einsum("ijk,k", poly, c[0]))
+        assert fock_cc.representation.ansatz._original_abc_data is None
+        assert np.allclose(fock_cc.representation.data, np.einsum("ijk,k", poly, c[0]))
 
     def test_add(self):
         d1 = Dgate([1], x=0.1, y=0.1)


### PR DESCRIPTION
### **User description**
**Context:** After [to_bargmann() original bargmann data bug](https://github.com/XanaduAI/MrMustard/commit/667c516453df9844baa514162f737da2d762f2fa) we always store the original Bargmann data when calling to_fock. This isn't ideal in the case when c is an array where instead keeping the array is more efficient. 

**Description of the Change:** `to_fock` checks the polynomial shape and only sets `._original_abc_data` if c is a scalar


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed a bug in `to_fock` method to conditionally store `_original_abc_data` only when `c` is a scalar.
- Added tests to ensure `_original_abc_data` is correctly set or not set based on the polynomial shape.
- Improved efficiency by avoiding unnecessary storage of data when `c` is an array.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>circuit_components.py</strong><dd><code>Conditional storage of `_original_abc_data` based on polynomial shape</code></dd></summary>
<hr>

mrmustard/lab_dev/circuit_components.py

<li>Added a condition to check if <code>polynomial_shape[0]</code> is zero before <br>setting <code>_original_abc_data</code>.<br> <li> Ensured <code>_original_abc_data</code> is only set when the condition is met.<br>


</details>


  </td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/493/files#diff-05cc8f1f470b3eab23b8a8b1b1a628a97c87852722ea6b5408e1bb70efd4ab72">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_circuit_components.py</strong><dd><code>Add tests for `_original_abc_data` conditional logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_lab_dev/test_circuit_components.py

<li>Added assertions to verify the correct setting of <code>_original_abc_data</code>.<br> <li> Updated tests to check for <code>None</code> when <code>c</code> is not a scalar.<br>


</details>


  </td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/493/files#diff-cf594d34002781ecbd6f00d55be035f5d6821af5cfde94038830e0e3ea5f5bc3">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information