### PR TITLE
Light cleanup of class methods

### DIFF
--- a/mrmustard/lab_dev/states/base.py
+++ b/mrmustard/lab_dev/states/base.py
@@ -50,7 +50,7 @@ from mrmustard.utils.typing import (
 )
 
 from ..circuit_components import CircuitComponent
-from ..circuit_components_utils import BtoPS
+from ..circuit_components_utils import BtoPS, BtoQ
 
 
 __all__ = ["State"]
@@ -158,7 +158,6 @@ class State(CircuitComponent):
         return math.real(rep)
 
     @classmethod
-    @abstractmethod
     def from_bargmann(
         cls,
         modes: Sequence[int],
@@ -195,9 +194,9 @@ class State(CircuitComponent):
             ValueError: If the ``A`` or ``b`` have a shape that is inconsistent with
                 the number of modes.
         """
+        return cls.from_ansatz(modes, PolyExpAnsatz(*triple), name)
 
     @classmethod
-    @abstractmethod
     def from_fock(
         cls,
         modes: Sequence[int],
@@ -236,6 +235,7 @@ class State(CircuitComponent):
             ValueError: If the given array has a shape that is inconsistent with the number of
                 modes.
         """
+        return cls.from_ansatz(modes, ArrayAnsatz(array, batched), name)
 
     @classmethod
     @abstractmethod
@@ -320,6 +320,9 @@ class State(CircuitComponent):
             ValueError: If the given triple has shapes that are inconsistent
                 with the number of modes.
         """
+        QtoB = BtoQ(modes, phi).inverse()
+        Q = cls.from_ansatz(modes, PolyExpAnsatz(*triple))
+        return cls.from_ansatz(modes, (Q >> QtoB).ansatz, name)
 
     def phase_space(self, s: float) -> tuple:
         r"""

--- a/mrmustard/lab_dev/states/base.py
+++ b/mrmustard/lab_dev/states/base.py
@@ -295,7 +295,6 @@ class State(CircuitComponent):
         """
 
     @classmethod
-    @abstractmethod
     def from_quadrature(
         cls,
         modes: Sequence[int],

--- a/mrmustard/lab_dev/states/dm.py
+++ b/mrmustard/lab_dev/states/dm.py
@@ -109,25 +109,6 @@ class DM(State):
         return self._L2_norms / self._probabilities
 
     @classmethod
-    def from_bargmann(
-        cls,
-        modes: Sequence[int],
-        triple: tuple[ComplexMatrix, ComplexVector, complex],
-        name: str | None = None,
-    ) -> State:
-        return DM.from_ansatz(modes, PolyExpAnsatz(*triple), name)
-
-    @classmethod
-    def from_fock(
-        cls,
-        modes: Sequence[int],
-        array: ComplexTensor,
-        name: str | None = None,
-        batched: bool = False,
-    ) -> State:
-        return DM.from_ansatz(modes, ArrayAnsatz(array, batched), name)
-
-    @classmethod
     def from_ansatz(
         cls,
         modes: Sequence[int],
@@ -171,36 +152,6 @@ class DM(State):
             PolyExpAnsatz.from_function(fn=wigner_to_bargmann_rho, cov=cov, means=means),
             name,
         )
-
-    @classmethod
-    def from_quadrature(
-        cls,
-        modes: Sequence[int],
-        triple: tuple[ComplexMatrix, ComplexVector, complex],
-        phi: float = 0.0,
-        name: str | None = None,
-    ) -> State:
-        r"""
-        Initializes a state from a triple (A,b,c) that parametrizes the wavefunction
-        as `c * exp(0.5 z^T A z + b^T z)` in the quadrature representation.
-
-        Args:
-            modes: The modes of this state.
-            triple: The ``(A, b, c)`` triple.
-            phi: The angle of the quadrature. 0 corresponds to the x quadrature (default).
-            name: The name of this state.
-
-        Returns:
-            A state of type ``cls``.
-
-        Raises:
-            ValueError: If the given triple has shapes that are inconsistent
-                with the number of modes.
-        """
-
-        QtoB = BtoQ(modes, phi).inverse()
-        Q = DM.from_ansatz(modes, PolyExpAnsatz(*triple))
-        return DM.from_ansatz(modes, (Q >> QtoB).ansatz, name)
 
     @classmethod
     def random(cls, modes: Sequence[int], m: int | None = None, max_r: float = 1.0) -> DM:

--- a/mrmustard/lab_dev/states/dm.py
+++ b/mrmustard/lab_dev/states/dm.py
@@ -31,11 +31,11 @@ from mrmustard.physics.bargmann_utils import wigner_to_bargmann_rho
 from mrmustard.physics.gaussian_integrals import complex_gaussian_integral_2
 from mrmustard.physics.representations import Representation
 from mrmustard.physics.wires import Wires
-from mrmustard.utils.typing import ComplexMatrix, ComplexVector, ComplexTensor, RealVector
+from mrmustard.utils.typing import ComplexTensor, RealVector
 
 from .base import State, _validate_operator, OperatorType
 from ..circuit_components import CircuitComponent
-from ..circuit_components_utils import BtoQ, TraceOut
+from ..circuit_components_utils import TraceOut
 
 from ..utils import shape_check
 

--- a/mrmustard/lab_dev/states/dm.py
+++ b/mrmustard/lab_dev/states/dm.py
@@ -31,7 +31,7 @@ from mrmustard.physics.bargmann_utils import wigner_to_bargmann_rho
 from mrmustard.physics.gaussian_integrals import complex_gaussian_integral_2
 from mrmustard.physics.representations import Representation
 from mrmustard.physics.wires import Wires, ReprEnum
-from mrmustard.utils.typing import ComplexMatrix, ComplexVector, ComplexTensor, RealVector
+from mrmustard.utils.typing import ComplexTensor, RealVector
 
 from .base import State, _validate_operator, OperatorType
 from ..circuit_components import CircuitComponent

--- a/mrmustard/lab_dev/states/ket.py
+++ b/mrmustard/lab_dev/states/ket.py
@@ -32,8 +32,6 @@ from mrmustard.physics.gaussian import purity
 from mrmustard.physics.representations import Representation
 from mrmustard.physics.wires import Wires
 from mrmustard.utils.typing import (
-    ComplexMatrix,
-    ComplexVector,
     ComplexTensor,
     RealVector,
     Scalar,
@@ -43,7 +41,7 @@ from mrmustard.utils.typing import (
 from .base import State, _validate_operator, OperatorType
 from .dm import DM
 from ..circuit_components import CircuitComponent
-from ..circuit_components_utils import BtoQ, TraceOut
+from ..circuit_components_utils import TraceOut
 from ..utils import shape_check
 
 __all__ = ["Ket"]
@@ -88,25 +86,6 @@ class Ket(State):
         return self._L2_norms
 
     @classmethod
-    def from_bargmann(
-        cls,
-        modes: Sequence[int],
-        triple: tuple[ComplexMatrix, ComplexVector, complex],
-        name: str | None = None,
-    ) -> State:
-        return Ket.from_ansatz(modes, PolyExpAnsatz(*triple), name)
-
-    @classmethod
-    def from_fock(
-        cls,
-        modes: Sequence[int],
-        array: ComplexTensor,
-        name: str | None = None,
-        batched: bool = False,
-    ) -> State:
-        return Ket.from_ansatz(modes, ArrayAnsatz(array, batched), name)
-
-    @classmethod
     def from_ansatz(
         cls,
         modes: Sequence[int],
@@ -143,19 +122,6 @@ class Ket(State):
             coeff * PolyExpAnsatz.from_function(fn=wigner_to_bargmann_psi, cov=cov, means=means),
             name,
         )
-
-    @classmethod
-    def from_quadrature(
-        cls,
-        modes: Sequence[int],
-        triple: tuple[ComplexMatrix, ComplexVector, complex],
-        phi: float = 0.0,
-        name: str | None = None,
-    ) -> State:
-
-        QtoB = BtoQ(modes, phi).inverse()
-        Q = Ket.from_ansatz(modes, PolyExpAnsatz(*triple))
-        return Ket.from_ansatz(modes, (Q >> QtoB).ansatz, name)
 
     @classmethod
     def random(cls, modes: Sequence[int], max_r: float = 1.0) -> Ket:

--- a/mrmustard/lab_dev/transformations/base.py
+++ b/mrmustard/lab_dev/transformations/base.py
@@ -91,7 +91,7 @@ class Transformation(CircuitComponent):
         array: ComplexTensor,
         batched: bool = False,
         name: str | None = None,
-    ) -> Unitary:
+    ) -> Transformation:
         r"""
         Initializes a transformation of type ``cls`` given modes and a fock array.
 


### PR DESCRIPTION
**Context:** Noticed we can cleanup some of our class methods on `states` and `transformations`. I believe a lot of this is just remnants of the Representation refactor where now we can rely on `from_ansatz` and have `cls` handle the proper return types. 

**Description of the Change:** Some abstract methods are now defined and removed unnecessary code.