### PR TITLE
adds padding when num poly wires is different

### DIFF
--- a/mrmustard/physics/ansatze.py
+++ b/mrmustard/physics/ansatze.py
@@ -202,8 +202,8 @@ class PolyExpBase(Ansatz):
         have polynomials attached to them and what the degree(+1) of the polynomial is
         on each of the wires.
         """
-        dim_poly = len(self.array.shape) - 1
         shape_poly = self.array.shape[1:]
+        dim_poly = len(shape_poly)
         return dim_poly, shape_poly
 
     @property
@@ -420,52 +420,44 @@ class PolyExpBase(Ansatz):
         shape of the combined object will be (2,5,4,5). It also pads A and b, to account for an eventual
         different number of polynomial wires.
         """
-        (_, n, _) = self.mat.shape
-        (_, m, _) = other.mat.shape
+        (_, n1, _) = self.mat.shape
+        (_, n2, _) = other.mat.shape
         self_num_poly, _ = self.polynomial_shape
         other_num_poly, _ = other.polynomial_shape
-        if self_num_poly - other_num_poly != n - m:
-            raise ValueError("Inconsistent polynomial shapes.")
-        if n < m:
-            self.mat = math.pad(self.mat, ((0, 0), (0, m - n), (0, m - n)))
-            self.vec = math.pad(self.vec, ((0, 0), (0, m - n)))
-            for _ in range(m - n):
-                self.array = math.expand_dims(self.array, axis=-1)
-        elif n > m:
-            other.mat = math.pad(other.mat, ((0, 0), (0, n - m), (0, n - m)))
-            other.vec = math.pad(other.vec, ((0, 0), (0, n - m)))
-            for _ in range(n - m):
-                other.array = math.expand_dims(other.array, axis=-1)
-        combined_matrices = math.concat([self.mat, other.mat], axis=0)
-        combined_vectors = math.concat([self.vec, other.vec], axis=0)
+        if self_num_poly - other_num_poly != n1 - n2:
+            raise ValueError(
+                f"Inconsistent polynomial shapes: the A matrices have shape {(n1,n1)} and {(n2,n2)} (difference of {n1-n2}), "
+                f"but the polynomials have {self_num_poly} and {other_num_poly} variables (difference of {self_num_poly-other_num_poly})."
+            )
 
-        a0s = self.array.shape[1:]
-        a1s = other.array.shape[1:]
-        if a0s == a1s:
-            combined_arrays = math.concat([self.array, other.array], axis=0)
+        def pad_and_expand(mat, vec, array, target_size):
+            pad_size = target_size - mat.shape[-1]
+            padded_mat = math.pad(mat, ((0, 0), (0, pad_size), (0, pad_size)))
+            padded_vec = math.pad(vec, ((0, 0), (0, pad_size)))
+            padding_array = math.ones((1,) * pad_size, dtype=array.dtype)
+            expanded_array = math.outer(array, padding_array)
+            return padded_mat, padded_vec, expanded_array
+
+        def combine_arrays(array1, array2):
+            shape1 = array1.shape[1:]
+            shape2 = array2.shape[1:]
+            max_shape = tuple(map(max, zip(shape1, shape2)))
+            pad_widths1 = [(0, 0)] + [(0, t - s) for s, t in zip(shape1, max_shape)]
+            pad_widths2 = [(0, 0)] + [(0, t - s) for s, t in zip(shape2, max_shape)]
+            padded_array1 = math.pad(array1, pad_widths1, "constant")
+            padded_array2 = math.pad(array2, pad_widths2, "constant")
+            return math.concat([padded_array1, padded_array2], axis=0)
+
+        if n1 <= n2:
+            mat1, vec1, array1 = pad_and_expand(self.mat, self.vec, self.array, n2)
+            combined_matrices = math.concat([mat1, other.mat], axis=0)
+            combined_vectors = math.concat([vec1, other.vec], axis=0)
+            combined_arrays = combine_arrays(array1, other.array)
         else:
-            s_max = np.maximum(np.array(a0s), np.array(a1s))
-
-            padding_array0 = np.array(
-                (
-                    np.zeros(len(s_max) + 1),
-                    np.concatenate((np.array([0]), np.array((s_max - a0s)))),
-                ),
-                dtype=int,
-            ).T
-            padding_tuple0 = tuple(tuple(padding_array0[i]) for i in range(len(s_max) + 1))
-
-            padding_array1 = np.array(
-                (
-                    np.zeros(len(s_max) + 1),
-                    np.concatenate((np.array([0]), np.array((s_max - a1s)))),
-                ),
-                dtype=int,
-            ).T
-            padding_tuple1 = tuple(tuple(padding_array1[i]) for i in range(len(s_max) + 1))
-            a0_new = np.pad(self.array, padding_tuple0, "constant")
-            a1_new = np.pad(other.array, padding_tuple1, "constant")
-            combined_arrays = math.concat([a0_new, a1_new], axis=0)
+            mat2, vec2, array2 = pad_and_expand(other.mat, other.vec, other.array, n1)
+            combined_matrices = math.concat([self.mat, mat2], axis=0)
+            combined_vectors = math.concat([self.vec, vec2], axis=0)
+            combined_arrays = combine_arrays(self.array, array2)
         # note output is not simplified
         return self.__class__(combined_matrices, combined_vectors, combined_arrays)
 
@@ -1076,7 +1068,7 @@ class ArrayAnsatz(Ansatz):
 
         if any(s > t for s, t in zip(shape, self.array.shape[1:])):
             warn(
-                "Warning: the fock array is being padded with zeros. If possible slice the arrays this one will contract with instead."
+                "Warning: the fock array is being padded with zeros. If possible, slice the arrays this one will contract with instead."
             )
             padded = math.pad(
                 self.array,

--- a/tests/test_physics/test_ansatz.py
+++ b/tests/test_physics/test_ansatz.py
@@ -610,3 +610,34 @@ class TestPolyExpAnsatz:
             (obj1_none0(z2[0].reshape(1, -1)), obj1_none1(z2[1].reshape(1, -1)))
         ).reshape(-1)
         assert np.allclose(val1, val2)
+
+    def test_add_different_poly_wires(self):
+        "tests that A and b are padded correctly"
+        A1 = np.random.random((1, 2, 2))
+        A2 = np.random.random((1, 3, 3))
+        b1 = np.random.random((1, 2))
+        b2 = np.random.random((1, 3))
+        c1 = np.random.random((1,))
+        c2 = np.random.random((1, 11))
+        ansatz1 = PolyExpAnsatz(A1, b1, c1)
+        ansatz2 = PolyExpAnsatz(A2, b2, c2)
+        ansatz_sum = ansatz1 + ansatz2
+        assert ansatz_sum.mat.shape == (2, 3, 3)
+        assert ansatz_sum.vec.shape == (2, 3)
+        assert ansatz_sum.array.shape == (2, 11)
+        ansatz_sum = ansatz2 + ansatz1
+        assert ansatz_sum.mat.shape == (2, 3, 3)
+        assert ansatz_sum.vec.shape == (2, 3)
+        assert ansatz_sum.array.shape == (2, 11)
+
+    def test_inconsistent_poly_shapes(self):
+        A1 = np.random.random((1, 2, 2))
+        A2 = np.random.random((1, 3, 3))
+        b1 = np.random.random((1, 2))
+        b2 = np.random.random((1, 3))
+        c1 = np.random.random((1,))
+        c2 = np.random.random((1, 5, 11))
+        ansatz1 = PolyExpAnsatz(A1, b1, c1)
+        ansatz2 = PolyExpAnsatz(A2, b2, c2)
+        with pytest.raises(ValueError):
+            ansatz1 + ansatz2  # pylint: disable=pointless-statement


### PR DESCRIPTION
### **User description**
We allow making linear superpositions of components with different number of polynomial wires by padding A and b with zeros, and adding empty dimensions to the c array.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Enhanced the addition operation in `ansatze.py` to pad matrices `A` and `b` when the number of polynomial wires differs, ensuring compatibility.
- Introduced a check to raise a `ValueError` if polynomial shapes are inconsistent.
- Expanded dimensions of arrays to handle different shapes during addition.
- Added tests to verify correct padding of `A` and `b` and to ensure a `ValueError` is raised for inconsistent polynomial shapes.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ansatze.py</strong><dd><code>Add padding for polynomial wires in ansatze addition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mrmustard/physics/ansatze.py

<li>Added padding for <code>A</code> and <code>b</code> matrices when polynomial wires differ.<br> <li> Implemented checks for consistent polynomial shapes.<br> <li> Expanded dimensions of arrays to accommodate different shapes.<br>


</details>


  </td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/499/files#diff-85405583f9e1c800d7cbad37cca5f7da9c0181a18dd40db2a207dcd134928fe0">+18/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_ansatz.py</strong><dd><code>Add tests for polynomial wire padding and shape consistency</code></dd></summary>
<hr>

tests/test_physics/test_ansatz.py

<li>Added test for padding <code>A</code> and <code>b</code> with different polynomial wires.<br> <li> Added test for inconsistent polynomial shapes raising a ValueError.<br>


</details>


  </td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/499/files#diff-8ae3f2522d16e5dd99914d95d64920f61fb075eb99cec87ee2a122872331da59">+31/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information