### PR TITLE
GitHub Workflow Python 3.10 Minimum

### DIFF
--- a/.github/workflows/tests_numpy.yml
+++ b/.github/workflows/tests_numpy.yml
@@ -12,7 +12,7 @@ jobs:
       id-token: write # This is required for requesting the JWT for S3 access
     strategy:
       matrix:
-        python-version: ['3.9', '3.12']
+        python-version: ['3.10', '3.12']
     concurrency:
       group: ${{ github.workflow }}-${{ matrix.python-version }}-${{ github.ref }}
       cancel-in-progress: true

--- a/.github/workflows/tests_tensorflow.yml
+++ b/.github/workflows/tests_tensorflow.yml
@@ -12,7 +12,7 @@ jobs:
       id-token: write # This is required for requesting the JWT for S3 access
     strategy:
       matrix:
-        python-version: ['3.9', '3.12']
+        python-version: ['3.10', '3.12']
     concurrency:
       group: ${{ github.workflow }}-${{ matrix.python-version }}-${{ github.ref }}
       cancel-in-progress: true


### PR DESCRIPTION
**Context:** When introducing Jax we bumped the minimum version of Python to 3.10 but forgot to update our workflows.

**Description of the Change:** Bumping up the min python version to 3.10 for our github workflows. 