### PR TITLE
Pass A,b and c as tensors than tuples to PolyExpAnsatz

### DIFF
--- a/mrmustard/physics/ansatz/polyexp_ansatz.py
+++ b/mrmustard/physics/ansatz/polyexp_ansatz.py
@@ -475,7 +475,7 @@ class PolyExpAnsatz(Ansatz):
                 )
             )
         A, b, c = zip(*Abc)
-        return PolyExpAnsatz(A=A, b=b, c=c)
+        return PolyExpAnsatz(A=math.astensor(A), b=math.astensor(b), c=math.astensor(c))
 
     def _call_none_single(self, Ai, bi, ci, zi):
         r"""


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new features must include a unit test.
      If you've fixed a bug or added code that should be tested, add a test to the
      test directory!

- [x] All new functions and code must be clearly commented and documented.
      If you do make documentation changes, make sure that the docs build and
      render correctly by running `make docs`.

- [x] Ensure that the test suite passes, by running `make test`.

- [x] Ensure that code and tests are properly formatted, by running `make format` or `black -l 100
      <filename>` on any relevant files. You will need to have the Black code format installed:
      `pip install black`.

- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
      change, and including a link back to the PR.

- [x] The Mr Mustard source code conforms to
      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/) except line length.
      We check all of our code against [Pylint](https://www.pylint.org/).
      To lint modified files, simply `pip install pylint`, and then
      run `pylint mrmustard/path/to/file.py`.

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
Backends other than Numpy are painfully slower when lists/tuples are passed. A typical victim of this behavior is: ```atleast_3d```, ```atleast_2d``` and the associated routines. TF is about 40x slower when a tuple is passed as input than a numpy array or tf tensor for these kind of functions. Can be checked using:
`import tensorflow as tf
import numpy as np
x_tuple = tuple(np.random.normal(size=(64_000, 2, 2)))
%timeit tf.experimental.numpy.atleast_3d(x_tuple)   # takes about 910 ms per loop
%timeit tf.experimental.numpy.atleast_3d(np.array(x_tuple))  # takes about 25 ms per loop
`

**Description of the Change:**
Convert to a backend appropriate tensor before initialization PolyExpAnsatz object.

**Benefits:**
Faster execution on backends other than Numpy.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A