### PR TITLE
Ability to choose DM ordering of wires

### DIFF
--- a/mrmustard/lab_dev/states/dm.py
+++ b/mrmustard/lab_dev/states/dm.py
@@ -303,7 +303,7 @@ class DM(State):
         Returns:
             array: The Fock representation of this component.
         """
-        array = super()._representation.fock_array(shape or self.auto_shape(), batched)
+        array = super().fock_array(shape or self.auto_shape(), batched)
         if standard_order:
             m = self.n_modes
             axes = tuple(range(m, 2 * m)) + tuple(

--- a/mrmustard/lab_dev/states/dm.py
+++ b/mrmustard/lab_dev/states/dm.py
@@ -288,21 +288,21 @@ class DM(State):
         self, shape: int | Sequence[int] | None = None, batched=False, standard_order: bool = False
     ) -> ComplexTensor:
         r"""
-        Returns an array representation of this component in the Fock basis with the given shape.
-        If the shape is not given, it defaults to the ``auto_shape`` of the component if it is
-        available, otherwise it defaults to the value of ``AUTOSHAPE_MAX`` in the settings.
-The ``standard_order`` boolean argument lets one choose the standard convention for the index ordering of the density matrix. For a single mode, if ``standard_order=True`` the returned 2D array :math:`rho_{ij}` has a first index corresponding to the "left" (ket) side of the matrix and the second index to the "right" (bra) side. Otherwise, MrMustard's convention is that the bra index comes before the ket index. In other words, for a single mode, the array returned by ``fock_array`` with ``standard_order=False`` (false by default) is the transpose of the standard density matrix. For multiple modes, the same applies to each pair of indices of each mode.
+                Returns an array representation of this component in the Fock basis with the given shape.
+                If the shape is not given, it defaults to the ``auto_shape`` of the component if it is
+                available, otherwise it defaults to the value of ``AUTOSHAPE_MAX`` in the settings.
+        The ``standard_order`` boolean argument lets one choose the standard convention for the index ordering of the density matrix. For a single mode, if ``standard_order=True`` the returned 2D array :math:`rho_{ij}` has a first index corresponding to the "left" (ket) side of the matrix and the second index to the "right" (bra) side. Otherwise, MrMustard's convention is that the bra index comes before the ket index. In other words, for a single mode, the array returned by ``fock_array`` with ``standard_order=False`` (false by default) is the transpose of the standard density matrix. For multiple modes, the same applies to each pair of indices of each mode.
 
-        Args:
-            shape: The shape of the returned representation. If ``shape`` is given as an ``int``,
-                it is broadcasted to all the dimensions. If not given, it is estimated.
-            batched: Whether the returned representation is batched or not. If ``False`` (default)
-                it will squeeze the batch dimension if it is 1.
-            standard_order: The ordering of the wires. If ``standard_order = False``, then the conventional ordering
-            of bra-ket is chosen. However, if one wants to get the actual matrix representation in the
-            standard conventions of linear algebra, then ``standard_order=True`` must be chosen.
-        Returns:
-            array: The Fock representation of this component.
+                Args:
+                    shape: The shape of the returned representation. If ``shape`` is given as an ``int``,
+                        it is broadcasted to all the dimensions. If not given, it is estimated.
+                    batched: Whether the returned representation is batched or not. If ``False`` (default)
+                        it will squeeze the batch dimension if it is 1.
+                    standard_order: The ordering of the wires. If ``standard_order = False``, then the conventional ordering
+                    of bra-ket is chosen. However, if one wants to get the actual matrix representation in the
+                    standard conventions of linear algebra, then ``standard_order=True`` must be chosen.
+                Returns:
+                    array: The Fock representation of this component.
         """
         array = super().fock_array(shape or self.auto_shape(), batched)
         if standard_order:

--- a/mrmustard/lab_dev/states/dm.py
+++ b/mrmustard/lab_dev/states/dm.py
@@ -17,7 +17,7 @@ This module contains the defintion of the density matrix class ``DM``.
 """
 
 from __future__ import annotations
-from typing import Collection
+from typing import Collection, Sequence
 
 from itertools import product
 import warnings
@@ -283,6 +283,34 @@ class DM(State):
             result = (self @ operator) >> TraceOut(self.modes)
 
         return result
+
+    def fock_array(
+        self, shape: int | Sequence[int] | None = None, batched=False, MM_order: bool = True
+    ) -> ComplexTensor:
+        r"""
+        Returns an array representation of this component in the Fock basis with the given shape.
+        If the shape is not given, it defaults to the ``auto_shape`` of the component if it is
+        available, otherwise it defaults to the value of ``AUTOSHAPE_MAX`` in the settings.
+
+        Args:
+            shape: The shape of the returned representation. If ``shape`` is given as an ``int``,
+                it is broadcasted to all the dimensions. If not given, it is estimated.
+            batched: Whether the returned representation is batched or not. If ``False`` (default)
+                it will squeeze the batch dimension if it is 1.
+            MM_order: The ordering of the wires. If ``MM_order = True``, then the conventional ordering
+            of bra-ket is chosen. However, if one wants to get the actual matrix representation in the
+            standard conventions of linear algebra, then ``MM_order=False`` must be chosen.
+        Returns:
+            array: The Fock representation of this component.
+        """
+        m = self.n_modes
+        axes = tuple(range(m, 2 * m)) + tuple(
+            range(m)
+        )  # to take care of multi-mode case, otherwise, for a single mode we could just use a simple transpose method
+        array = self._representation.fock_array(shape or self.auto_shape(), batched)
+        if not MM_order:
+            array = math.transpose(array, perm=axes)
+        return array
 
     def fock_distribution(self, cutoff: int) -> ComplexTensor:
         r"""

--- a/mrmustard/lab_dev/states/dm.py
+++ b/mrmustard/lab_dev/states/dm.py
@@ -285,7 +285,7 @@ class DM(State):
         return result
 
     def fock_array(
-        self, shape: int | Sequence[int] | None = None, batched=False, MM_order: bool = True
+        self, shape: int | Sequence[int] | None = None, batched=False, standard_order: bool = False
     ) -> ComplexTensor:
         r"""
         Returns an array representation of this component in the Fock basis with the given shape.
@@ -297,18 +297,18 @@ class DM(State):
                 it is broadcasted to all the dimensions. If not given, it is estimated.
             batched: Whether the returned representation is batched or not. If ``False`` (default)
                 it will squeeze the batch dimension if it is 1.
-            MM_order: The ordering of the wires. If ``MM_order = True``, then the conventional ordering
+            standard_order: The ordering of the wires. If ``standard_order = False``, then the conventional ordering
             of bra-ket is chosen. However, if one wants to get the actual matrix representation in the
-            standard conventions of linear algebra, then ``MM_order=False`` must be chosen.
+            standard conventions of linear algebra, then ``standard_order=True`` must be chosen.
         Returns:
             array: The Fock representation of this component.
         """
-        m = self.n_modes
-        axes = tuple(range(m, 2 * m)) + tuple(
-            range(m)
-        )  # to take care of multi-mode case, otherwise, for a single mode we could just use a simple transpose method
-        array = self._representation.fock_array(shape or self.auto_shape(), batched)
-        if not MM_order:
+        array = super()._representation.fock_array(shape or self.auto_shape(), batched)
+        if standard_order:
+            m = self.n_modes
+            axes = tuple(range(m, 2 * m)) + tuple(
+                range(m)
+            )  # to take care of multi-mode case, otherwise, for a single mode we could just use a simple transpose method
             array = math.transpose(array, perm=axes)
         return array
 

--- a/mrmustard/lab_dev/states/dm.py
+++ b/mrmustard/lab_dev/states/dm.py
@@ -291,6 +291,7 @@ class DM(State):
         Returns an array representation of this component in the Fock basis with the given shape.
         If the shape is not given, it defaults to the ``auto_shape`` of the component if it is
         available, otherwise it defaults to the value of ``AUTOSHAPE_MAX`` in the settings.
+The ``standard_order`` boolean argument lets one choose the standard convention for the index ordering of the density matrix. For a single mode, if ``standard_order=True`` the returned 2D array :math:`rho_{ij}` has a first index corresponding to the "left" (ket) side of the matrix and the second index to the "right" (bra) side. Otherwise, MrMustard's convention is that the bra index comes before the ket index. In other words, for a single mode, the array returned by ``fock_array`` with ``standard_order=False`` (false by default) is the transpose of the standard density matrix. For multiple modes, the same applies to each pair of indices of each mode.
 
         Args:
             shape: The shape of the returned representation. If ``shape`` is given as an ``int``,

--- a/tests/test_lab_dev/test_states/test_dm.py
+++ b/tests/test_lab_dev/test_states/test_dm.py
@@ -395,3 +395,12 @@ class TestDM:  # pylint:disable=too-many-public-methods
         rho = 2 * rho
         assert not rho.is_physical
         assert Ket.random(modes).dm().is_physical
+
+    def test_from_fock(self):
+        rho = Number([0], 0) + 1j * Number([0], 1)
+        rho = (Number([0], 0) + 1j * Number([0], 1)).dm()
+        rho_fock = rho.fock_array(MM_order=False)
+
+        assert math.allclose(
+            rho_fock, math.astensor([[1.0 + 0.0j, 0.0 - 1.0j], [0.0 + 1.0j, 1.0 + 0.0j]])
+        )

--- a/tests/test_lab_dev/test_states/test_dm.py
+++ b/tests/test_lab_dev/test_states/test_dm.py
@@ -399,7 +399,7 @@ class TestDM:  # pylint:disable=too-many-public-methods
     def test_from_fock(self):
         rho = Number([0], 0) + 1j * Number([0], 1)
         rho = (Number([0], 0) + 1j * Number([0], 1)).dm()
-        rho_fock = rho.fock_array(MM_order=False)
+        rho_fock = rho.fock_array(standard_order=True)
 
         assert math.allclose(
             rho_fock, math.astensor([[1.0 + 0.0j, 0.0 - 1.0j], [0.0 + 1.0j, 1.0 + 0.0j]])

--- a/tests/test_lab_dev/test_states/test_dm.py
+++ b/tests/test_lab_dev/test_states/test_dm.py
@@ -396,7 +396,7 @@ class TestDM:  # pylint:disable=too-many-public-methods
         assert not rho.is_physical
         assert Ket.random(modes).dm().is_physical
 
-    def test_from_fock(self):
+    def test_fock_array_ordering(self):
         rho = Number([0], 0) + 1j * Number([0], 1)
         rho = (Number([0], 0) + 1j * Number([0], 1)).dm()
         rho_fock = rho.fock_array(standard_order=True)

--- a/tests/test_lab_dev/test_transformations/test_transformations_base.py
+++ b/tests/test_lab_dev/test_transformations/test_transformations_base.py
@@ -21,7 +21,7 @@ import pytest
 
 from mrmustard import math
 from mrmustard.lab_dev.circuit_components import CircuitComponent
-from mrmustard.lab_dev.states import Vacuum, Coherent
+from mrmustard.lab_dev.states import Coherent, Vacuum
 from mrmustard.lab_dev.transformations import (
     Attenuator,
     Channel,
@@ -29,9 +29,9 @@ from mrmustard.lab_dev.transformations import (
     Identity,
     Map,
     Operation,
+    PhaseNoise,
     Sgate,
     Unitary,
-    PhaseNoise,
 )
 from mrmustard.physics.wires import Wires
 

--- a/tests/test_physics/test_wires.py
+++ b/tests/test_physics/test_wires.py
@@ -20,8 +20,10 @@ from unittest.mock import patch
 
 import pytest
 from ipywidgets import HTML
-from mrmustard.physics.wires import Wires
+
 from mrmustard.lab_dev.states import QuadratureEigenstate
+from mrmustard.physics.wires import Wires
+
 from ..conftest import skip_np
 
 


### PR DESCRIPTION
**Context:**
Currently, MM uses the non-standard ordering of wires when outputting DMs in Fock basis.

**Description of the Change:**
Added `MM_order` to the `from_fock` functionality of DMs so that by `MM_order = False` we get the standard convention back.

**Benefits:**
Easier for Fock manipulations. 

**Possible Drawbacks:**
None.

**Related GitHub Issues:**
None.