### PR TITLE
Making S2gate of lab and lab_dev

### DIFF
--- a/mrmustard/lab_dev/transformations/s2gate.py
+++ b/mrmustard/lab_dev/transformations/s2gate.py
@@ -64,8 +64,8 @@ class S2gate(Unitary):
             A = \begin{bmatrix}
                     O & e^{i\phi}\tanh(r) & \sech(r) & 0 \\
                     e^{i\phi}\tanh(r) & 0 & 0 & \sech(r) \\
-                    \sech(r) & & 0 & 0 e^{i\phi}\tanh(r) \\
-                    O & \sech(r) & e^{i\phi}\tanh(r) & 0
+                    \sech(r) & & 0 & 0 -e^{i\phi}\tanh(r) \\
+                    O & \sech(r) & -e^{i\phi}\tanh(r) & 0
                 \end{bmatrix} \text{, }
             b = O_{4} \text{, and }
             c = \sech(r)

--- a/mrmustard/physics/triples.py
+++ b/mrmustard/physics/triples.py
@@ -526,9 +526,9 @@ def twomode_squeezing_gate_Abc(
     tanhr = math.diag(math.exp(1j * phi) * math.sinh(r) / math.cosh(r))
     sechr = math.diag(1 / math.cosh(r))
 
-    A_block1 = math.block([[O, -tanhr], [-tanhr, O]])
+    A_block1 = math.block([[O, tanhr], [tanhr, O]])
 
-    A_block2 = math.block([[O, math.conj(tanhr)], [math.conj(tanhr), O]])
+    A_block2 = math.block([[O, -math.conj(tanhr)], [-math.conj(tanhr), O]])
 
     A_block3 = math.block([[sechr, O], [O, sechr]])
 

--- a/tests/test_lab_dev/test_transformations/test_s2gate.py
+++ b/tests/test_lab_dev/test_transformations/test_s2gate.py
@@ -52,10 +52,10 @@ class TestS2gate:
 
         A_exp = [
             [
-                [0, -tanhr, sechr, 0],
-                [-tanhr, 0, 0, sechr],
-                [sechr, 0, 0, np.conj(tanhr)],
-                [0, sechr, np.conj(tanhr), 0],
+                [0, tanhr, sechr, 0],
+                [tanhr, 0, 0, sechr],
+                [sechr, 0, 0, -np.conj(tanhr)],
+                [0, sechr, -np.conj(tanhr), 0],
             ]
         ]
         assert math.allclose(rep1.A, A_exp)
@@ -77,7 +77,7 @@ class TestS2gate:
         assert gate3.parameters.phi.value == 2
 
     def test_operation(self):
-        rep1 = (Vacuum([0]) >> Vacuum([1]) >> S2gate(modes=[0, 1], r=1, phi=0.5)).ansatz
+        rep1 = (Vacuum([0]) >> Vacuum([1]) >> S2gate(modes=[0, 1], r=-1, phi=0.5)).ansatz
         rep2 = (TwoModeSqueezedVacuum(modes=[0, 1], r=1, phi=0.5)).ansatz
 
         assert math.allclose(rep1.A, rep2.A)


### PR DESCRIPTION
**Context:**
there is a discrepancy between lab and lab_dev in defining `S2gate` : squeezing parameter of one is the negative of the other.
 
**Description of the Change:**
Making `S2gate` of lab and lab_dev compatible by changing the lab_dev one.

**Benefits:**
Consistency.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None