### PR TITLE
Added the ability to control slackness in physicality conditions.

### DIFF
--- a/mrmustard/lab_dev/states/dm.py
+++ b/mrmustard/lab_dev/states/dm.py
@@ -49,10 +49,12 @@ class DM(State):
 
     short_name = "DM"
 
-    @property
-    def is_positive(self) -> bool:
+    def is_positive(self, atol: float = settings.ATOL) -> bool:
         r"""
         Whether this DM is a positive operator.
+
+        Arg:
+            atol: The tolerance we allow for positivity conditions.
         """
         batch_dim = self.ansatz.batch_size
         if batch_dim > 1:
@@ -64,18 +66,20 @@ class DM(State):
         gamma_A = A[:m, m:]
 
         if (
-            math.real(math.norm(gamma_A - math.conj(gamma_A.T))) > settings.ATOL
+            math.real(math.norm(gamma_A - math.conj(gamma_A.T))) > atol
         ):  # checks if gamma_A is Hermitian
             return False
 
-        return all(math.real(math.eigvals(gamma_A)) >= 0)
+        return all(math.real(math.eigvals(gamma_A)) >= -atol)
 
-    @property
-    def is_physical(self) -> bool:
+    def is_physical(self, atol: float = settings.ATOL) -> bool:
         r"""
         Whether this DM is a physical density operator.
+
+        Arg:
+            atol: the tolerance we allow for physicality conditions.
         """
-        return self.is_positive and math.allclose(self.probability, 1, settings.ATOL)
+        return self.is_positive(atol) and math.allclose(self.probability, 1, atol)
 
     @property
     def probability(self) -> float:

--- a/mrmustard/lab_dev/states/ket.py
+++ b/mrmustard/lab_dev/states/ket.py
@@ -56,11 +56,14 @@ class Ket(State):
 
     short_name = "Ket"
 
-    @property
-    def is_physical(self) -> bool:
+    def is_physical(self, atol: float = settings.ATOL) -> bool:
         r"""
         Whether the ket object is a physical one.
+
+        Arg:
+            atol: The tolerance we allow for physicality conditions. The default value is settings.ATOL.
         """
+
         batch_dim = self.ansatz.batch_size
         if batch_dim > 1:
             raise ValueError(
@@ -69,9 +72,7 @@ class Ket(State):
 
         A = self.ansatz.A[0]
 
-        return all(math.abs(math.eigvals(A)) < 1) and math.allclose(
-            self.probability, 1, settings.ATOL
-        )
+        return all(math.abs(math.eigvals(A)) < 1) and math.allclose(self.probability, 1, atol)
 
     @property
     def probability(self) -> float:

--- a/mrmustard/lab_dev/transformations/base.py
+++ b/mrmustard/lab_dev/transformations/base.py
@@ -356,10 +356,12 @@ class Channel(Map):
 
     short_name = "Ch"
 
-    @property
-    def is_CP(self) -> bool:
+    def is_CP(self, atol: float = settings.ATOL) -> bool:
         r"""
         Whether this channel is completely positive (CP).
+
+        Arg:
+            atol: The tolerance we allow for CP conditions (default value is settings.ATOL)
         """
         batch_dim = self.ansatz.batch_size
         if batch_dim > 1:
@@ -371,30 +373,34 @@ class Channel(Map):
         gamma_A = A[0, :m, m:]
 
         if (
-            math.real(math.norm(gamma_A - math.conj(gamma_A.T))) > settings.ATOL
+            math.real(math.norm(gamma_A - math.conj(gamma_A.T))) > atol
         ):  # checks if gamma_A is Hermitian
             return False
 
-        return all(math.real(math.eigvals(gamma_A)) > -settings.ATOL)
+        return all(math.real(math.eigvals(gamma_A)) > -atol)
 
-    @property
-    def is_TP(self) -> bool:
+    def is_TP(self, atol: float = settings.ATOL) -> bool:
         r"""
         Whether this channel is trace preserving (TP).
+
+        Arg:
+            atol: The tolerance we allow for TP condition (default value is settings.ATOL)
         """
         A = self.ansatz.A
         m = A.shape[-1] // 2
         gamma_A = A[0, :m, m:]
         lambda_A = A[0, m:, m:]
         temp_A = gamma_A + math.conj(lambda_A.T) @ math.inv(math.eye(m) - gamma_A.T) @ lambda_A
-        return math.real(math.norm(temp_A - math.eye(m))) < settings.ATOL
+        return math.real(math.norm(temp_A - math.eye(m))) < atol
 
-    @property
-    def is_physical(self) -> bool:
+    def is_physical(self, atol: float = settings.ATOL) -> bool:
         r"""
         Whether this channel is physical (i.e. CPTP).
+
+        Arg:
+            atol: The tolerance we allow for CPTP conditions (default value is settings.ATOL)
         """
-        return self.is_CP and self.is_TP
+        return self.is_CP(atol) and self.is_TP(atol)
 
     @property
     def XY(self) -> tuple[ComplexMatrix, ComplexMatrix]:


### PR DESCRIPTION
**Context:**
Currently, the tolerance for channel CPTP conditions, density matrix positivity and trace conditions, and pure state norm conditions use `settings.ATOL` to control their slackness. This PR allows to use arbitrary slackness for them.

**Description of the Change:**
Introduced new variable `atol: float = settings.ATOL` which is to control this slackness in all physicality conditions including `is_CP`, `is_TP`, and `is_physical` for Channels, and `is_positive` and `is_physical` for DMs, and finally, `is_physical` for Kets.

**Benefits:**
Will be convenient to set the slackness. Also, is helpful in some tests.

**Possible Drawbacks:**
None.
**Related GitHub Issues:**
None.