### PR TITLE
c of BtoPS

### DIFF
--- a/mrmustard/physics/triples.py
+++ b/mrmustard/physics/triples.py
@@ -677,7 +677,7 @@ def displacement_map_s_parametrized_Abc(s: int, n_modes: int) -> Union[Matrix, V
 
     A = math.astensor(math.asnumpy(A)[order_list, :][:, order_list])
     b = _vacuum_B_vector(4 * n_modes)
-    c = 1.0 / (2 * np.pi) ** n_modes + 0.0j
+    c = 1.0
     return math.astensor(A), b, c
 
 

--- a/tests/test_lab_dev/test_circuit_components_utils.py
+++ b/tests/test_lab_dev/test_circuit_components_utils.py
@@ -34,6 +34,7 @@ from mrmustard.lab_dev.circuit_components_utils import TraceOut, BtoPS, BtoQ
 from mrmustard.lab_dev.circuit_components import CircuitComponent
 from mrmustard.lab_dev.states import Coherent, DM
 from mrmustard.lab_dev.wires import Wires
+from mrmustard.lab_dev.states import Ket
 
 
 # original settings
@@ -163,6 +164,9 @@ class TestBtoPS:
         assert math.allclose(A1, A2)
         assert math.allclose(b1, b2)
         assert math.allclose(c1, c2)
+
+        psi = Ket.random([0])
+        assert math.allclose((psi >> BtoPS([0], 1)).representation([0, 0]), [1.0])
 
 
 class TestBtoQ:

--- a/tests/test_lab_dev/test_states/test_states_base.py
+++ b/tests/test_lab_dev/test_states/test_states_base.py
@@ -145,7 +145,7 @@ class TestKet:  # pylint: disable=too-many-public-methods
     @pytest.mark.parametrize("modes", [[0], [0, 1], [3, 19, 2]])
     def test_to_from_phase_space(self, modes):
         cov, means, coeff = Coherent([0], x=1, y=2).phase_space(s=0)
-        assert math.allclose(coeff[0], 1.0 / (2 * np.pi))
+        assert math.allclose(coeff[0], 1.0)
         assert math.allclose(cov[0], np.eye(2) * settings.HBAR / 2)
         assert math.allclose(means[0], np.array([1.0, 2.0]) * np.sqrt(2 * settings.HBAR))
         n_modes = len(modes)
@@ -553,7 +553,7 @@ class TestDM:  # pylint:disable=too-many-public-methods
     def test_to_from_phase_space(self):
         state0 = Coherent([0], x=1, y=2) >> Attenuator([0], 1.0)
         cov, means, coeff = state0.phase_space(s=0)  # batch = 1
-        assert coeff == 1.0 / (2 * np.pi)
+        assert coeff == 1.0
         assert math.allclose(cov[0], np.eye(2) * settings.HBAR / 2)
         assert math.allclose(means[0], np.array([1.0, 2.0]) * np.sqrt(settings.HBAR * 2))
 

--- a/tests/test_lab_dev/test_transformations/test_cft.py
+++ b/tests/test_lab_dev/test_transformations/test_cft.py
@@ -50,5 +50,5 @@ class TestCFT:
         )  # scaling to take care of HBAR
         Z = np.array([X - 1j * Y, X + 1j * Y]).transpose((1, 2, 0))
         assert math.allclose(
-            2 / settings.HBAR * (np.real(Wigner(Z))), (np.real(wigner.T)), atol=1e-8
+            2 / (2*np.pi*settings.HBAR) * (np.real(Wigner(Z))), (np.real(wigner.T)), atol=1e-8
         )  # scaling to take care of HBAR

--- a/tests/test_lab_dev/test_transformations/test_cft.py
+++ b/tests/test_lab_dev/test_transformations/test_cft.py
@@ -50,5 +50,5 @@ class TestCFT:
         )  # scaling to take care of HBAR
         Z = np.array([X - 1j * Y, X + 1j * Y]).transpose((1, 2, 0))
         assert math.allclose(
-            2 / (2*np.pi*settings.HBAR) * (np.real(Wigner(Z))), (np.real(wigner.T)), atol=1e-8
+            2 / (2 * np.pi * settings.HBAR) * (np.real(Wigner(Z))), (np.real(wigner.T)), atol=1e-8
         )  # scaling to take care of HBAR

--- a/tests/test_physics/test_ansatz.py
+++ b/tests/test_physics/test_ansatz.py
@@ -241,7 +241,7 @@ class TestArrayAnsatz:
         ) = bargmann_Abc_to_phasespace_cov_means(A1, b1, c1)
         assert np.allclose(state_cov, new_state_cov)
         assert np.allclose(state_means, new_state_means)
-        assert np.allclose(1.0 / (2 * np.pi), new_state_coeff)
+        assert np.allclose(1.0, new_state_coeff)
 
         state_cov = np.array(
             [

--- a/tests/test_physics/test_ansatz.py
+++ b/tests/test_physics/test_ansatz.py
@@ -273,8 +273,8 @@ class TestArrayAnsatz:
         assert math.allclose(new_state_cov1, state_cov)
         assert math.allclose(new_state_means1, state_means)
         assert math.allclose(new_state_means22, state_means)
-        assert math.allclose(new_state_coeff1, 1 / (2 * np.pi) ** 2)
-        assert math.allclose(new_state_coeff22, 1 / (2 * np.pi) ** 2)
+        assert math.allclose(new_state_coeff1, 1.0)
+        assert math.allclose(new_state_coeff22, 1.0)
 
 
 class TestPolyExpAnsatz:

--- a/tests/test_physics/test_triples.py
+++ b/tests/test_physics/test_triples.py
@@ -317,19 +317,19 @@ class TestTriples:
         A1_correct = np.array([[0, -0.5, -1, 0], [-0.5, 0, 0, 1], [-1, 0, 0, 1], [0, 1, 1, 0]])
         assert math.allclose(A1, A1_correct[[0, 3, 1, 2], :][:, [0, 3, 1, 2]])
         assert math.allclose(b1, math.zeros(4))
-        assert math.allclose(c1, 1 / (2 * np.pi))
+        assert math.allclose(c1, 1.0)
 
         A2, b2, c2 = triples.displacement_map_s_parametrized_Abc(s=1, n_modes=1)
         A2_correct = np.array([[0, 0, -1, 0], [0, 0, 0, 1], [-1, 0, 0, 1], [0, 1, 1, 0]])
         assert math.allclose(A2, A2_correct[[0, 3, 1, 2], :][:, [0, 3, 1, 2]])
         assert math.allclose(b2, math.zeros(4))
-        assert math.allclose(c2, 1 / (2 * np.pi))
+        assert math.allclose(c2, 1.0)
 
         A3, b3, c3 = triples.displacement_map_s_parametrized_Abc(s=-1, n_modes=1)
         A3_correct = np.array([[0, -1, -1, 0], [-1, 0, 0, 1], [-1, 0, 0, 1], [0, 1, 1, 0]])
         assert math.allclose(A3, A3_correct[[0, 3, 1, 2], :][:, [0, 3, 1, 2]])
         assert math.allclose(b3, math.zeros(4))
-        assert math.allclose(c3, 1 / (2 * np.pi))
+        assert math.allclose(c3, 1.0)
 
     @pytest.mark.parametrize("eta", [0.0, 0.1, 0.5, 0.9, 1.0])
     def test_attenuator_kraus_Abc(self, eta):


### PR DESCRIPTION
**Context:**
We would like `BtoPS` to compute the characteristic function, but it currently computes it with a `1/2pi` prefactor. 

**Description of the Change:**
Changing the `c` of `BtoPS` from `1/(2*pi)` back to `1` so that we can readily compute characteristic function (and propagating to tests).

**Benefits:**
Minor (we can compute characteristic function directly by BtoPS)

**Possible Drawbacks:**
Need to be ware of this change when computing Wigner function (the 2pi factor would be placed there -- look at `test_cft.py` to see how to do this).

**Related GitHub Issues:**
None.