### PR TITLE
atleast_nd

### DIFF
--- a/mrmustard/math/backend_manager.py
+++ b/mrmustard/math/backend_manager.py
@@ -293,7 +293,7 @@ class BackendManager:  # pylint: disable=too-many-public-methods, fixme
         Returns:
             The array with at least one dimension.
         """
-        return self._apply("atleast_1d", (array, dtype))
+        return self._apply("atleast_nd", (array, 1, dtype))
 
     def atleast_2d(self, array: Tensor, dtype=None) -> Tensor:
         r"""Returns an array with at least two dimensions.
@@ -306,12 +306,10 @@ class BackendManager:  # pylint: disable=too-many-public-methods, fixme
         Returns:
             The array with at least two dimensions.
         """
-        return self._apply("atleast_2d", (array, dtype))
+        return self._apply("atleast_nd", (array, 2, dtype))
 
     def atleast_3d(self, array: Tensor, dtype=None) -> Tensor:
-        r"""Returns an array with at least three dimensions by eventually inserting
-        new axes at the beginning. Note this is not the way atleast_3d works in numpy
-        and tensorflow, where it adds at the beginning and/or end.
+        r"""Returns an array with at least three dimensions.
 
         Args:
             array: The array to convert.
@@ -321,7 +319,21 @@ class BackendManager:  # pylint: disable=too-many-public-methods, fixme
         Returns:
             The array with at least three dimensions.
         """
-        return self._apply("atleast_3d", (array, dtype))
+        return self._apply("atleast_nd", (array, 3, dtype))
+
+    def atleast_nd(self, array: Tensor, n: int, dtype=None) -> Tensor:
+        r"""Returns an array with at least n dimensions. Note that dimensions are
+        prepended to meet the minimum number of dimensions.
+
+        Args:
+            array: The array to convert.
+            n: The minimum number of dimensions.
+            dtype: The data type of the array. If ``None``, the returned array
+                is of the same type as the given one.
+        Returns:
+            The array with at least n dimensions.
+        """
+        return self._apply("atleast_nd", (array, n, dtype))
 
     def block_diag(self, mat1: Matrix, mat2: Matrix) -> Matrix:
         r"""Returns a block diagonal matrix from the given matrices.

--- a/mrmustard/math/backend_numpy.py
+++ b/mrmustard/math/backend_numpy.py
@@ -96,17 +96,8 @@ class BackendNumpy(BackendBase):  # pragma: no cover
         array = np.array(array)
         return self.cast(array, dtype=dtype or array.dtype)
 
-    def atleast_1d(self, array: np.ndarray, dtype=None) -> np.ndarray:
-        return np.atleast_1d(self.astensor(array, dtype))
-
-    def atleast_2d(self, array: np.ndarray, dtype=None) -> np.ndarray:
-        return np.atleast_2d(self.astensor(array, dtype))
-
-    def atleast_3d(self, array: np.ndarray, dtype=None) -> np.ndarray:
-        array = self.atleast_2d(self.atleast_1d(array))
-        if len(array.shape) == 2:
-            array = array[None, ...]
-        return array
+    def atleast_nd(self, array: np.ndarray, n: int, dtype=None) -> np.ndarray:
+        return np.array(array, ndmin=n, dtype=dtype)
 
     def block(self, blocks: list[list[np.ndarray]], axes=(-2, -1)) -> np.ndarray:
         rows = [self.concat(row, axis=axes[1]) for row in blocks]
@@ -413,7 +404,7 @@ class BackendNumpy(BackendBase):  # pragma: no cover
     def update_tensor(
         self, tensor: np.ndarray, indices: np.ndarray, values: np.ndarray
     ) -> np.ndarray:
-        indices = self.atleast_2d(indices)
+        indices = self.atleast_nd(indices, 2)
         for i, v in zip(indices, values):
             tensor[tuple(i)] = v
         return tensor
@@ -422,7 +413,7 @@ class BackendNumpy(BackendBase):  # pragma: no cover
     def update_add_tensor(
         self, tensor: np.ndarray, indices: np.ndarray, values: np.ndarray
     ) -> np.ndarray:
-        indices = self.atleast_2d(indices)
+        indices = self.atleast_nd(indices, 2)
         for i, v in zip(indices, values):
             tensor[tuple(i)] += v
         return tensor

--- a/mrmustard/math/backend_tensorflow.py
+++ b/mrmustard/math/backend_tensorflow.py
@@ -94,17 +94,8 @@ class BackendTensorflow(BackendBase):  # pragma: no cover
         dtype = dtype or np.array(array).dtype.name
         return tf.cast(tf.convert_to_tensor(array, dtype_hint=dtype), dtype)
 
-    def atleast_1d(self, array: tf.Tensor, dtype=None) -> tf.Tensor:
-        return tf.experimental.numpy.atleast_1d(self.cast(self.astensor(array), dtype))
-
-    def atleast_2d(self, array: tf.Tensor, dtype=None) -> tf.Tensor:
-        return tf.experimental.numpy.atleast_2d(self.cast(self.astensor(array), dtype))
-
-    def atleast_3d(self, array: tf.Tensor, dtype=None) -> tf.Tensor:
-        array = self.atleast_2d(self.atleast_1d(self.cast(self.astensor(array), dtype)))
-        if len(array.shape) == 2:
-            array = self.expand_dims(array, 0)
-        return array
+    def atleast_nd(self, array: tf.Tensor, n: int, dtype=None) -> tf.Tensor:
+        return tf.experimental.numpy.array(array, ndmin=n, dtype=dtype)
 
     def block_diag(self, mat1: tf.Tensor, mat2: tf.Tensor) -> tf.Tensor:
         Za = self.zeros((mat1.shape[-2], mat2.shape[-1]), dtype=mat1.dtype)

--- a/tests/test_math/test_backend_manager.py
+++ b/tests/test_math/test_backend_manager.py
@@ -203,6 +203,24 @@ class TestBackendManager:
             exp_shape = arr.shape
         assert res.shape == exp_shape
 
+    @pytest.mark.parametrize("t", types)
+    @pytest.mark.parametrize("l", [l1, l3, l5])
+    @pytest.mark.parametrize("n", [1, 2, 3])
+    def test_atleast_nd(self, t, l, n):
+        r"""
+        Tests the ``atleast_nd`` method.
+        """
+        dtype = getattr(math, t, None)
+        arr = np.array(l)
+
+        res = math.asnumpy(math.atleast_nd(arr, n, dtype=dtype))
+
+        if arr.ndim < n:
+            exp_shape = (1,) * (n - arr.ndim) + arr.shape
+        else:
+            exp_shape = arr.shape
+        assert res.shape == exp_shape
+
     def test_boolean_mask(self):
         r"""
         Tests the ``boolean_mask`` method.


### PR DESCRIPTION
**Context:** Pulling out of the `BtoF_V2` branch. `atleast_nd` is a more general implementation of our `at_least1d`, `at_least2d`, `at_least3d` methods. 

**Description of the Change:** Implemented `atleast_nd` and changed `at_least1d`, `at_least2d` and `at_least3d` to be convenience methods for certain cases of `atleast_nd` 

**Benefits:** Single implementation of `atleast_nd` 

**Possible Drawbacks:** N/A