### PR TITLE
channel from kraus

### DIFF
--- a/mrmustard/lab_dev/transformations/base.py
+++ b/mrmustard/lab_dev/transformations/base.py
@@ -438,6 +438,18 @@ class Channel(Map):
         kraus = ansatz.conj.contract(ansatz, range(2 * m), range(2 * m))
         return Channel.from_bargmann(modes, modes, kraus.triple)
 
+    @classmethod
+    def from_kraus(cls, kraus: Operation) -> Channel:
+        r"""
+        Initialize a Channel from its Kraus representation.
+        Args:
+            modes_out: The output modes of the channel.
+            modes_in: The input modes of the channel.
+            kraus: The Kraus operator of the channel.
+        """
+        ch = kraus @ kraus.adjoint
+        return Channel.from_ansatz(kraus.wires.output.modes, kraus.wires.input.modes, ch.ansatz)
+
     def __rshift__(self, other: CircuitComponent) -> CircuitComponent:
         r"""
         Contracts ``self`` and ``other`` as it would in a circuit, adding the adjoints when

--- a/tests/test_lab_dev/test_transformations/test_transformations_base.py
+++ b/tests/test_lab_dev/test_transformations/test_transformations_base.py
@@ -237,3 +237,11 @@ class TestChannel:
         assert psi.to_fock((cutoff, cutoff)) == (Coherent(0, 2) >> PhaseNoise(0, sigma)).to_fock(
             (cutoff, cutoff)
         )
+
+    def test_from_kraus(self):
+        U = Unitary.random((0, 1))
+        ch = Channel.from_kraus(U)
+
+        X, _ = ch.XY
+        assert X == U.symplectic[0]
+        assert ch.is_physical


### PR DESCRIPTION
**Context:**
We are missing a method to define a channel by its Kraus operator.

**Description of the Change:**
Adds the method `.from_kraus`.

**Benefits:**
Helps integration with MK.

**Possible Drawbacks:**
None.

**Related GitHub Issues:**
None.