### PR TITLE
Fixing Ansatz contract signature

### DIFF
--- a/mrmustard/physics/ansatz/array_ansatz.py
+++ b/mrmustard/physics/ansatz/array_ansatz.py
@@ -126,11 +126,9 @@ class ArrayAnsatz(Ansatz):
     def contract(
         self,
         other: ArrayAnsatz,
-        idx1: int | tuple[int, ...] | None = None,
-        idx2: int | tuple[int, ...] | None = None,
+        idx1: int | tuple[int, ...] = tuple(),
+        idx2: int | tuple[int, ...] = tuple(),
     ) -> ArrayAnsatz:
-        idx1 = idx1 or ()
-        idx2 = idx2 or ()
         idx1 = (idx1,) if isinstance(idx1, int) else idx1
         idx2 = (idx2,) if isinstance(idx2, int) else idx2
         for i, j in zip(idx1, idx2):

--- a/mrmustard/physics/ansatz/base.py
+++ b/mrmustard/physics/ansatz/base.py
@@ -108,8 +108,8 @@ class Ansatz(ABC):
     def contract(
         self,
         other: Ansatz,
-        idx1: int | tuple[int, ...] | None = None,
-        idx2: int | tuple[int, ...] | None = None,
+        idx1: int | tuple[int, ...] = tuple(),
+        idx2: int | tuple[int, ...] = tuple(),
     ) -> Ansatz:
         r"""
         Contract two ansatz together.

--- a/mrmustard/physics/ansatz/polyexp_ansatz.py
+++ b/mrmustard/physics/ansatz/polyexp_ansatz.py
@@ -208,11 +208,9 @@ class PolyExpAnsatz(Ansatz):
     def contract(
         self,
         other: PolyExpAnsatz,
-        idx1: int | tuple[int, ...] | None = None,
-        idx2: int | tuple[int, ...] | None = None,
+        idx1: int | tuple[int, ...] = tuple(),
+        idx2: int | tuple[int, ...] = tuple(),
     ) -> PolyExpAnsatz:
-        idx1 = idx1 or ()
-        idx2 = idx2 or ()
         idx1 = (idx1,) if isinstance(idx1, int) else idx1
         idx2 = (idx2,) if isinstance(idx2, int) else idx2
         for i, j in zip(idx1, idx2):


### PR DESCRIPTION
**Context:** The Ansatz contract method was changing behaviour with it defaulting idxs to `None`. Thanks to @timmysilv for pointing out the issue.

**Description of the Change:** `Ansatz.contract`'s `idx1` and `idx2` no longer default to `None` but rather a `tuple` 
