### PR TITLE
Splitting things out from "Improved PolyExpAnsatz and Batching"

### DIFF
--- a/mrmustard/lab_dev/states/base.py
+++ b/mrmustard/lab_dev/states/base.py
@@ -339,9 +339,7 @@ class State(CircuitComponent):
             raise ValueError("Can calculate phase space only for Bargmann states.")
 
         new_state = self >> BtoPS(self.modes, s=s)
-        return bargmann_Abc_to_phasespace_cov_means(
-            *new_state.bargmann_triple(batched=True), batched=True
-        )
+        return bargmann_Abc_to_phasespace_cov_means(*new_state.bargmann_triple(batched=True))
 
     def visualize_2d(
         self,

--- a/mrmustard/math/backend_jax.py
+++ b/mrmustard/math/backend_jax.py
@@ -256,7 +256,7 @@ class BackendJax(BackendBase):  # pragma: no cover
     @Autocast()
     @jax.jit
     def matvec(self, a: jnp.ndarray, b: jnp.ndarray) -> jnp.ndarray:
-        return jnp.matmul(a, b)
+        return jnp.matmul(a, b[..., None])[..., 0]
 
     @jax.jit
     def cos(self, array: jnp.ndarray) -> jnp.ndarray:

--- a/mrmustard/math/backend_jax.py
+++ b/mrmustard/math/backend_jax.py
@@ -91,6 +91,9 @@ class BackendJax(BackendBase):  # pragma: no cover
     def broadcast_to(self, array: jnp.ndarray, shape: tuple[int]) -> jnp.ndarray:
         return jnp.broadcast_to(array, shape)
 
+    def broadcast_arrays(self, *arrays: list[jnp.ndarray]) -> list[jnp.ndarray]:
+        return jnp.broadcast_arrays(*arrays)
+
     @partial(jax.jit, static_argnames=["axis"])
     def prod(self, x: jnp.ndarray, axis: int | None):
         return jnp.prod(x, axis=axis)

--- a/mrmustard/math/backend_manager.py
+++ b/mrmustard/math/backend_manager.py
@@ -350,21 +350,6 @@ class BackendManager:  # pylint: disable=too-many-public-methods, fixme
         """
         return self._apply("atleast_nd", (array, n, dtype))
 
-    def batched_transpose(self, a: Tensor, batch_dims: int = 0) -> Tensor:
-        r"""
-        Transposes the array ``a`` with shape ``(batch_dims, ..., n, m)`` to shape ``(batch_dims, ..., m, n)``.
-
-        Args:
-            a: The array to transpose
-            batch_dims: The number of batch dimensions
-
-        Returns:
-            The transposed array.
-        """
-        perm = tuple(range(len(a.shape)))
-        perm = perm[:batch_dims] + perm[batch_dims:][::-1]
-        return self._apply("transpose", (a, perm))
-
     def block_diag(self, mat1: Matrix, mat2: Matrix) -> Matrix:
         r"""Returns a block diagonal matrix from the given matrices.
 

--- a/mrmustard/math/backend_numpy.py
+++ b/mrmustard/math/backend_numpy.py
@@ -103,6 +103,9 @@ class BackendNumpy(BackendBase):  # pragma: no cover
     def broadcast_to(self, array: np.ndarray, shape: tuple[int]) -> np.ndarray:
         return np.broadcast_to(array, shape)
 
+    def broadcast_arrays(self, *arrays: list[np.ndarray]) -> list[np.ndarray]:
+        return np.broadcast_arrays(*arrays)
+
     def block_diag(self, *blocks: list[np.ndarray]) -> np.ndarray:
         return sp.linalg.block_diag(*blocks)
 
@@ -287,7 +290,7 @@ class BackendNumpy(BackendBase):  # pragma: no cover
 
     @Autocast()
     def matvec(self, a: np.ndarray, b: np.ndarray) -> np.ndarray:
-        return self.matmul(a, b[:, None])[:, 0]
+        return self.matmul(a, b[..., None])[..., 0]
 
     @Autocast()
     def maximum(self, a: np.ndarray, b: np.ndarray) -> np.ndarray:
@@ -324,7 +327,7 @@ class BackendNumpy(BackendBase):  # pragma: no cover
         return np.ones(array.shape, dtype=array.dtype)
 
     def infinity_like(self, array: np.ndarray) -> np.ndarray:
-        return np.full_like(array.shape, np.inf, dtype=array.dtype)
+        return np.full_like(array, np.inf)
 
     def conditional(
         self, cond: np.ndarray, true_fn: Callable, false_fn: Callable, *args

--- a/mrmustard/math/lattice/strategies/vanilla.py
+++ b/mrmustard/math/lattice/strategies/vanilla.py
@@ -206,7 +206,7 @@ def vanilla_stable(shape: tuple[int, ...], A, b, c) -> ComplexTensor:  # pragma:
 
 @njit(parallel=True)
 def vanilla_stable_batch(shape: tuple[int, ...], A, b, c) -> ComplexTensor:  # pragma: no cover
-    """Batched version of the stable vanilla algorithm for calculating the fock representation of a Gaussian tensor.
+    r"""Batched version of the stable vanilla algorithm for calculating the fock representation of a Gaussian tensor.
     See the documentation of ``vanilla_stable`` for more details about the non-batched version.
 
     Args:

--- a/mrmustard/physics/bargmann_utils.py
+++ b/mrmustard/physics/bargmann_utils.py
@@ -209,9 +209,7 @@ def symplectic2Au(S):
 
     S: symplectic in XXPP order
     """
-    m = S.shape[-1]
-    m = m // 2
-    batch_dim = len(S.shape[:-2])
+    m = S.shape[-1] // 2
     # the following lines of code transform the quadrature symplectic matrix to
     # the annihilation one
     R = math.rotmat(m)
@@ -243,7 +241,6 @@ def XY_of_channel(A: ComplexMatrix):
     """
     n = A.shape[-1] // 2
     m = n // 2
-    batch_dim = len(A.shape[:-2])
 
     # here we transform to the other convention for wires i.e. {out-bra, out-ket, in-bra, in-ket}
     A_out = math.block(

--- a/mrmustard/physics/fock_utils.py
+++ b/mrmustard/physics/fock_utils.py
@@ -858,14 +858,13 @@ def quadrature_basis(
         if not np.isclose(phi, 0.0):
             theta = -math.arange(shapes[dim]) * phi
             Ur = math.make_complex(math.cos(theta), math.sin(theta))
-            q_to_n = math.einsum("a,ab->ab", Ur, q_to_n)
+            q_to_n = math.einsum("n,nq->nq", Ur, q_to_n)
         if conjugates[dim]:
             q_to_n = math.conj(q_to_n)
         quad_basis_vecs += [math.cast(q_to_n, "complex128")]
 
     # Convert each dimension to quadrature
-    subscripts = [chr(i) for i in range(98, 98 + dims)]
-    fock_string = "".join(subscripts[:dims])  #'bcd....'
+    fock_string = "".join([chr(i) for i in range(98, 98 + dims)])  #'bcd....'
     q_string = "".join([fock_string[i] + "a," for i in range(dims - 1)] + [fock_string[-1] + "a"])
     quad_array = math.einsum(
         fock_string + "," + q_string + "->" + "a", fock_array, *quad_basis_vecs

--- a/mrmustard/physics/fock_utils.py
+++ b/mrmustard/physics/fock_utils.py
@@ -858,7 +858,7 @@ def quadrature_basis(
         if not np.isclose(phi, 0.0):
             theta = -math.arange(shapes[dim]) * phi
             Ur = math.make_complex(math.cos(theta), math.sin(theta))
-            q_to_n = math.einsum("n,nq->nq", Ur, q_to_n)
+            q_to_n = math.einsum("a,ab->ab", Ur, q_to_n)
         if conjugates[dim]:
             q_to_n = math.conj(q_to_n)
         quad_basis_vecs += [math.cast(q_to_n, "complex128")]

--- a/mrmustard/physics/triples.py
+++ b/mrmustard/physics/triples.py
@@ -90,7 +90,7 @@ def vacuum_state_Abc(n_modes: int) -> Union[Matrix, Vector, Scalar]:
     """
     A = _vacuum_A_matrix(n_modes)
     b = _vacuum_B_vector(n_modes)
-    c = 1.0 + 0j
+    c = math.astensor(1.0 + 0j)
 
     return A, b, c
 
@@ -791,7 +791,7 @@ def displacement_map_s_parametrized_Abc(s: int, n_modes: int) -> Union[Matrix, V
 
     A = math.astensor(math.asnumpy(A)[order_list, :][:, order_list])
     b = _vacuum_B_vector(4 * n_modes)
-    c = 1.0
+    c = math.astensor(1.0 + 0.0j)
     return math.astensor(A), b, c
 
 

--- a/mrmustard/physics/triples.py
+++ b/mrmustard/physics/triples.py
@@ -90,7 +90,7 @@ def vacuum_state_Abc(n_modes: int) -> Union[Matrix, Vector, Scalar]:
     """
     A = _vacuum_A_matrix(n_modes)
     b = _vacuum_B_vector(n_modes)
-    c = math.astensor(1.0 + 0j)
+    c = math.astensor(1.0 + 0.0j)
 
     return A, b, c
 

--- a/tests/test_math/test_backend_manager.py
+++ b/tests/test_math/test_backend_manager.py
@@ -262,6 +262,16 @@ class TestBackendManager:
         assert R.shape == (8, 8)
         assert math.allclose(math.block([[I, O], [O, 1j * I]]), R)
 
+    def test_broadcast_arrays(self):
+        r"""
+        Tests the ``broadcast_arrays`` method.
+        """
+        arr1 = math.astensor([[1, 2, 3]])
+        arr2 = math.astensor([[4], [5], [6]])
+        res = math.broadcast_arrays(arr1, arr2)
+        assert math.allclose(res[0], math.astensor([[1, 2, 3], [1, 2, 3], [1, 2, 3]]))
+        assert math.allclose(res[1], math.astensor([[4, 4, 4], [5, 5, 5], [6, 6, 6]]))
+
     def test_broadcast_to(self):
         r"""
         Tests the ``broadcast_to`` method.


### PR DESCRIPTION
### **User description**
**Context:** In an effort to make [Improved PolyExpAnsatz and Batching](https://github.com/XanaduAI/MrMustard/pull/558) smaller here we split out changes to the backend as well as `bargmann_utils.py` and `fock_utils.py`. 

**Description of the Change:** Added `batched_transpose` and `broadcast_arrays`. `bargmann_utils.py` and `fock_utils.py` updated for the batch changes


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Added `batched_transpose` and `broadcast_arrays` methods across backends.

- Refactored `bargmann_utils.py` to remove unused `batched` parameter.

- Improved batch handling in mathematical operations and physics utilities.

- Fixed minor issues in broadcasting, matrix operations, and tensor handling.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>base.py</strong><dd><code>Refactor phase space calculation for Bargmann states</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/569/files#diff-782e8b404915d7267d5cc991ba0b8c52926808d9005e7b45fdb98da00dfa9f00">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>backend_jax.py</strong><dd><code>Add `broadcast_arrays` method for JAX backend</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/569/files#diff-277d6b9d9077473e0fca45c03a82a1503f283442e0b7503da968e5330ec3c242">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>backend_manager.py</strong><dd><code>Introduce `batched_transpose` and improve tensor operations</code></dd></td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/569/files#diff-272a316cdf15707ddb7384f13258135f593fc560e21dc19cf17c16cfb5d0aa1c">+36/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>backend_numpy.py</strong><dd><code>Add `broadcast_arrays` and fix tensor operations in NumPy backend</code></dd></td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/569/files#diff-c949c22a107a6cbdc038de07d7b8f9c9c5b3445a876d530ab2ee4780ca00e7a2">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>backend_tensorflow.py</strong><dd><code>Implement `broadcast_arrays` for TensorFlow backend</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/569/files#diff-9b9d2f0045f871a5f865532687c4b9733e960270cfdb405a5688c2e62568feb0">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>bargmann_utils.py</strong><dd><code>Remove unused `batched` parameter and improve matrix operations</code></dd></td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/569/files#diff-1aab45d7cd1e6d057f031857c9f189dbd772673ba9e70f72756e37721b43c34d">+20/-33</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>vanilla.py</strong><dd><code>Update docstring for batched vanilla stable algorithm</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/569/files#diff-e5930fe6347cb3355e54ff2d78cace247ec1b71bb018410019ac6c56befc98a6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>fock_utils.py</strong><dd><code>Fix einsum subscripts for quadrature basis calculation</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/569/files#diff-cac821102bf4c426e4141ccf3ae40620229504c9210b8caa86f9da8b1848dc8c">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>triples.py</strong><dd><code>Ensure consistent tensor initialization in vacuum state calculations</code></dd></td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/569/files#diff-615d7fb7ff981fd55f46b6a2e69b1f999b052812ff6d2d49c00ba9f0a98b0004">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>