### PR TITLE
Getting rid of CircuitComponent level access of parameters in the ParameterSet

### DIFF
--- a/mrmustard/lab_dev/circuit_components.py
+++ b/mrmustard/lab_dev/circuit_components.py
@@ -42,7 +42,6 @@ from mrmustard.utils.typing import (
 from mrmustard.physics.ansatz import Ansatz, PolyExpAnsatz, ArrayAnsatz
 from mrmustard.physics.fock_utils import quadrature_basis
 from mrmustard.math.parameter_set import ParameterSet
-from mrmustard.math.parameters import Constant, Variable
 from mrmustard.physics.wires import Wires
 from mrmustard.physics.representations import Representation
 

--- a/mrmustard/lab_dev/circuit_components_utils/b_to_ps.py
+++ b/mrmustard/lab_dev/circuit_components_utils/b_to_ps.py
@@ -45,21 +45,23 @@ class BtoPS(Map):
         s: float,
     ):
         super().__init__(name="BtoPS")
-        self._add_parameter(make_parameter(False, s, "s", (None, None)))
+        self.parameters.add_parameter(make_parameter(False, s, "s", (None, None)))
         self._representation = self.from_ansatz(
             modes_in=modes,
             modes_out=modes,
             ansatz=PolyExpAnsatz.from_function(
-                fn=triples.displacement_map_s_parametrized_Abc, s=self.s, n_modes=len(modes)
+                fn=triples.displacement_map_s_parametrized_Abc,
+                s=self.parameters.s,
+                n_modes=len(modes),
             ),
         ).representation
         for i in self.wires.input.indices:
             self.representation._idx_reps[i] = (RepEnum.BARGMANN, None)
         for i in self.wires.output.indices:
-            self.representation._idx_reps[i] = (RepEnum.PHASESPACE, float(self.s.value))
+            self.representation._idx_reps[i] = (RepEnum.PHASESPACE, float(self.parameters.s.value))
 
     def inverse(self):
-        ret = BtoPS(self.modes, self.s)
+        ret = BtoPS(self.modes, self.parameters.s)
         ret._representation = super().inverse().representation
         ret._representation._wires = ret.representation.wires.dual
         return ret

--- a/mrmustard/lab_dev/circuit_components_utils/b_to_q.py
+++ b/mrmustard/lab_dev/circuit_components_utils/b_to_q.py
@@ -45,21 +45,24 @@ class BtoQ(Operation):
         phi: float = 0.0,
     ):
         super().__init__(name="BtoQ")
-        self._add_parameter(make_parameter(False, phi, "phi", (None, None)))
+        self.parameters.add_parameter(make_parameter(False, phi, "phi", (None, None)))
         self._representation = self.from_ansatz(
             modes_in=modes,
             modes_out=modes,
             ansatz=PolyExpAnsatz.from_function(
-                fn=triples.bargmann_to_quadrature_Abc, n_modes=len(modes), phi=self.phi
+                fn=triples.bargmann_to_quadrature_Abc, n_modes=len(modes), phi=self.parameters.phi
             ),
         ).representation
         for i in self.wires.input.indices:
             self.representation._idx_reps[i] = (RepEnum.BARGMANN, None)
         for i in self.wires.output.indices:
-            self.representation._idx_reps[i] = (RepEnum.QUADRATURE, float(self.phi.value))
+            self.representation._idx_reps[i] = (
+                RepEnum.QUADRATURE,
+                float(self.parameters.phi.value),
+            )
 
     def inverse(self):
-        ret = BtoQ(self.modes, self.phi)
+        ret = BtoQ(self.modes, self.parameters.phi)
         ret._representation = super().inverse().representation
         ret._representation._wires = ret.representation.wires.dual
         return ret

--- a/mrmustard/lab_dev/circuits.py
+++ b/mrmustard/lab_dev/circuits.py
@@ -369,12 +369,12 @@ class Circuit:
             else:
                 cc_names = [f"{cc_name}"]
 
-            if comp.parameter_set.names and settings.DRAW_CIRCUIT_PARAMS:
+            if comp.parameters.names and settings.DRAW_CIRCUIT_PARAMS:
                 values = []
-                for name in comp.parameter_set.names:
-                    param = comp.parameter_set.constants.get(
+                for name in comp.parameters.names:
+                    param = comp.parameters.constants.get(name) or comp.parameters.variables.get(
                         name
-                    ) or comp.parameter_set.variables.get(name)
+                    )
                     new_values = math.atleast_1d(param.value)
                     if len(new_values) == 1 and cc_name not in control_gates:
                         new_values = math.tile(new_values, (len(comp.modes),))

--- a/mrmustard/lab_dev/samplers.py
+++ b/mrmustard/lab_dev/samplers.py
@@ -152,7 +152,7 @@ class Sampler(ABC):
         if self._povms is None:
             raise ValueError("This sampler has no POVMs defined.")
         if isinstance(self.povms, CircuitComponent):
-            kwargs = self.povms.parameter_set.to_dict()
+            kwargs = self.povms.parameters.to_dict()
             kwargs[self._outcome_arg] = meas_outcome
             return self.povms.__class__(modes=[mode], **kwargs)
         else:

--- a/mrmustard/lab_dev/states/bargmann_eigenstate.py
+++ b/mrmustard/lab_dev/states/bargmann_eigenstate.py
@@ -60,8 +60,10 @@ class BargmannEigenstate(Ket):
     ):
         super().__init__(name="BargmannEigenstate")
 
-        self._add_parameter(make_parameter(alpha_trainable, alpha, "alpha", alpha_bounds))
+        self.parameters.add_parameter(make_parameter(alpha_trainable, alpha, "alpha", alpha_bounds))
         self._representation = self.from_ansatz(
             modes=modes,
-            ansatz=PolyExpAnsatz.from_function(fn=triples.bargmann_eigenstate_Abc, x=self.alpha),
+            ansatz=PolyExpAnsatz.from_function(
+                fn=triples.bargmann_eigenstate_Abc, x=self.parameters.alpha
+            ),
         ).representation

--- a/mrmustard/lab_dev/states/base.py
+++ b/mrmustard/lab_dev/states/base.py
@@ -153,9 +153,8 @@ class State(CircuitComponent):
         The `L2` norm squared of a ``Ket``, or the Hilbert-Schmidt norm of a ``DM``,
         element-wise along the batch dimension.
         """
-        settings.UNSAFE_ZIP_BATCH = True
-        rep = self >> self.dual
-        settings.UNSAFE_ZIP_BATCH = False
+        with settings(UNSAFE_ZIP_BATCH=True):
+            rep = self >> self.dual
         return math.real(rep)
 
     @classmethod

--- a/mrmustard/lab_dev/states/coherent.py
+++ b/mrmustard/lab_dev/states/coherent.py
@@ -80,10 +80,12 @@ class Coherent(Ket):
         super().__init__(name="Coherent")
 
         xs, ys = list(reshape_params(len(modes), x=x, y=y))
-        self._add_parameter(make_parameter(x_trainable, xs, "x", x_bounds))
-        self._add_parameter(make_parameter(y_trainable, ys, "y", y_bounds))
+        self.parameters.add_parameter(make_parameter(x_trainable, xs, "x", x_bounds))
+        self.parameters.add_parameter(make_parameter(y_trainable, ys, "y", y_bounds))
 
         self._representation = self.from_ansatz(
             modes=modes,
-            ansatz=PolyExpAnsatz.from_function(fn=triples.coherent_state_Abc, x=self.x, y=self.y),
+            ansatz=PolyExpAnsatz.from_function(
+                fn=triples.coherent_state_Abc, x=self.parameters.x, y=self.parameters.y
+            ),
         ).representation

--- a/mrmustard/lab_dev/states/displaced_squeezed.py
+++ b/mrmustard/lab_dev/states/displaced_squeezed.py
@@ -80,18 +80,18 @@ class DisplacedSqueezed(Ket):
 
         params = reshape_params(len(modes), x=x, y=y, r=r, phi=phi)
         xs, ys, rs, phis = list(params)
-        self._add_parameter(make_parameter(x_trainable, xs, "x", x_bounds))
-        self._add_parameter(make_parameter(y_trainable, ys, "y", y_bounds))
-        self._add_parameter(make_parameter(r_trainable, rs, "r", r_bounds))
-        self._add_parameter(make_parameter(phi_trainable, phis, "phi", phi_bounds))
+        self.parameters.add_parameter(make_parameter(x_trainable, xs, "x", x_bounds))
+        self.parameters.add_parameter(make_parameter(y_trainable, ys, "y", y_bounds))
+        self.parameters.add_parameter(make_parameter(r_trainable, rs, "r", r_bounds))
+        self.parameters.add_parameter(make_parameter(phi_trainable, phis, "phi", phi_bounds))
 
         self._representation = self.from_ansatz(
             modes=modes,
             ansatz=PolyExpAnsatz.from_function(
                 fn=triples.displaced_squeezed_vacuum_state_Abc,
-                x=self.x,
-                y=self.y,
-                r=self.r,
-                phi=self.phi,
+                x=self.parameters.x,
+                y=self.parameters.y,
+                r=self.parameters.r,
+                phi=self.parameters.phi,
             ),
         ).representation

--- a/mrmustard/lab_dev/states/dm.py
+++ b/mrmustard/lab_dev/states/dm.py
@@ -394,7 +394,7 @@ class DM(State):
             msg = f"Expected a subset of `{self.modes}, found `{list(modes)}`."
             raise ValueError(msg)
 
-        if self._parameter_set:
+        if self._parameters:
             # if ``self`` has a parameter set it means it is a built-in state,
             # in which case we slice the parameters
             return self._getitem_builtin(modes)

--- a/mrmustard/lab_dev/states/gstate.py
+++ b/mrmustard/lab_dev/states/gstate.py
@@ -67,7 +67,7 @@ class GKet(Ket):
 
         symplectic = symplectic if symplectic is not None else math.random_symplectic(m)
 
-        self._add_parameter(
+        self.parameters.add_parameter(
             make_parameter(
                 symplectic_trainable,
                 symplectic,
@@ -80,7 +80,7 @@ class GKet(Ket):
         self._representation = self.from_ansatz(
             modes=modes,
             ansatz=PolyExpAnsatz.from_function(
-                fn=triples.gket_state_Abc, symplectic=self.symplectic
+                fn=triples.gket_state_Abc, symplectic=self.parameters.symplectic
             ),
         ).representation
 
@@ -136,7 +136,7 @@ class GDM(DM):
         if symplectic is None:
             symplectic = math.random_symplectic(m)
 
-        self._add_parameter(
+        self.parameters.add_parameter(
             make_parameter(
                 symplectic_trainable,
                 symplectic,
@@ -148,7 +148,7 @@ class GDM(DM):
 
         betas = math.astensor(list(reshape_params(len(modes), betas=beta))[0])
 
-        self._add_parameter(
+        self.parameters.add_parameter(
             make_parameter(
                 beta_trainable,
                 math.astensor(betas),
@@ -160,7 +160,7 @@ class GDM(DM):
         self._representation = self.from_ansatz(
             modes=modes,
             ansatz=PolyExpAnsatz.from_function(
-                fn=triples.gdm_state_Abc, betas=self.beta, symplectic=symplectic
+                fn=triples.gdm_state_Abc, betas=self.parameters.beta, symplectic=symplectic
             ),
         ).representation
 

--- a/mrmustard/lab_dev/states/gstate.py
+++ b/mrmustard/lab_dev/states/gstate.py
@@ -132,10 +132,8 @@ class GDM(DM):
     ) -> None:
         super().__init__(name="GDM")
         m = len(modes)
-
-        if symplectic is None:
-            symplectic = math.random_symplectic(m)
-
+        symplectic = symplectic if symplectic is not None else math.random_symplectic(m)
+        (betas,) = list(reshape_params(len(modes), betas=beta))
         self.parameters.add_parameter(
             make_parameter(
                 symplectic_trainable,
@@ -145,22 +143,20 @@ class GDM(DM):
                 update_symplectic,
             )
         )
-
-        betas = math.astensor(list(reshape_params(len(modes), betas=beta))[0])
-
         self.parameters.add_parameter(
             make_parameter(
                 beta_trainable,
-                math.astensor(betas),
+                betas,
                 "beta",
                 (0, None),
             )
         )
-
         self._representation = self.from_ansatz(
             modes=modes,
             ansatz=PolyExpAnsatz.from_function(
-                fn=triples.gdm_state_Abc, betas=self.parameters.beta, symplectic=symplectic
+                fn=triples.gdm_state_Abc,
+                betas=self.parameters.beta,
+                symplectic=self.parameters.symplectic,
             ),
         ).representation
 

--- a/mrmustard/lab_dev/states/ket.py
+++ b/mrmustard/lab_dev/states/ket.py
@@ -353,7 +353,7 @@ class Ket(State):
         if not modes.issubset(self.modes):
             raise ValueError(f"Expected a subset of `{self.modes}, found `{list(modes)}`.")
 
-        if self._parameter_set:
+        if self._parameters:
             # if ``self`` has a parameter set, it is a built-in state, and we slice the
             # parameters
             return self._getitem_builtin(modes)

--- a/mrmustard/lab_dev/states/number.py
+++ b/mrmustard/lab_dev/states/number.py
@@ -75,7 +75,7 @@ class Number(Ket):
         self._representation = self.from_ansatz(
             modes=modes,
             ansatz=ArrayAnsatz.from_function(
-                fock_state, n=self.parameters.n.value, cutoffs=self.parameters.cutoffs.value
+                fock_state, n=self.parameters.n, cutoffs=self.parameters.cutoffs
             ),
         ).representation
         self.short_name = [str(int(n)) for n in self.parameters.n.value]

--- a/mrmustard/lab_dev/states/number.py
+++ b/mrmustard/lab_dev/states/number.py
@@ -70,14 +70,14 @@ class Number(Ket):
         super().__init__(name="N")
 
         ns, cs = list(reshape_params(len(modes), n=n, cutoffs=n if cutoffs is None else cutoffs))
-        self._add_parameter(make_parameter(False, ns, "n", (None, None), dtype="int64"))
-        self._add_parameter(make_parameter(False, cs, "cutoffs", (None, None)))
+        self.parameters.add_parameter(make_parameter(False, ns, "n", (None, None), dtype="int64"))
+        self.parameters.add_parameter(make_parameter(False, cs, "cutoffs", (None, None)))
         self._representation = self.from_ansatz(
             modes=modes,
             ansatz=ArrayAnsatz.from_function(
-                fock_state, n=self.n.value, cutoffs=self.cutoffs.value
+                fock_state, n=self.parameters.n.value, cutoffs=self.parameters.cutoffs.value
             ),
         ).representation
-        self.short_name = [str(int(n)) for n in self.n.value]
-        for i, cutoff in enumerate(self.cutoffs.value):
+        self.short_name = [str(int(n)) for n in self.parameters.n.value]
+        for i, cutoff in enumerate(self.parameters.cutoffs.value):
             self.manual_shape[i] = int(cutoff) + 1

--- a/mrmustard/lab_dev/states/quadrature_eigenstate.py
+++ b/mrmustard/lab_dev/states/quadrature_eigenstate.py
@@ -66,14 +66,14 @@ class QuadratureEigenstate(Ket):
         super().__init__(name="QuadratureEigenstate")
 
         xs, phis = list(reshape_params(len(modes), x=x, phi=phi))
-        self._add_parameter(make_parameter(x_trainable, xs, "x", x_bounds))
-        self._add_parameter(make_parameter(phi_trainable, phis, "phi", phi_bounds))
+        self.parameters.add_parameter(make_parameter(x_trainable, xs, "x", x_bounds))
+        self.parameters.add_parameter(make_parameter(phi_trainable, phis, "phi", phi_bounds))
         self.manual_shape = (50,)
 
         self._representation = self.from_ansatz(
             modes=modes,
             ansatz=PolyExpAnsatz.from_function(
-                fn=triples.quadrature_eigenstates_Abc, x=self.x, phi=self.phi
+                fn=triples.quadrature_eigenstates_Abc, x=self.parameters.x, phi=self.parameters.phi
             ),
         ).representation
 

--- a/mrmustard/lab_dev/states/sauron.py
+++ b/mrmustard/lab_dev/states/sauron.py
@@ -48,7 +48,7 @@ class Sauron(Ket):
             modes=modes,
             ansatz=PolyExpAnsatz.from_function(
                 triples.sauron_state_Abc,
-                n=self.parameters.n.value,
-                epsilon=self.parameters.epsilon.value,
+                n=self.parameters.n,
+                epsilon=self.parameters.epsilon,
             ),
         ).representation

--- a/mrmustard/lab_dev/states/sauron.py
+++ b/mrmustard/lab_dev/states/sauron.py
@@ -41,12 +41,14 @@ class Sauron(Ket):
     def __init__(self, modes: Sequence[int], n: int, epsilon: float = 0.1):
         super().__init__(name=f"Sauron-{n}")
 
-        self._add_parameter(make_parameter(False, n, "n", (None, None), dtype="int64"))
-        self._add_parameter(make_parameter(False, epsilon, "epsilon", (None, None)))
+        self.parameters.add_parameter(make_parameter(False, n, "n", (None, None), dtype="int64"))
+        self.parameters.add_parameter(make_parameter(False, epsilon, "epsilon", (None, None)))
 
         self._representation = self.from_ansatz(
             modes=modes,
             ansatz=PolyExpAnsatz.from_function(
-                triples.sauron_state_Abc, n=self.n.value, epsilon=self.epsilon.value
+                triples.sauron_state_Abc,
+                n=self.parameters.n.value,
+                epsilon=self.parameters.epsilon.value,
             ),
         ).representation

--- a/mrmustard/lab_dev/states/squeezed_vacuum.py
+++ b/mrmustard/lab_dev/states/squeezed_vacuum.py
@@ -67,12 +67,12 @@ class SqueezedVacuum(Ket):
         super().__init__(name="SqueezedVacuum")
 
         rs, phis = list(reshape_params(len(modes), r=r, phi=phi))
-        self._add_parameter(make_parameter(r_trainable, rs, "r", r_bounds))
-        self._add_parameter(make_parameter(phi_trainable, phis, "phi", phi_bounds))
+        self.parameters.add_parameter(make_parameter(r_trainable, rs, "r", r_bounds))
+        self.parameters.add_parameter(make_parameter(phi_trainable, phis, "phi", phi_bounds))
 
         self._representation = self.from_ansatz(
             modes=modes,
             ansatz=PolyExpAnsatz.from_function(
-                fn=triples.squeezed_vacuum_state_Abc, r=self.r, phi=self.phi
+                fn=triples.squeezed_vacuum_state_Abc, r=self.parameters.r, phi=self.parameters.phi
             ),
         ).representation

--- a/mrmustard/lab_dev/states/thermal.py
+++ b/mrmustard/lab_dev/states/thermal.py
@@ -60,8 +60,10 @@ class Thermal(DM):
     ) -> None:
         super().__init__(name="Thermal")
         (nbars,) = list(reshape_params(len(modes), nbar=nbar))
-        self._add_parameter(make_parameter(nbar_trainable, nbars, "nbar", nbar_bounds))
+        self.parameters.add_parameter(make_parameter(nbar_trainable, nbars, "nbar", nbar_bounds))
         self._representation = self.from_ansatz(
             modes=modes,
-            ansatz=PolyExpAnsatz.from_function(fn=triples.thermal_state_Abc, nbar=self.nbar),
+            ansatz=PolyExpAnsatz.from_function(
+                fn=triples.thermal_state_Abc, nbar=self.parameters.nbar
+            ),
         ).representation

--- a/mrmustard/lab_dev/states/two_mode_squeezed_vacuum.py
+++ b/mrmustard/lab_dev/states/two_mode_squeezed_vacuum.py
@@ -64,11 +64,13 @@ class TwoModeSqueezedVacuum(Ket):
     ):
         super().__init__(name="TwoModeSqueezedVacuum")
         rs, phis = list(reshape_params(int(len(modes) / 2), r=r, phi=phi))
-        self._add_parameter(make_parameter(r_trainable, rs, "r", r_bounds))
-        self._add_parameter(make_parameter(phi_trainable, phis, "phi", phi_bounds))
+        self.parameters.add_parameter(make_parameter(r_trainable, rs, "r", r_bounds))
+        self.parameters.add_parameter(make_parameter(phi_trainable, phis, "phi", phi_bounds))
         self._representation = self.from_ansatz(
             modes=modes,
             ansatz=PolyExpAnsatz.from_function(
-                fn=triples.two_mode_squeezed_vacuum_state_Abc, r=self.r, phi=self.phi
+                fn=triples.two_mode_squeezed_vacuum_state_Abc,
+                r=self.parameters.r,
+                phi=self.parameters.phi,
             ),
         ).representation

--- a/mrmustard/lab_dev/transformations/amplifier.py
+++ b/mrmustard/lab_dev/transformations/amplifier.py
@@ -86,7 +86,7 @@ class Amplifier(Channel):
     ):
         super().__init__(name="Amp~")
         (gs,) = list(reshape_params(len(modes), gain=gain))
-        self._add_parameter(
+        self.parameters.add_parameter(
             make_parameter(
                 gain_trainable,
                 gs,
@@ -98,5 +98,5 @@ class Amplifier(Channel):
         self._representation = self.from_ansatz(
             modes_in=modes,
             modes_out=modes,
-            ansatz=PolyExpAnsatz.from_function(fn=triples.amplifier_Abc, g=self.gain),
+            ansatz=PolyExpAnsatz.from_function(fn=triples.amplifier_Abc, g=self.parameters.gain),
         ).representation

--- a/mrmustard/lab_dev/transformations/attenuator.py
+++ b/mrmustard/lab_dev/transformations/attenuator.py
@@ -42,7 +42,7 @@ class Attenuator(Channel):
 
         >>> channel = Attenuator(modes=[1, 2], transmissivity=0.1)
         >>> assert channel.modes == [1, 2]
-        >>> assert np.allclose(channel.transmissivity.value, [0.1, 0.1])
+        >>> assert np.allclose(channel.parameters.transmissivity.value, [0.1, 0.1])
 
     Args:
         modes: The modes this gate is applied to.

--- a/mrmustard/lab_dev/transformations/attenuator.py
+++ b/mrmustard/lab_dev/transformations/attenuator.py
@@ -86,7 +86,7 @@ class Attenuator(Channel):
     ):
         super().__init__(name="Att~")
         (etas,) = list(reshape_params(len(modes), transmissivity=transmissivity))
-        self._add_parameter(
+        self.parameters.add_parameter(
             make_parameter(
                 transmissivity_trainable,
                 etas,
@@ -98,5 +98,7 @@ class Attenuator(Channel):
         self._representation = self.from_ansatz(
             modes_in=modes,
             modes_out=modes,
-            ansatz=PolyExpAnsatz.from_function(fn=triples.attenuator_Abc, eta=self.transmissivity),
+            ansatz=PolyExpAnsatz.from_function(
+                fn=triples.attenuator_Abc, eta=self.parameters.transmissivity
+            ),
         ).representation

--- a/mrmustard/lab_dev/transformations/bsgate.py
+++ b/mrmustard/lab_dev/transformations/bsgate.py
@@ -41,8 +41,8 @@ class BSgate(Unitary):
 
         >>> unitary = BSgate(modes=[1, 2], theta=0.1)
         >>> assert unitary.modes == [1, 2]
-        >>> assert np.allclose(unitary.theta.value, 0.1)
-        >>> assert np.allclose(unitary.phi.value, 0.0)
+        >>> assert np.allclose(unitary.parameters.theta.value, 0.1)
+        >>> assert np.allclose(unitary.parameters.phi.value, 0.0)
 
     Args:
         modes: The modes this gate is applied to.

--- a/mrmustard/lab_dev/transformations/bsgate.py
+++ b/mrmustard/lab_dev/transformations/bsgate.py
@@ -102,12 +102,14 @@ class BSgate(Unitary):
             raise ValueError(f"Expected a pair of modes, found {modes}.")
 
         super().__init__(name="BSgate")
-        self._add_parameter(make_parameter(theta_trainable, theta, "theta", theta_bounds))
-        self._add_parameter(make_parameter(phi_trainable, phi, "phi", phi_bounds))
+        self.parameters.add_parameter(make_parameter(theta_trainable, theta, "theta", theta_bounds))
+        self.parameters.add_parameter(make_parameter(phi_trainable, phi, "phi", phi_bounds))
         self._representation = self.from_ansatz(
             modes_in=modes,
             modes_out=modes,
             ansatz=PolyExpAnsatz.from_function(
-                fn=triples.beamsplitter_gate_Abc, theta=self.theta, phi=self.phi
+                fn=triples.beamsplitter_gate_Abc,
+                theta=self.parameters.theta,
+                phi=self.parameters.phi,
             ),
         ).representation

--- a/mrmustard/lab_dev/transformations/cxgate.py
+++ b/mrmustard/lab_dev/transformations/cxgate.py
@@ -19,11 +19,11 @@ The class representing a controlled-X gate.
 from __future__ import annotations
 
 from typing import Sequence
-from mrmustard import math
 from mrmustard.physics.ansatz import PolyExpAnsatz
 
 from .base import Unitary
 from ..utils import make_parameter
+from ...physics import symplectics
 
 __all__ = ["CXgate"]
 
@@ -63,19 +63,14 @@ class CXgate(Unitary):
             )
         super().__init__(name="CXgate")
         self.parameters.add_parameter(make_parameter(s_trainable, s, "s", s_bounds))
-        symplectic = math.astensor(
-            [
-                [1, 0, 0, 0],
-                [s, 1, 0, 0],
-                [0, 0, 1, -s],
-                [0, 0, 0, 1],
-            ],
-            dtype="complex128",
-        )
+
         self._representation = self.from_ansatz(
             modes_in=modes,
             modes_out=modes,
             ansatz=PolyExpAnsatz.from_function(
-                fn=lambda sym: Unitary.from_symplectic(modes, sym).bargmann_triple(), sym=symplectic
+                fn=lambda s: Unitary.from_symplectic(
+                    modes, symplectics.cxgate_symplectic(s)
+                ).bargmann_triple(),
+                s=self.parameters.s,
             ),
         ).representation

--- a/mrmustard/lab_dev/transformations/cxgate.py
+++ b/mrmustard/lab_dev/transformations/cxgate.py
@@ -62,7 +62,7 @@ class CXgate(Unitary):
                 f"The number of modes for a CXgate must be 2 (your input has {len(modes)} many modes)."
             )
         super().__init__(name="CXgate")
-        self._add_parameter(make_parameter(s_trainable, s, "s", s_bounds))
+        self.parameters.add_parameter(make_parameter(s_trainable, s, "s", s_bounds))
         symplectic = math.astensor(
             [
                 [1, 0, 0, 0],

--- a/mrmustard/lab_dev/transformations/czgate.py
+++ b/mrmustard/lab_dev/transformations/czgate.py
@@ -64,7 +64,7 @@ class CZgate(Unitary):
                 f"The number of modes for a CZgate must be 2 (your input has {len(modes)} many modes)."
             )
         super().__init__(name="CZgate")
-        self._add_parameter(make_parameter(s_trainable, s, "s", s_bounds))
+        self.parameters.add_parameter(make_parameter(s_trainable, s, "s", s_bounds))
         symplectic = math.astensor(
             [
                 [1, 0, 0, 0],

--- a/mrmustard/lab_dev/transformations/czgate.py
+++ b/mrmustard/lab_dev/transformations/czgate.py
@@ -19,11 +19,11 @@ The class representing a controlled-phase gate.
 from __future__ import annotations
 
 from typing import Sequence
-from mrmustard import math
 from mrmustard.physics.ansatz import PolyExpAnsatz
 
 from .base import Unitary
 from ..utils import make_parameter
+from ...physics import symplectics
 
 __all__ = ["CZgate"]
 
@@ -65,18 +65,13 @@ class CZgate(Unitary):
             )
         super().__init__(name="CZgate")
         self.parameters.add_parameter(make_parameter(s_trainable, s, "s", s_bounds))
-        symplectic = math.astensor(
-            [
-                [1, 0, 0, 0],
-                [0, 1, 0, 0],
-                [0, s, 1, 0],
-                [s, 0, 0, 1],
-            ]
-        )
         self._representation = self.from_ansatz(
             modes_in=modes,
             modes_out=modes,
             ansatz=PolyExpAnsatz.from_function(
-                fn=lambda sym: Unitary.from_symplectic(modes, sym).bargmann_triple(), sym=symplectic
+                fn=lambda s: Unitary.from_symplectic(
+                    modes, symplectics.czgate_symplectic(s)
+                ).bargmann_triple(),
+                s=self.parameters.s,
             ),
         ).representation

--- a/mrmustard/lab_dev/transformations/dgate.py
+++ b/mrmustard/lab_dev/transformations/dgate.py
@@ -46,8 +46,8 @@ class Dgate(Unitary):
 
         >>> unitary = Dgate(modes=[1, 2], x=0.1, y=[0.2, 0.3])
         >>> assert unitary.modes == [1, 2]
-        >>> assert np.allclose(unitary.x.value, [0.1, 0.1])
-        >>> assert np.allclose(unitary.y.value, [0.2, 0.3])
+        >>> assert np.allclose(unitary.parameters.x.value, [0.1, 0.1])
+        >>> assert np.allclose(unitary.parameters.y.value, [0.2, 0.3])
 
     Args:
         modes: The modes this gate is applied to.

--- a/mrmustard/lab_dev/transformations/dgate.py
+++ b/mrmustard/lab_dev/transformations/dgate.py
@@ -93,13 +93,13 @@ class Dgate(Unitary):
     ) -> None:
         super().__init__(name="Dgate")
         xs, ys = list(reshape_params(len(modes), x=x, y=y))
-        self._add_parameter(make_parameter(x_trainable, xs, "x", x_bounds))
-        self._add_parameter(make_parameter(y_trainable, ys, "y", y_bounds))
+        self.parameters.add_parameter(make_parameter(x_trainable, xs, "x", x_bounds))
+        self.parameters.add_parameter(make_parameter(y_trainable, ys, "y", y_bounds))
         self._representation = self.from_ansatz(
             modes_in=modes,
             modes_out=modes,
             ansatz=PolyExpAnsatz.from_function(
-                fn=triples.displacement_gate_Abc, x=self.x, y=self.y
+                fn=triples.displacement_gate_Abc, x=self.parameters.x, y=self.parameters.y
             ),
         ).representation
 
@@ -125,8 +125,8 @@ class Dgate(Unitary):
                 f"Expected Fock shape of length {len(auto_shape)}, got length {len(shape)}"
             )
         N = self.n_modes
-        x = self.x.value * math.ones(N, dtype=self.x.value.dtype)
-        y = self.y.value * math.ones(N, dtype=self.y.value.dtype)
+        x = self.parameters.x.value * math.ones(N, dtype=self.parameters.x.value.dtype)
+        y = self.parameters.y.value * math.ones(N, dtype=self.parameters.y.value.dtype)
 
         if N > 1:
             # calculate displacement unitary for each mode and concatenate with outer product

--- a/mrmustard/lab_dev/transformations/fockdamping.py
+++ b/mrmustard/lab_dev/transformations/fockdamping.py
@@ -76,7 +76,7 @@ class FockDamping(Operation):
     ):
         super().__init__(name="FockDamping")
         (betas,) = list(reshape_params(len(modes), damping=damping))
-        self._add_parameter(
+        self.parameters.add_parameter(
             make_parameter(
                 damping_trainable,
                 betas,
@@ -88,5 +88,7 @@ class FockDamping(Operation):
         self._representation = self.from_ansatz(
             modes_in=modes,
             modes_out=modes,
-            ansatz=PolyExpAnsatz.from_function(fn=triples.fock_damping_Abc, beta=self.damping),
+            ansatz=PolyExpAnsatz.from_function(
+                fn=triples.fock_damping_Abc, beta=self.parameters.damping
+            ),
         ).representation

--- a/mrmustard/lab_dev/transformations/fockdamping.py
+++ b/mrmustard/lab_dev/transformations/fockdamping.py
@@ -44,7 +44,7 @@ class FockDamping(Operation):
         >>> input_state = Coherent(modes=[0], x=1, y=0.5)
         >>> output_state = input_state >> operator
         >>> assert operator.modes == [0]
-        >>> assert np.allclose(operator.damping.value, [0.1, 0.1])
+        >>> assert np.allclose(operator.parameters.damping.value, [0.1, 0.1])
         >>> assert output_state.L2_norm < 1
 
     Args:

--- a/mrmustard/lab_dev/transformations/gaussrandnoise.py
+++ b/mrmustard/lab_dev/transformations/gaussrandnoise.py
@@ -41,7 +41,7 @@ class GaussRandNoise(Channel):
 
         >>> channel = GaussRandNoise(modes=[1, 2], Y = .2 * np.eye(4))
         >>> assert channel.modes == [1, 2]
-        >>> assert np.allclose(channel.Y.value, .2 * np.eye(4))
+        >>> assert np.allclose(channel.parameters.Y.value, .2 * np.eye(4))
 
     Args:
         modes: The modes the channel is applied to

--- a/mrmustard/lab_dev/transformations/gaussrandnoise.py
+++ b/mrmustard/lab_dev/transformations/gaussrandnoise.py
@@ -75,9 +75,13 @@ class GaussRandNoise(Channel):
             raise ValueError("The input Y matrix has negative eigen-values.")
 
         super().__init__(name="GRN~")
-        self._add_parameter(make_parameter(Y_trainable, value=Y, name="Y", bounds=(None, None)))
+        self.parameters.add_parameter(
+            make_parameter(Y_trainable, value=Y, name="Y", bounds=(None, None))
+        )
         self._representation = self.from_ansatz(
             modes_in=modes,
             modes_out=modes,
-            ansatz=PolyExpAnsatz.from_function(fn=triples.gaussian_random_noise_Abc, Y=self.Y),
+            ansatz=PolyExpAnsatz.from_function(
+                fn=triples.gaussian_random_noise_Abc, Y=self.parameters.Y
+            ),
         ).representation

--- a/mrmustard/lab_dev/transformations/ggate.py
+++ b/mrmustard/lab_dev/transformations/ggate.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 from typing import Sequence
 from mrmustard import math
+from mrmustard.math.parameters import update_symplectic
 from mrmustard.utils.typing import RealMatrix
 
 from .base import Unitary
@@ -58,8 +59,11 @@ class Ggate(Unitary):
         super().__init__(name="Ggate")
 
         symplectic = symplectic if symplectic is not None else math.random_symplectic(len(modes))
-        S = make_parameter(symplectic_trainable, symplectic, "symplectic", (None, None))
-        self.parameters.add_parameter(S)
+        self.parameters.add_parameter(
+            make_parameter(
+                symplectic_trainable, symplectic, "symplectic", (None, None), update_symplectic
+            )
+        )
         self._representation = self.from_ansatz(
             modes_in=modes,
             modes_out=modes,

--- a/mrmustard/lab_dev/transformations/ggate.py
+++ b/mrmustard/lab_dev/transformations/ggate.py
@@ -59,16 +59,16 @@ class Ggate(Unitary):
 
         symplectic = symplectic if symplectic is not None else math.random_symplectic(len(modes))
         S = make_parameter(symplectic_trainable, symplectic, "symplectic", (None, None))
-        self.parameter_set.add_parameter(S)
+        self.parameters.add_parameter(S)
         self._representation = self.from_ansatz(
             modes_in=modes,
             modes_out=modes,
             ansatz=PolyExpAnsatz.from_function(
                 fn=lambda s: Unitary.from_symplectic(modes, s).bargmann_triple(),
-                s=self.parameter_set.symplectic,
+                s=self.parameters.symplectic,
             ),
         ).representation
 
     @property
     def symplectic(self):
-        return self.parameter_set.symplectic.value
+        return self.parameters.symplectic.value

--- a/mrmustard/lab_dev/transformations/interferometer.py
+++ b/mrmustard/lab_dev/transformations/interferometer.py
@@ -57,13 +57,19 @@ class Interferometer(Unitary):
                 f"The size of the unitary must match the number of modes: {unitary.shape[-1]} =/= {num_modes}"
             )
         super().__init__(name="Interferometer")
-        self._add_parameter(
+        self.parameters.add_parameter(
             make_parameter(unitary_trainable, unitary, "unitary", (None, None), update_unitary)
         )
         symplectic = math.block(
             [
-                [math.real(self.unitary.value), -math.imag(self.unitary.value)],
-                [math.imag(self.unitary.value), math.real(self.unitary.value)],
+                [
+                    math.real(self.parameters.unitary.value),
+                    -math.imag(self.parameters.unitary.value),
+                ],
+                [
+                    math.imag(self.parameters.unitary.value),
+                    math.real(self.parameters.unitary.value),
+                ],
             ]
         )
 

--- a/mrmustard/lab_dev/transformations/interferometer.py
+++ b/mrmustard/lab_dev/transformations/interferometer.py
@@ -26,12 +26,14 @@ from mrmustard.utils.typing import ComplexMatrix
 
 from .base import Unitary
 from ..utils import make_parameter
+from ...physics import symplectics
 
 __all__ = ["Interferometer"]
 
 
 class Interferometer(Unitary):
-    r"""N-mode interferometer.
+    r"""
+    N-mode interferometer.
 
     It corresponds to a Ggate with zero mean and a ``2N x 2N`` unitary symplectic matrix.
 
@@ -60,23 +62,13 @@ class Interferometer(Unitary):
         self.parameters.add_parameter(
             make_parameter(unitary_trainable, unitary, "unitary", (None, None), update_unitary)
         )
-        symplectic = math.block(
-            [
-                [
-                    math.real(self.parameters.unitary.value),
-                    -math.imag(self.parameters.unitary.value),
-                ],
-                [
-                    math.imag(self.parameters.unitary.value),
-                    math.real(self.parameters.unitary.value),
-                ],
-            ]
-        )
-
         self._representation = self.from_ansatz(
             modes_in=modes,
             modes_out=modes,
             ansatz=PolyExpAnsatz.from_function(
-                fn=lambda sym: Unitary.from_symplectic(modes, sym).bargmann_triple(), sym=symplectic
+                fn=lambda uni: Unitary.from_symplectic(
+                    modes, symplectics.interferometer_symplectic(uni)
+                ).bargmann_triple(),
+                uni=self.parameters.unitary,
             ),
         ).representation

--- a/mrmustard/lab_dev/transformations/mzgate.py
+++ b/mrmustard/lab_dev/transformations/mzgate.py
@@ -62,8 +62,8 @@ class MZgate(Unitary):
         internal: bool = False,
     ):
         super().__init__(name="MZgate")
-        self._add_parameter(make_parameter(phi_a_trainable, phi_a, "phi_a", phi_a_bounds))
-        self._add_parameter(make_parameter(phi_b_trainable, phi_b, "phi_b", phi_b_bounds))
+        self.parameters.add_parameter(make_parameter(phi_a_trainable, phi_a, "phi_a", phi_a_bounds))
+        self.parameters.add_parameter(make_parameter(phi_b_trainable, phi_b, "phi_b", phi_b_bounds))
 
         ca = math.cos(complex(phi_a))
         sa = math.sin(complex(phi_a))

--- a/mrmustard/lab_dev/transformations/mzgate.py
+++ b/mrmustard/lab_dev/transformations/mzgate.py
@@ -19,11 +19,11 @@ The class representing a Mach-Zehnder gate.
 from __future__ import annotations
 
 from typing import Sequence
-from mrmustard import math
 from mrmustard.physics.ansatz import PolyExpAnsatz
 
 from .base import Unitary
 from ..utils import make_parameter
+from ...physics import symplectics
 
 __all__ = ["MZgate"]
 
@@ -65,37 +65,15 @@ class MZgate(Unitary):
         self.parameters.add_parameter(make_parameter(phi_a_trainable, phi_a, "phi_a", phi_a_bounds))
         self.parameters.add_parameter(make_parameter(phi_b_trainable, phi_b, "phi_b", phi_b_bounds))
 
-        ca = math.cos(complex(phi_a))
-        sa = math.sin(complex(phi_a))
-        cb = math.cos(complex(phi_b))
-        sb = math.sin(complex(phi_b))
-        cp = math.cos(complex(phi_a + phi_b))
-        sp = math.sin(complex(phi_a + phi_b))
-
-        if internal:
-            symplectic = 0.5 * math.astensor(
-                [
-                    [ca - cb, -sa - sb, sb - sa, -ca - cb],
-                    [-sa - sb, cb - ca, -ca - cb, sa - sb],
-                    [sa - sb, ca + cb, ca - cb, -sa - sb],
-                    [ca + cb, sb - sa, -sa - sb, cb - ca],
-                ]
-            )
-
-        else:
-            symplectic = 0.5 * math.astensor(
-                [
-                    [cp - ca, -sb, sa - sp, -1 - cb],
-                    [-sa - sp, 1 - cb, -ca - cp, sb],
-                    [sp - sa, 1 + cb, cp - ca, -sb],
-                    [cp + ca, -sb, -sa - sp, 1 - cb],
-                ]
-            )
-
         self._representation = self.from_ansatz(
             modes_in=modes,
             modes_out=modes,
             ansatz=PolyExpAnsatz.from_function(
-                fn=lambda sym: Unitary.from_symplectic(modes, sym).bargmann_triple(), sym=symplectic
+                fn=lambda phi_a, phi_b, internal: Unitary.from_symplectic(
+                    modes, symplectics.mzgate_symplectic(phi_a, phi_b, internal)
+                ).bargmann_triple(),
+                phi_a=self.parameters.phi_a,
+                phi_b=self.parameters.phi_b,
+                internal=internal,
             ),
         ).representation

--- a/mrmustard/lab_dev/transformations/pgate.py
+++ b/mrmustard/lab_dev/transformations/pgate.py
@@ -19,11 +19,11 @@ The class representing a quadratic phase gate.
 from __future__ import annotations
 
 from typing import Sequence
-from mrmustard import math
 from mrmustard.physics.ansatz import PolyExpAnsatz
 
 from .base import Unitary
 from ..utils import make_parameter
+from ...physics import symplectics
 
 __all__ = ["Pgate"]
 
@@ -62,17 +62,14 @@ class Pgate(Unitary):
         self.parameters.add_parameter(
             make_parameter(shearing_trainable, shearing, "shearing", shearing_bounds)
         )
-
-        symplectic = math.block(
-            [
-                [math.eye(len(modes)), math.zeros((len(modes), len(modes)))],
-                [math.eye(len(modes)) * shearing, math.eye(len(modes))],
-            ]
-        )
         self._representation = self.from_ansatz(
             modes_in=modes,
             modes_out=modes,
             ansatz=PolyExpAnsatz.from_function(
-                fn=lambda s: Unitary.from_symplectic(modes, s).bargmann_triple(), s=symplectic
+                fn=lambda n_modes, shearing: Unitary.from_symplectic(
+                    modes, symplectics.pgate_symplectic(n_modes, shearing)
+                ).bargmann_triple(),
+                n_modes=len(modes),
+                shearing=self.parameters.shearing,
             ),
         ).representation

--- a/mrmustard/lab_dev/transformations/pgate.py
+++ b/mrmustard/lab_dev/transformations/pgate.py
@@ -59,7 +59,7 @@ class Pgate(Unitary):
         shearing_bounds: tuple[float | None, float | None] = (None, None),
     ):
         super().__init__(name="Pgate")
-        self._add_parameter(
+        self.parameters.add_parameter(
             make_parameter(shearing_trainable, shearing, "shearing", shearing_bounds)
         )
 

--- a/mrmustard/lab_dev/transformations/phasenoise.py
+++ b/mrmustard/lab_dev/transformations/phasenoise.py
@@ -54,7 +54,7 @@ class PhaseNoise(Channel):
         phase_stdev_bounds: tuple[float | None, float | None] = (0.0, None),
     ):
         super().__init__(name="PhaseNoise")
-        self._add_parameter(
+        self.parameters.add_parameter(
             make_parameter(phase_stdev_trainable, phase_stdev, "phase_stdev", phase_stdev_bounds)
         )
         self._representation = self.from_ansatz(
@@ -80,7 +80,7 @@ class PhaseNoise(Channel):
             phase_factors = math.exp(
                 -0.5
                 * (mode_indices[mode] - mode_indices[other.n_modes + mode]) ** 2
-                * self.phase_stdev.value**2
+                * self.parameters.phase_stdev.value**2
             )
             array *= phase_factors
         return CircuitComponent(Representation(ArrayAnsatz(array, False), other.wires), self.name)

--- a/mrmustard/lab_dev/transformations/realinterferometer.py
+++ b/mrmustard/lab_dev/transformations/realinterferometer.py
@@ -26,12 +26,14 @@ from mrmustard.utils.typing import RealMatrix
 
 from .base import Unitary
 from ..utils import make_parameter
+from ...physics import symplectics
 
 __all__ = ["RealInterferometer"]
 
 
 class RealInterferometer(Unitary):
-    r"""N-mode interferometer parametrized by an NxN orthogonal matrix (or 2N x 2N block-diagonal orthogonal matrix). This interferometer does not mix q and p.
+    r"""
+    N-mode interferometer parametrized by an NxN orthogonal matrix (or 2N x 2N block-diagonal orthogonal matrix).
     Does not mix q's and p's.
 
     Args:
@@ -62,23 +64,13 @@ class RealInterferometer(Unitary):
                 orthogonal_trainable, orthogonal, "orthogonal", (None, None), update_orthogonal
             )
         )
-        symplectic = math.block(
-            [
-                [
-                    self.parameters.orthogonal.value,
-                    -math.zeros_like(self.parameters.orthogonal.value),
-                ],
-                [
-                    math.zeros_like(self.parameters.orthogonal.value),
-                    self.parameters.orthogonal.value,
-                ],
-            ]
-        )
-
         self._representation = self.from_ansatz(
             modes_in=modes,
             modes_out=modes,
             ansatz=PolyExpAnsatz.from_function(
-                fn=lambda sym: Unitary.from_symplectic(modes, sym).bargmann_triple(), sym=symplectic
+                fn=lambda ortho: Unitary.from_symplectic(
+                    modes, symplectics.realinterferometer_symplectic(ortho)
+                ).bargmann_triple(),
+                ortho=self.parameters.orthogonal,
             ),
         ).representation

--- a/mrmustard/lab_dev/transformations/realinterferometer.py
+++ b/mrmustard/lab_dev/transformations/realinterferometer.py
@@ -57,15 +57,21 @@ class RealInterferometer(Unitary):
         orthogonal = orthogonal if orthogonal is not None else math.random_orthogonal(num_modes)
 
         super().__init__(name="RealInterferometer")
-        self._add_parameter(
+        self.parameters.add_parameter(
             make_parameter(
                 orthogonal_trainable, orthogonal, "orthogonal", (None, None), update_orthogonal
             )
         )
         symplectic = math.block(
             [
-                [self.orthogonal.value, -math.zeros_like(self.orthogonal.value)],
-                [math.zeros_like(self.orthogonal.value), self.orthogonal.value],
+                [
+                    self.parameters.orthogonal.value,
+                    -math.zeros_like(self.parameters.orthogonal.value),
+                ],
+                [
+                    math.zeros_like(self.parameters.orthogonal.value),
+                    self.parameters.orthogonal.value,
+                ],
             ]
         )
 

--- a/mrmustard/lab_dev/transformations/rgate.py
+++ b/mrmustard/lab_dev/transformations/rgate.py
@@ -61,9 +61,11 @@ class Rgate(Unitary):
     ):
         super().__init__(name="Rgate")
         (phis,) = list(reshape_params(len(modes), phi=phi))
-        self._add_parameter(make_parameter(phi_trainable, phis, "phi", phi_bounds))
+        self.parameters.add_parameter(make_parameter(phi_trainable, phis, "phi", phi_bounds))
         self._representation = self.from_ansatz(
             modes_in=modes,
             modes_out=modes,
-            ansatz=PolyExpAnsatz.from_function(fn=triples.rotation_gate_Abc, theta=self.phi),
+            ansatz=PolyExpAnsatz.from_function(
+                fn=triples.rotation_gate_Abc, theta=self.parameters.phi
+            ),
         ).representation

--- a/mrmustard/lab_dev/transformations/s2gate.py
+++ b/mrmustard/lab_dev/transformations/s2gate.py
@@ -41,8 +41,8 @@ class S2gate(Unitary):
 
         >>> unitary = S2gate(modes=[1, 2], r=1)
         >>> assert unitary.modes == [1, 2]
-        >>> assert np.allclose(unitary.r.value, 1)
-        >>> assert np.allclose(unitary.phi.value, 0.0)
+        >>> assert np.allclose(unitary.parameters.r.value, 1)
+        >>> assert np.allclose(unitary.parameters.phi.value, 0.0)
 
     Args:
         modes: The modes this gate is applied to.

--- a/mrmustard/lab_dev/transformations/s2gate.py
+++ b/mrmustard/lab_dev/transformations/s2gate.py
@@ -85,12 +85,12 @@ class S2gate(Unitary):
             raise ValueError(f"Expected a pair of modes, found {modes}.")
 
         super().__init__(name="S2gate")
-        self._add_parameter(make_parameter(r_trainable, r, "r", r_bounds))
-        self._add_parameter(make_parameter(phi_trainable, phi, "phi", phi_bounds))
+        self.parameters.add_parameter(make_parameter(r_trainable, r, "r", r_bounds))
+        self.parameters.add_parameter(make_parameter(phi_trainable, phi, "phi", phi_bounds))
         self._representation = self.from_ansatz(
             modes_in=modes,
             modes_out=modes,
             ansatz=PolyExpAnsatz.from_function(
-                fn=triples.twomode_squeezing_gate_Abc, r=self.r, phi=self.phi
+                fn=triples.twomode_squeezing_gate_Abc, r=self.parameters.r, phi=self.parameters.phi
             ),
         ).representation

--- a/mrmustard/lab_dev/transformations/sgate.py
+++ b/mrmustard/lab_dev/transformations/sgate.py
@@ -92,12 +92,12 @@ class Sgate(Unitary):
     ):
         super().__init__(name="Sgate")
         rs, phis = list(reshape_params(len(modes), r=r, phi=phi))
-        self._add_parameter(make_parameter(r_trainable, rs, "r", r_bounds))
-        self._add_parameter(make_parameter(phi_trainable, phis, "phi", phi_bounds))
+        self.parameters.add_parameter(make_parameter(r_trainable, rs, "r", r_bounds))
+        self.parameters.add_parameter(make_parameter(phi_trainable, phis, "phi", phi_bounds))
         self._representation = self.from_ansatz(
             modes_in=modes,
             modes_out=modes,
             ansatz=PolyExpAnsatz.from_function(
-                fn=triples.squeezing_gate_Abc, r=self.r, delta=self.phi
+                fn=triples.squeezing_gate_Abc, r=self.parameters.r, delta=self.parameters.phi
             ),
         ).representation

--- a/mrmustard/lab_dev/transformations/sgate.py
+++ b/mrmustard/lab_dev/transformations/sgate.py
@@ -42,8 +42,8 @@ class Sgate(Unitary):
 
         >>> unitary = Sgate(modes=[1, 2], r=0.1, phi=[0.2, 0.3])
         >>> assert unitary.modes == [1, 2]
-        >>> assert np.allclose(unitary.r.value, [0.1, 0.1])
-        >>> assert np.allclose(unitary.phi.value, [0.2, 0.3])
+        >>> assert np.allclose(unitary.parameters.r.value, [0.1, 0.1])
+        >>> assert np.allclose(unitary.parameters.phi.value, [0.2, 0.3])
 
     Args:
         modes: The modes this gate is applied to.

--- a/mrmustard/physics/ansatz/array_ansatz.py
+++ b/mrmustard/physics/ansatz/array_ansatz.py
@@ -27,6 +27,7 @@ from numpy.typing import ArrayLike
 from IPython.display import display
 
 from mrmustard import math, widgets
+from mrmustard.math.parameters import Variable
 from mrmustard.utils.typing import Batch, Scalar, Tensor, Vector
 
 from .base import Ansatz
@@ -203,8 +204,20 @@ class ArrayAnsatz(Ansatz):
         return ArrayAnsatz([trace] if trace.shape == () else trace, batched=True)
 
     def _generate_ansatz(self):
-        if self._array is None:
-            self.array = [self._fn(**self._kwargs)]
+        names = list(self._kwargs.keys())
+        vars = list(self._kwargs.values())
+
+        params = {}
+        param_types = []
+        for name, param in zip(names, vars):
+            try:
+                params[name] = param.value
+                param_types.append(type(param))
+            except AttributeError:
+                params[name] = param
+
+        if self._array is None or Variable in param_types:
+            self.array = [self._fn(**params)]
 
     def _ipython_display_(self):
         if widgets.IN_INTERACTIVE_SHELL or (w := widgets.fock(self)) is None:

--- a/mrmustard/physics/ansatz/array_ansatz.py
+++ b/mrmustard/physics/ansatz/array_ansatz.py
@@ -213,7 +213,7 @@ class ArrayAnsatz(Ansatz):
             try:
                 params[name] = param.value
                 param_types.append(type(param))
-            except AttributeError:
+            except AttributeError:  # pragma: no cover
                 params[name] = param
 
         if self._array is None or Variable in param_types:

--- a/mrmustard/physics/symplectics.py
+++ b/mrmustard/physics/symplectics.py
@@ -1,0 +1,140 @@
+# Copyright 2024 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module contains the symplectic matrices for the Fock-Bargmann representation of
+various states and transformations.
+"""
+from __future__ import annotations
+
+from mrmustard import math
+from mrmustard.utils.typing import Matrix
+
+
+def cxgate_symplectic(s: float) -> Matrix:
+    r"""
+    The symplectic matrix of a controlled X gate.
+
+    Args:
+        s: The control parameter.
+
+    Returns:
+        The symplectic matrix of a CX gate.
+    """
+    return math.astensor(
+        [[1, 0, 0, 0], [s, 1, 0, 0], [0, 0, 1, -s], [0, 0, 0, 1]], dtype="complex128"
+    )
+
+
+def czgate_symplectic(s: float) -> Matrix:
+    r"""
+    The symplectic matrix of a controlled Z gate.
+
+    Args:
+        s: The control parameter.
+
+    Returns:
+        The symplectic matrix of a CZ gate.
+    """
+    return math.astensor([[1, 0, 0, 0], [0, 1, 0, 0], [0, s, 1, 0], [s, 0, 0, 1]])
+
+
+def interferometer_symplectic(unitary: Matrix) -> Matrix:
+    r"""
+    The symplectic matrix of an N-mode interferometer parametrized by an NxN unitary matrix.
+
+    Args:
+        unitary : A unitary matrix. For N modes it must have shape `(N,N)`.
+
+    Returns:
+        The symplectic matrix of an N-mode interferometer.
+    """
+    return math.block(
+        [[math.real(unitary), -math.imag(unitary)], [math.imag(unitary), math.real(unitary)]]
+    )
+
+
+def mzgate_symplectic(phi_a: float, phi_b: float, internal: bool) -> Matrix:
+    r"""
+    The symplectic matrix of a Mach-Zehnder gate.
+
+    It supports two conventions:
+        1. if ``internal=True``, both phases act inside the interferometer: ``phi_a`` on the upper arm, ``phi_b`` on the lower arm;
+        2. if ``internal = False``, both phases act on the upper arm: ``phi_a`` before the first BS, ``phi_b`` after the first BS.
+
+    Args:
+        phi_a: The phase in the upper arm of the MZ interferometer
+        phi_b: The phase in the lower arm or external of the MZ interferometer
+        internal: Whether phases are both in the internal arms.
+
+    Returns:
+        The symplectic matrix of a Mach-Zehnder gate.
+    """
+    ca = math.cos(complex(phi_a))
+    sa = math.sin(complex(phi_a))
+    cb = math.cos(complex(phi_b))
+    sb = math.sin(complex(phi_b))
+    cp = math.cos(complex(phi_a + phi_b))
+    sp = math.sin(complex(phi_a + phi_b))
+    if internal:
+        return 0.5 * math.astensor(
+            [
+                [ca - cb, -sa - sb, sb - sa, -ca - cb],
+                [-sa - sb, cb - ca, -ca - cb, sa - sb],
+                [sa - sb, ca + cb, ca - cb, -sa - sb],
+                [ca + cb, sb - sa, -sa - sb, cb - ca],
+            ]
+        )
+    else:
+        return 0.5 * math.astensor(
+            [
+                [cp - ca, -sb, sa - sp, -1 - cb],
+                [-sa - sp, 1 - cb, -ca - cp, sb],
+                [sp - sa, 1 + cb, cp - ca, -sb],
+                [cp + ca, -sb, -sa - sp, 1 - cb],
+            ]
+        )
+
+
+def pgate_symplectic(n_modes: int, shearing: float) -> Matrix:
+    r"""
+    The symplectic matrix of a quadratic phase gate.
+
+    Args:
+        shearing: The shearing parameter.
+
+    Returns:
+        The symplectic matrix of a phase gate.
+    """
+    return math.block(
+        [
+            [math.eye(n_modes), math.zeros((n_modes, n_modes))],
+            [math.eye(n_modes) * shearing, math.eye(n_modes)],
+        ]
+    )
+
+
+def realinterferometer_symplectic(orthogonal: Matrix) -> Matrix:
+    r"""
+    The symplectic matrix of an N-mode interferometer parametrized by an NxN orthogonal matrix.
+
+    Args:
+        orthogonal : A real orthogonal matrix. For N modes it must have shape `(N,N)`.
+
+    Returns:
+        The symplectic matrix of an N-mode interferometer.
+    """
+    return math.block(
+        [[orthogonal, -math.zeros_like(orthogonal)], [math.zeros_like(orthogonal), orthogonal]]
+    )

--- a/tests/test_lab_dev/test_circuit_components.py
+++ b/tests/test_lab_dev/test_circuit_components.py
@@ -133,14 +133,14 @@ class TestCircuitComponent:
         assert isinstance(d1_adj, CircuitComponent)
         assert d1_adj.name == d1.name
         assert d1_adj.wires == d1.wires.adjoint
-        assert d1_adj.parameter_set == d1.parameter_set
+        assert d1_adj.parameters == d1.parameters
         assert d1_adj.ansatz == d1.ansatz.conj  # this holds for the Dgate but not in general
 
         d1_adj_adj = d1_adj.adjoint
         assert isinstance(d1_adj_adj, CircuitComponent)
         assert d1_adj_adj.wires == d1.wires
-        assert d1_adj_adj.parameter_set == d1_adj.parameter_set
-        assert d1_adj_adj.parameter_set == d1.parameter_set
+        assert d1_adj_adj.parameters == d1_adj.parameters
+        assert d1_adj_adj.parameters == d1.parameters
         assert d1_adj_adj.ansatz == d1.ansatz
 
     def test_dual(self):
@@ -151,14 +151,14 @@ class TestCircuitComponent:
         assert isinstance(d1_dual, CircuitComponent)
         assert d1_dual.name == d1.name
         assert d1_dual.wires == d1.wires.dual
-        assert d1_dual.parameter_set == d1.parameter_set
+        assert d1_dual.parameters == d1.parameters
         assert (vac >> d1 >> d1_dual).ansatz == vac.ansatz
         assert (vac >> d1_dual >> d1).ansatz == vac.ansatz
 
         d1_dual_dual = d1_dual.dual
         assert isinstance(d1_dual_dual, CircuitComponent)
-        assert d1_dual_dual.parameter_set == d1_dual.parameter_set
-        assert d1_dual_dual.parameter_set == d1.parameter_set
+        assert d1_dual_dual.parameters == d1_dual.parameters
+        assert d1_dual_dual.parameters == d1.parameters
         assert d1_dual_dual.wires == d1.wires
         assert d1_dual_dual.ansatz == d1.ansatz
 
@@ -170,7 +170,7 @@ class TestCircuitComponent:
         )
         d1_cp = d1._light_copy()
 
-        assert d1_cp.parameter_set is d1.parameter_set
+        assert d1_cp.parameters is d1.parameters
         assert d1_cp.ansatz is d1.ansatz
         assert d1_cp.wires is not d1.wires
 
@@ -180,13 +180,13 @@ class TestCircuitComponent:
 
         d89 = DisplacedSqueezed([8, 9], x=[1, 2], y=3, r_trainable=True)
         d67 = d89.on([6, 7])
-        assert isinstance(d67.x, Constant)
-        assert math.allclose(d89.x.value, d67.x.value)
-        assert isinstance(d67.y, Constant)
-        assert math.allclose(d89.y.value, d67.y.value)
-        assert isinstance(d67.r, Variable)
-        assert math.allclose(d89.r.value, d67.r.value)
-        assert bool(d67.parameter_set) is True
+        assert isinstance(d67.parameters.x, Constant)
+        assert math.allclose(d89.parameters.x.value, d67.parameters.x.value)
+        assert isinstance(d67.parameters.y, Constant)
+        assert math.allclose(d89.parameters.y.value, d67.parameters.y.value)
+        assert isinstance(d67.parameters.r, Variable)
+        assert math.allclose(d89.parameters.r.value, d67.parameters.r.value)
+        assert bool(d67.parameters) is True
         assert d67.ansatz is d89.ansatz
 
     def test_on_error(self):

--- a/tests/test_lab_dev/test_circuit_components_utils/test_b_to_ps.py
+++ b/tests/test_lab_dev/test_circuit_components_utils/test_b_to_ps.py
@@ -48,7 +48,7 @@ class TestBtoPS:
         kets = btops.wires.ket.indices
         assert adjoint_btops.ansatz == btops.ansatz.reorder(kets + bras).conj
         assert adjoint_btops.wires == btops.wires.adjoint
-        assert adjoint_btops.s == btops.s
+        assert adjoint_btops.parameters.s == btops.parameters.s
 
     def test_dual(self):
         btops = BtoPS([0], 0)
@@ -60,7 +60,7 @@ class TestBtoPS:
         ob = btops.wires.bra.output.indices
         assert dual_btops.ansatz == btops.ansatz.reorder(ib + ob + ik + ok).conj
         assert dual_btops.wires == btops.wires.dual
-        assert dual_btops.s == btops.s
+        assert dual_btops.parameters.s == btops.parameters.s
 
     def test_inverse(self):
         btops = BtoPS([0], 0)

--- a/tests/test_lab_dev/test_circuit_components_utils/test_b_to_q.py
+++ b/tests/test_lab_dev/test_circuit_components_utils/test_b_to_q.py
@@ -40,7 +40,7 @@ class TestBtoQ:
         kets = btoq.wires.ket.indices
         assert adjoint_btoq.ansatz == btoq.ansatz.reorder(kets).conj
         assert adjoint_btoq.wires == btoq.wires.adjoint
-        assert adjoint_btoq.phi == btoq.phi
+        assert adjoint_btoq.parameters.phi == btoq.parameters.phi
 
     def test_dual(self):
         btoq = BtoQ([0], 0.5)
@@ -50,7 +50,7 @@ class TestBtoQ:
         ik = dual_btoq.wires.ket.input.indices
         assert dual_btoq.ansatz == btoq.ansatz.reorder(ik + ok).conj
         assert dual_btoq.wires == btoq.wires.dual
-        assert dual_btoq.phi == btoq.phi
+        assert dual_btoq.parameters.phi == btoq.parameters.phi
 
     def test_inverse(self):
         btoq = BtoQ([0], 0.5)

--- a/tests/test_lab_dev/test_states/test_bargmann_eigenstate.py
+++ b/tests/test_lab_dev/test_states/test_bargmann_eigenstate.py
@@ -31,7 +31,7 @@ class TestBargmannEigenstate:
         "Tests the initialization."
         be = BargmannEigenstate([0, 1], [0.1, 0.2])
         assert be.name == "BargmannEigenstate"
-        assert math.allclose(be.alpha.value, [0.1, 0.2])
+        assert math.allclose(be.parameters.alpha.value, [0.1, 0.2])
         assert be.modes == [0, 1]
         assert math.allclose(be.ansatz.b[0], [0.1, 0.2])
         assert math.allclose(be.ansatz.A[0], math.zeros((2, 2)))

--- a/tests/test_lab_dev/test_states/test_coherent.py
+++ b/tests/test_lab_dev/test_states/test_coherent.py
@@ -52,13 +52,13 @@ class TestCoherent:
         state3 = Coherent([0], 1, 1, y_trainable=True, y_bounds=(-2, 2))
 
         with pytest.raises(AttributeError):
-            state1.x.value = 3
+            state1.parameters.x.value = 3
 
-        state2.x.value = 2
-        assert state2.x.value == 2
+        state2.parameters.x.value = 2
+        assert state2.parameters.x.value == 2
 
-        state3.y.value = 2
-        assert state3.y.value == 2
+        state3.parameters.y.value = 2
+        assert state3.parameters.y.value == 2
 
     def test_representation(self):
         rep1 = Coherent(modes=[0], x=0.1, y=0.2).ansatz

--- a/tests/test_lab_dev/test_states/test_displaced_squeezed.py
+++ b/tests/test_lab_dev/test_states/test_displaced_squeezed.py
@@ -53,13 +53,13 @@ class TestDisplacedSqueezed:
         state3 = DisplacedSqueezed([0], 1, 1, y_trainable=True, y_bounds=(-2, 2))
 
         with pytest.raises(AttributeError):
-            state1.x.value = 3
+            state1.parameters.x.value = 3
 
-        state2.x.value = 2
-        assert state2.x.value == 2
+        state2.parameters.x.value = 2
+        assert state2.parameters.x.value == 2
 
-        state3.y.value = 2
-        assert state3.y.value == 2
+        state3.parameters.y.value = 2
+        assert state3.parameters.y.value == 2
 
     @pytest.mark.parametrize("modes,x,y,r,phi", zip(modes, x, y, r, phi))
     def test_representation(self, modes, x, y, r, phi):

--- a/tests/test_lab_dev/test_states/test_gstate.py
+++ b/tests/test_lab_dev/test_states/test_gstate.py
@@ -32,7 +32,7 @@ class TestGKet:
         gket = GKet([0, 1])
 
         assert gket.modes == [0, 1]
-        assert gket.symplectic.value.shape == (4, 4)
+        assert gket.parameters.symplectic.value.shape == (4, 4)
         assert gket.name == "GKet"
         assert math.allclose(gket.probability, 1.0)
 
@@ -40,7 +40,7 @@ class TestGKet:
         "Tests is the attributes are consistent"
 
         g = GKet([0])
-        sym = g.symplectic.value
+        sym = g.parameters.symplectic.value
         u = Unitary.from_symplectic([0], sym)
         assert g == Vacuum([0]) >> u
 
@@ -66,8 +66,8 @@ class TestGDM:
 
         assert rho.modes == [0, 1]
         assert rho.name == "GDM"
-        assert math.allclose(rho.beta.value, math.astensor([0.2, 0.3]))
-        assert rho.symplectic.value.shape == (4, 4)
+        assert math.allclose(rho.parameters.beta.value, math.astensor([0.2, 0.3]))
+        assert rho.parameters.symplectic.value.shape == (4, 4)
         assert math.allclose(rho.probability, 1.0)
 
     def test_getitem(self):

--- a/tests/test_lab_dev/test_states/test_ket.py
+++ b/tests/test_lab_dev/test_states/test_ket.py
@@ -376,30 +376,30 @@ class TestKet:  # pylint: disable=too-many-public-methods
         x = math.asnumpy([0, 1, 2])
         s = DisplacedSqueezed(modes, x=x, y=3, y_trainable=True, y_bounds=(0, 6))
 
-        assert np.all(s.y.value == 3)
-        assert s.y.value.shape == (len(modes),)
-        assert s.r.value.shape == (len(modes),)
-        assert s.phi.value.shape == (len(modes),)
+        assert np.all(s.parameters.y.value == 3)
+        assert s.parameters.y.value.shape == (len(modes),)
+        assert s.parameters.r.value.shape == (len(modes),)
+        assert s.parameters.phi.value.shape == (len(modes),)
 
         si = s[m]
         assert isinstance(si, DisplacedSqueezed)
         assert si == DisplacedSqueezed(m, x=x[idx], y=3, y_trainable=True, y_bounds=(0, 6))
 
-        assert isinstance(si.x, Constant)
-        assert math.allclose(si.x.value, x[idx])
+        assert isinstance(si.parameters.x, Constant)
+        assert math.allclose(si.parameters.x.value, x[idx])
 
-        assert isinstance(si.y, Variable)
-        assert np.all(si.y.value == 3)
-        assert si.y.value.shape == (len(idx),)
-        assert si.y.bounds == s.y.bounds
+        assert isinstance(si.parameters.y, Variable)
+        assert np.all(si.parameters.y.value == 3)
+        assert si.parameters.y.value.shape == (len(idx),)
+        assert si.parameters.y.bounds == s.parameters.y.bounds
 
-        assert isinstance(si.r, Constant)
-        assert np.all(si.r.value == 0)
-        assert si.r.value.shape == (len(idx),)
+        assert isinstance(si.parameters.r, Constant)
+        assert np.all(si.parameters.r.value == 0)
+        assert si.parameters.r.value.shape == (len(idx),)
 
-        assert isinstance(si.phi, Constant)
-        assert np.all(si.phi.value == 0)
-        assert si.phi.value.shape == (len(idx),)
+        assert isinstance(si.parameters.phi, Constant)
+        assert np.all(si.parameters.phi.value == 0)
+        assert si.parameters.phi.value.shape == (len(idx),)
 
     def test_private_batched_properties(self):
         cat = Coherent([0], x=1.0) + Coherent([0], x=-1.0)  # used as a batch

--- a/tests/test_lab_dev/test_states/test_quadrature_eigenstate.py
+++ b/tests/test_lab_dev/test_states/test_quadrature_eigenstate.py
@@ -48,8 +48,8 @@ class TestQuadratureEigenstate:
         assert state.name == "QuadratureEigenstate"
         assert state.modes == [modes] if not isinstance(modes, list) else sorted(modes)
         assert state.L2_norm == np.inf
-        assert np.allclose(state.x.value, x)
-        assert np.allclose(state.phi.value, phi)
+        assert np.allclose(state.parameters.x.value, x)
+        assert np.allclose(state.parameters.phi.value, phi)
 
     def test_init_error(self):
         with pytest.raises(ValueError, match="x"):
@@ -78,13 +78,13 @@ class TestQuadratureEigenstate:
         state3 = QuadratureEigenstate([0, 1], 1, 1, phi_trainable=True, phi_bounds=(-2, 2))
 
         with pytest.raises(AttributeError):
-            state1.x.value = 3
+            state1.parameters.x.value = 3
 
-        state2.x.value = 2
-        assert state2.x.value == 2
+        state2.parameters.x.value = 2
+        assert state2.parameters.x.value == 2
 
-        state3.phi.value = 2
-        assert state3.phi.value == 2
+        state3.parameters.phi.value = 2
+        assert state3.parameters.phi.value == 2
 
     def test_with_coherent(self):
         val0 = Coherent([0], 0, 0) >> QuadratureEigenstate([0], 0, 0).dual

--- a/tests/test_lab_dev/test_states/test_squeezed_vacuum.py
+++ b/tests/test_lab_dev/test_states/test_squeezed_vacuum.py
@@ -55,13 +55,13 @@ class TestSqueezedVacuum:
         state3 = SqueezedVacuum([0], 1, 1, phi_trainable=True, phi_bounds=(-2, 2))
 
         with pytest.raises(AttributeError):
-            state1.r.value = 3
+            state1.parameters.r.value = 3
 
-        state2.r.value = 2
-        assert state2.r.value == 2
+        state2.parameters.r.value = 2
+        assert state2.parameters.r.value == 2
 
-        state3.phi.value = 2
-        assert state3.phi.value == 2
+        state3.parameters.phi.value = 2
+        assert state3.parameters.phi.value == 2
 
     @pytest.mark.parametrize("modes,r,phi", zip(modes, r, phi))
     def test_representation(self, modes, r, phi):

--- a/tests/test_lab_dev/test_states/test_two_mode_squeezed_vacuum.py
+++ b/tests/test_lab_dev/test_states/test_two_mode_squeezed_vacuum.py
@@ -51,13 +51,13 @@ class TestTwoModeSqueezedVacuum:
         state3 = TwoModeSqueezedVacuum([0, 1], 1, 1, phi_trainable=True, phi_bounds=(-2, 2))
 
         with pytest.raises(AttributeError):
-            state1.r.value = 3
+            state1.parameters.r.value = 3
 
-        state2.r.value = 2
-        assert state2.r.value == 2
+        state2.parameters.r.value = 2
+        assert state2.parameters.r.value == 2
 
-        state3.phi.value = 2
-        assert state3.phi.value == 2
+        state3.parameters.phi.value = 2
+        assert state3.parameters.phi.value == 2
 
     @pytest.mark.parametrize("modes,r,phi", zip(modes, r, phi))
     def test_representation(self, modes, r, phi):

--- a/tests/test_lab_dev/test_transformations/test_amplifier.py
+++ b/tests/test_lab_dev/test_transformations/test_amplifier.py
@@ -58,10 +58,10 @@ class TestAmplifier:
         gate2 = Amplifier([0], 1.1, gain_trainable=True, gain_bounds=(1.0, 1.5))
 
         with pytest.raises(AttributeError):
-            gate1.gain.value = 1.7
+            gate1.parameters.gain.value = 1.7
 
-        gate2.gain.value = 1.5
-        assert gate2.gain.value == 1.5
+        gate2.parameters.gain.value = 1.5
+        assert gate2.parameters.gain.value == 1.5
 
     def test_representation_error(self):
         with pytest.raises(ValueError):

--- a/tests/test_lab_dev/test_transformations/test_attenuator.py
+++ b/tests/test_lab_dev/test_transformations/test_attenuator.py
@@ -56,10 +56,10 @@ class TestAttenuator:
         )
 
         with pytest.raises(AttributeError):
-            gate1.transmissivity.value = 0.3
+            gate1.parameters.transmissivity.value = 0.3
 
-        gate2.transmissivity.value = 0.2
-        assert gate2.transmissivity.value == 0.2
+        gate2.parameters.transmissivity.value = 0.2
+        assert gate2.parameters.transmissivity.value == 0.2
 
     def test_representation_error(self):
         with pytest.raises(ValueError):

--- a/tests/test_lab_dev/test_transformations/test_bsgate.py
+++ b/tests/test_lab_dev/test_transformations/test_bsgate.py
@@ -37,8 +37,8 @@ class TestBSgate:
 
         assert gate.name == "BSgate"
         assert gate.modes == [0, 1]
-        assert gate.theta.value == 2
-        assert gate.phi.value == 3
+        assert gate.parameters.theta.value == 2
+        assert gate.parameters.phi.value == 3
 
     def test_init_error(self):
         with pytest.raises(ValueError, match="Expected a pair"):
@@ -77,10 +77,10 @@ class TestBSgate:
         gate3 = BSgate([0, 1], 1, 1, phi_trainable=True, phi_bounds=(-2, 2))
 
         with pytest.raises(AttributeError):
-            gate1.theta.value = 3
+            gate1.parameters.theta.value = 3
 
-        gate2.theta.value = 2
-        assert gate2.theta.value == 2
+        gate2.parameters.theta.value = 2
+        assert gate2.parameters.theta.value == 2
 
-        gate3.phi.value = 2
-        assert gate3.phi.value == 2
+        gate3.parameters.phi.value = 2
+        assert gate3.parameters.phi.value == 2

--- a/tests/test_lab_dev/test_transformations/test_cxgate.py
+++ b/tests/test_lab_dev/test_transformations/test_cxgate.py
@@ -35,7 +35,7 @@ class TestCXgate:
         cx = CXgate([0, 1], 0.3)
         assert cx.modes == [0, 1]
         assert cx.name == "CXgate"
-        assert cx.s.value == 0.3
+        assert cx.parameters.s.value == 0.3
 
         with pytest.raises(
             ValueError,

--- a/tests/test_lab_dev/test_transformations/test_czgate.py
+++ b/tests/test_lab_dev/test_transformations/test_czgate.py
@@ -35,7 +35,7 @@ class TestCZgate:
         cz = CZgate([0, 1], 0.3)
         assert cz.modes == [0, 1]
         assert cz.name == "CZgate"
-        assert cz.s.value == 0.3
+        assert cz.parameters.s.value == 0.3
 
         with pytest.raises(
             ValueError,

--- a/tests/test_lab_dev/test_transformations/test_dgate.py
+++ b/tests/test_lab_dev/test_transformations/test_dgate.py
@@ -77,17 +77,17 @@ class TestDgate:
         gate3 = Dgate([0], 1, 1, y_trainable=True, y_bounds=(-2, 2))
 
         with pytest.raises(AttributeError):
-            gate1.x.value = 3
+            gate1.parameters.x.value = 3
 
-        gate2.x.value = 2
-        assert gate2.x.value == 2
+        gate2.parameters.x.value = 2
+        assert gate2.parameters.x.value == 2
 
-        gate3.y.value = 2
-        assert gate3.y.value == 2
+        gate3.parameters.y.value = 2
+        assert gate3.parameters.y.value == 2
 
         gate_fock = gate3.to_fock()
         assert isinstance(gate_fock.ansatz, ArrayAnsatz)
-        assert gate_fock.y.value == 2
+        assert gate_fock.parameters.y.value == 2
 
     def test_representation_error(self):
         with pytest.raises(ValueError):

--- a/tests/test_lab_dev/test_transformations/test_fockdamping.py
+++ b/tests/test_lab_dev/test_transformations/test_fockdamping.py
@@ -37,7 +37,7 @@ class TestFockDamping:
 
         assert gate.name == "FockDamping"
         assert gate.modes == [modes] if not isinstance(modes, list) else sorted(modes)
-        assert np.allclose(gate.damping.value, damping)
+        assert np.allclose(gate.parameters.damping.value, damping)
 
     def test_representation(self):
         rep1 = FockDamping(modes=[0], damping=0.1).ansatz
@@ -62,10 +62,10 @@ class TestFockDamping:
         gate2 = FockDamping([0], 0.1, damping_trainable=True, damping_bounds=(0.0, 0.2))
 
         with pytest.raises(AttributeError):
-            gate1.damping.value = 0.3
+            gate1.parameters.damping.value = 0.3
 
-        gate2.damping.value = 0.2
-        assert gate2.damping.value == 0.2
+        gate2.parameters.damping.value = 0.2
+        assert gate2.parameters.damping.value == 0.2
 
     def test_representation_error(self):
         with pytest.raises(ValueError):

--- a/tests/test_lab_dev/test_transformations/test_mzgate.py
+++ b/tests/test_lab_dev/test_transformations/test_mzgate.py
@@ -33,13 +33,13 @@ class TestMZgate:
         "Tests the initialization of an MZgate object"
         mz = MZgate([0, 1], 0.1, 0.2, internal=True)
         assert mz.modes == [0, 1]
-        assert mz.phi_a.value == 0.1
-        assert mz.phi_b.value == 0.2
+        assert mz.parameters.phi_a.value == 0.1
+        assert mz.parameters.phi_b.value == 0.2
         assert mz.name == "MZgate"
 
         mz = MZgate([1, 2])
-        assert mz.phi_a.value == 0
-        assert mz.phi_b.value == 0
+        assert mz.parameters.phi_a.value == 0
+        assert mz.parameters.phi_b.value == 0
 
     @pytest.mark.parametrize("phi_a", [0, np.random.random(), np.pi / 2])
     def test_application(self, phi_a):

--- a/tests/test_lab_dev/test_transformations/test_pgate.py
+++ b/tests/test_lab_dev/test_transformations/test_pgate.py
@@ -33,7 +33,7 @@ class TestPgate:
         up = Pgate([0, 1], 0.3)
         assert up.modes == [0, 1]
         assert up.name == "Pgate"
-        assert up.shearing.value == 0.3
+        assert up.parameters.shearing.value == 0.3
 
     @pytest.mark.parametrize("s", [0.1, 0.5, 1])
     def test_application(self, s):

--- a/tests/test_lab_dev/test_transformations/test_phasenoise.py
+++ b/tests/test_lab_dev/test_transformations/test_phasenoise.py
@@ -34,7 +34,7 @@ class TestPhaseNoise:
         "Tests the PhaseNoise initialization."
         ch = PhaseNoise([0, 1], 0.2)
         assert ch.name == "PhaseNoise"
-        assert ch.phase_stdev.value == 0.2
+        assert ch.parameters.phase_stdev.value == 0.2
         assert ch.modes == [0, 1]
         assert ch.ansatz is None
 

--- a/tests/test_lab_dev/test_transformations/test_rgate.py
+++ b/tests/test_lab_dev/test_transformations/test_rgate.py
@@ -89,10 +89,10 @@ class TestRgate:
         gate2 = Rgate([0], 1, True, (-2, 2))
 
         with pytest.raises(AttributeError):
-            gate1.phi.value = 3
+            gate1.parameters.phi.value = 3
 
-        gate2.phi.value = 2
-        assert gate2.phi.value == 2
+        gate2.parameters.phi.value = 2
+        assert gate2.parameters.phi.value == 2
 
     def test_representation_error(self):
         with pytest.raises(ValueError):

--- a/tests/test_lab_dev/test_transformations/test_s2gate.py
+++ b/tests/test_lab_dev/test_transformations/test_s2gate.py
@@ -38,8 +38,8 @@ class TestS2gate:
 
         assert gate.name == "S2gate"
         assert gate.modes == [0, 1]
-        assert gate.r.value == 2
-        assert gate.phi.value == 1
+        assert gate.parameters.r.value == 2
+        assert gate.parameters.phi.value == 1
 
     def test_init_error(self):
         with pytest.raises(ValueError, match="Expected a pair"):
@@ -68,13 +68,13 @@ class TestS2gate:
         gate3 = S2gate([0, 1], 1, 1, phi_trainable=True, phi_bounds=(-2, 2))
 
         with pytest.raises(AttributeError):
-            gate1.r.value = 3
+            gate1.parameters.r.value = 3
 
-        gate2.r.value = 2
-        assert gate2.r.value == 2
+        gate2.parameters.r.value = 2
+        assert gate2.parameters.r.value == 2
 
-        gate3.phi.value = 2
-        assert gate3.phi.value == 2
+        gate3.parameters.phi.value = 2
+        assert gate3.parameters.phi.value == 2
 
     def test_operation(self):
         rep1 = (Vacuum([0]) >> Vacuum([1]) >> S2gate(modes=[0, 1], r=1, phi=0.5)).ansatz

--- a/tests/test_lab_dev/test_transformations/test_sgate.py
+++ b/tests/test_lab_dev/test_transformations/test_sgate.py
@@ -94,13 +94,13 @@ class TestSgate:
         gate3 = Sgate([0], 1, 1, phi_trainable=True, phi_bounds=(-2, 2))
 
         with pytest.raises(AttributeError):
-            gate1.r.value = 3
+            gate1.parameters.r.value = 3
 
-        gate2.r.value = 2
-        assert gate2.r.value == 2
+        gate2.parameters.r.value = 2
+        assert gate2.parameters.r.value == 2
 
-        gate3.phi.value = 2
-        assert gate3.phi.value == 2
+        gate3.parameters.phi.value = 2
+        assert gate3.parameters.phi.value == 2
 
     def test_representation_error(self):
         with pytest.raises(ValueError):


### PR DESCRIPTION
**Context:** By exposing parameters in the parameter set of a circuit component we introduce the potential for name collisions. In fact, we already see this with `symplectic` on `Ggate`. The alternative is to access parameters only through the parameter set itself.  

**Description of the Change:** Removed `CircuitComponent._add_parameter` no longer exposing parameters at the `CircuitComponent` level. Renamed the attribute `parameter_set` to `parameters`.  Fixed the inits of states and transformations to properly handle parameters. Added the `symplectics.py` file to `physics`. 

**Benefits:** Fewer attribute name collisions. Parameters are properly handled now. 

**Possible Drawbacks:** Minor inconvenience having to specify `.parameters` 

