### PR TITLE
np -> math

### DIFF
--- a/mrmustard/lab_dev/transformations/phasenoise.py
+++ b/mrmustard/lab_dev/transformations/phasenoise.py
@@ -77,7 +77,7 @@ class PhaseNoise(Channel):
         array = math.asnumpy(other.fock_array())
         mode_indices = np.indices(array.shape)
         for mode in self.modes:
-            phase_factors = np.exp(
+            phase_factors = math.exp(
                 -0.5
                 * (mode_indices[mode] - mode_indices[other.n_modes + mode]) ** 2
                 * self.phase_stdev.value**2

--- a/mrmustard/math/backend_manager.py
+++ b/mrmustard/math/backend_manager.py
@@ -981,6 +981,20 @@ class BackendManager:  # pylint: disable=too-many-public-methods, fixme
         """
         return self._apply("real", (array,))
 
+    def repeat(self, array: Tensor, repeats: int, axis: int = None) -> Tensor:
+        """
+        Repeats elements of a tensor along a specified axis.
+
+        Args:
+            array: The input tensor.
+            repeats: The number of repetitions for each element.
+            axis: The axis along which to repeat values. If None, use the flattened input tensor.
+
+        Returns:
+            The tensor with repeated elements.
+        """
+        return self._apply("repeat", (array, repeats, axis))
+
     def reshape(self, array: Tensor, shape: Sequence[int]) -> Tensor:
         r"""The reshaped array.
 

--- a/mrmustard/math/backend_numpy.py
+++ b/mrmustard/math/backend_numpy.py
@@ -312,6 +312,9 @@ class BackendNumpy(BackendBase):  # pragma: no cover
     def reshape(self, array: np.ndarray, shape: Sequence[int]) -> np.ndarray:
         return np.reshape(array, shape)
 
+    def repeat(self, array: np.ndarray, repeats: int, axis: int = None) -> np.ndarray:
+        return np.repeat(array, repeats, axis=axis)
+
     def round(self, array: np.ndarray, decimals: int = 0) -> np.ndarray:
         return np.round(array, decimals)
 

--- a/mrmustard/math/backend_tensorflow.py
+++ b/mrmustard/math/backend_tensorflow.py
@@ -311,6 +311,9 @@ class BackendTensorflow(BackendBase):  # pragma: no cover
     def reshape(self, array: tf.Tensor, shape: Sequence[int]) -> tf.Tensor:
         return tf.reshape(array, shape)
 
+    def repeat(self, array: tf.Tensor, repeats: int, axis: int = None) -> tf.Tensor:
+        return tf.repeat(array, repeats, axis=axis)
+
     def round(self, array: tf.Tensor, decimals: int = 0) -> tf.Tensor:
         return tf.round(10**decimals * array) / 10**decimals
 

--- a/mrmustard/physics/bargmann_utils.py
+++ b/mrmustard/physics/bargmann_utils.py
@@ -270,7 +270,12 @@ def XY_of_channel(A: ComplexMatrix):
             [A[2 * m : 3 * m, m : 2 * m], A[2 * m : 3 * m, 3 * m :]],
         ]
     )
-    X_tilde = -math.inv(np.eye(n) - math.Xmat(m) @ A_out) @ math.Xmat(m) @ R @ math.Xmat(m)
+    X_tilde = (
+        -math.inv(math.eye(n, dtype=math.complex128) - math.Xmat(m) @ A_out)
+        @ math.Xmat(m)
+        @ R
+        @ math.Xmat(m)
+    )
     transformation = math.block(
         [
             [math.eye(m, dtype=math.complex128), math.eye(m, dtype=math.complex128)],

--- a/mrmustard/physics/gaussian_integrals.py
+++ b/mrmustard/physics/gaussian_integrals.py
@@ -247,23 +247,23 @@ def join_Abc(Abc1: tuple, Abc2: tuple, mode: str = "kron") -> tuple:
     c2 = math.reshape(c2, (batch2, -1))
 
     if mode == "kron":
-        A1 = np.repeat(A1, batch2, axis=0)
-        A2 = np.tile(A2, (batch1, 1, 1))
-        A1Z = np.concatenate([A1, np.zeros((batch1 * batch2, nA1, nA2))], axis=-1)
-        ZA2 = np.concatenate([np.zeros((batch1 * batch2, nA2, nA1)), A2], axis=-1)
-        b1 = np.repeat(b1, batch2, axis=0)
-        b2 = np.tile(b2, (batch1, 1))
+        A1 = math.repeat(A1, batch2, axis=0)
+        A2 = math.tile(A2, (batch1, 1, 1))
+        A1Z = math.concat([A1, math.zeros((batch1 * batch2, nA1, nA2), dtype=A1.dtype)], axis=-1)
+        ZA2 = math.concat([math.zeros((batch1 * batch2, nA2, nA1), dtype=A2.dtype), A2], axis=-1)
+        b1 = math.repeat(b1, batch2, axis=0)
+        b2 = math.tile(b2, (batch1, 1))
         c = math.reshape(
             math.einsum("ba,dc->bdac", c1, c2),
             [batch1 * batch2] + poly_shape1 + poly_shape2,
         )
     elif mode == "zip":
-        A1Z = np.concatenate([A1, np.zeros((batch1, nA1, nA2))], axis=-1)
-        ZA2 = np.concatenate([np.zeros((batch1, nA2, nA1)), A2], axis=-1)
+        A1Z = math.concat([A1, math.zeros((batch1, nA1, nA2), dtype=A1.dtype)], axis=-1)
+        ZA2 = math.concat([math.zeros((batch1, nA2, nA1), dtype=A2.dtype), A2], axis=-1)
         c = math.reshape(math.einsum("ba,bc->bac", c1, c2), [batch1] + poly_shape1 + poly_shape2)
 
-    A = np.concatenate([A1Z, ZA2], axis=-2)
-    A = np.concatenate(
+    A = math.concat([A1Z, ZA2], axis=-2)
+    A = math.concat(
         [
             A[:, :n1, :],
             A[:, nA1 : nA1 + n2, :],
@@ -272,7 +272,7 @@ def join_Abc(Abc1: tuple, Abc2: tuple, mode: str = "kron") -> tuple:
         ],
         axis=-2,
     )
-    A = np.concatenate(
+    A = math.concat(
         [
             A[:, :, :n1],
             A[:, :, nA1 : nA1 + n2],
@@ -281,8 +281,8 @@ def join_Abc(Abc1: tuple, Abc2: tuple, mode: str = "kron") -> tuple:
         ],
         axis=-1,
     )
-    b = np.concatenate([b1, b2], axis=-1)
-    b = np.concatenate(
+    b = math.concat([b1, b2], axis=-1)
+    b = math.concat(
         [
             b[:, :n1],
             b[:, nA1 : nA1 + n2],


### PR DESCRIPTION
Adds the `repeat` method to the backend and replaces a bunch of np calls to math calls. This enables gradients to be computed and optimiziation to run (with caveats).