### PR TITLE
Rshift order bugfix

### DIFF
--- a/mrmustard/lab_dev/circuit_components.py
+++ b/mrmustard/lab_dev/circuit_components.py
@@ -821,9 +821,9 @@ class CircuitComponent:
         if only_ket or only_bra or both_sides:
             ret = self @ other
         elif self_needs_bra or self_needs_ket:
-            ret = self.adjoint @ (self @ other)
+            ret = (self.adjoint @ self) @ other
         elif other_needs_bra or other_needs_ket:
-            ret = (self @ other) @ other.adjoint
+            ret = self @ (other @ other.adjoint)
         else:
             msg = f"``>>`` not supported between {self} and {other} because it's not clear "
             msg += "whether or where to add bra wires. Use ``@`` instead and specify all the components."


### PR DESCRIPTION
### **User description**
**Context:** The following fails on develop:

```
rng = np.random.default_rng(seed=2334255467567)
r = [rng.random(), -rng.random()]
theta = rng.random() * 2 * np.pi
pnr_cutoff = rng.integers(1, 25)
out_loss = rng.random()
pnr_loss = rng.random()
outcome = rng.integers(0, pnr_cutoff)

mm_state = (
    SqueezedVacuum([0, 1], r)
    >> BSgate([0, 1], theta)
    >> Attenuator([0, 1], [1 - out_loss, 1 - pnr_loss])
    >> Number([1], outcome).dual
)
mm_state_dm = (
    SqueezedVacuum([0, 1], r)
    >> BSgate([0, 1], theta)
    >> Attenuator([0, 1], [1 - out_loss, 1 - pnr_loss])
    >> Number([1], outcome).dm().dual
)
assert mm_state.representation == mm_state_dm.representation
```
This is due to the permutation order of `mm_state_dm` differing to `mm_state` because of the order of matmul operations.

**Description of the Change:** Changes the order of operations in `CircuitComponent.__rshift__`. Added example as a test.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed a bug in the `__rshift__` method of `CircuitComponent` by adjusting the order of operations to ensure correct permutation order.
- Added a test case to verify the fix for the permutation order issue.
- Reintroduced and modified a test for `rshift` with ketbra to ensure correctness.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>circuit_components.py</strong><dd><code>Fix permutation order in `__rshift__` method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mrmustard/lab_dev/circuit_components.py

<li>Adjusted the order of operations in <code>__rshift__</code> method.<br> <li> Fixed the permutation order issue causing incorrect results.<br>


</details>


  </td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/507/files#diff-05cc8f1f470b3eab23b8a8b1b1a628a97c87852722ea6b5408e1bb70efd4ab72">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_circuit_components.py</strong><dd><code>Add tests for `__rshift__` permutation order fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_lab_dev/test_circuit_components.py

<li>Added a test to verify the correct permutation order.<br> <li> Reintroduced and modified a test for <code>rshift</code> with ketbra.<br>


</details>


  </td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/507/files#diff-cf594d34002781ecbd6f00d55be035f5d6821af5cfde94038830e0e3ea5f5bc3">+40/-10</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information