### PR TITLE
Add the uv pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,7 @@ repos:
     rev: 22.12.0
     hooks:
     -   id: black
+-   repo: https://github.com/astral-sh/uv-pre-commit
+    rev: 0.5.23
+    hooks:
+      - id: uv-lock

--- a/uv.lock
+++ b/uv.lock
@@ -1589,7 +1589,7 @@ wheels = [
 
 [[package]]
 name = "mrmustard"
-version = "0.7.3"
+version = "1.0.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "grpcio" },


### PR DESCRIPTION
### **User description**
**Context:**
I ran `uv sync` and realized that I forgot to in #553 !

**Description of the Change:**
- Run `uv lock`
- Add the `uv-lock` pre-commit hook

**Benefits:**
People will not forget to run `uv lock` after making changes

**Possible Drawbacks:**
Won't do anything if you have not run `pre-commit install`

**Related GitHub Issues:**
Missed change from #553


___

### **PR Type**
enhancement, configuration changes


___

### **Description**
- Added a new `uv-lock` pre-commit hook to `.pre-commit-config.yaml`.

- Ensures `uv lock` is run after changes to maintain consistency.

- Helps prevent missed updates in pre-commit workflows.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.pre-commit-config.yaml</strong><dd><code>Add `uv-lock` hook to pre-commit configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.pre-commit-config.yaml

<li>Added a new repository <code>astral-sh/uv-pre-commit</code>.<br> <li> Included the <code>uv-lock</code> hook under the new repository.<br> <li> Ensures <code>uv lock</code> is executed as part of pre-commit checks.


</details>


  </td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/555/files#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>