### PR TITLE
adds atol to allclose in ansatz

### DIFF
--- a/mrmustard/physics/ansatz/array_ansatz.py
+++ b/mrmustard/physics/ansatz/array_ansatz.py
@@ -336,7 +336,7 @@ class ArrayAnsatz(Ansatz):
         if self.batch_shape != other.batch_shape:
             return False
         slices = tuple(slice(0, min(si, oi)) for si, oi in zip(self.core_shape, other.core_shape))
-        return np.allclose(
+        return math.allclose(
             self.array[(...,) + slices], other.array[(...,) + slices], atol=settings.ATOL
         )
 

--- a/mrmustard/physics/ansatz/array_ansatz.py
+++ b/mrmustard/physics/ansatz/array_ansatz.py
@@ -25,7 +25,7 @@ from numpy.typing import ArrayLike
 
 from IPython.display import display
 
-from mrmustard import math, widgets
+from mrmustard import math, widgets, settings
 from mrmustard.math.parameters import Variable
 from mrmustard.utils.typing import Batch, Scalar, Tensor
 
@@ -336,7 +336,9 @@ class ArrayAnsatz(Ansatz):
         if self.batch_shape != other.batch_shape:
             return False
         slices = tuple(slice(0, min(si, oi)) for si, oi in zip(self.core_shape, other.core_shape))
-        return np.allclose(self.array[(...,) + slices], other.array[(...,) + slices], atol=1e-10)
+        return np.allclose(
+            self.array[(...,) + slices], other.array[(...,) + slices], atol=settings.ATOL
+        )
 
     def __mul__(self, other: Scalar) -> ArrayAnsatz:
         return ArrayAnsatz(array=self.array * other, batch_dims=self.batch_dims)

--- a/mrmustard/physics/ansatz/polyexp_ansatz.py
+++ b/mrmustard/physics/ansatz/polyexp_ansatz.py
@@ -496,7 +496,7 @@ class PolyExpAnsatz(Ansatz):
     def _equal_no_array(self, other: PolyExpAnsatz) -> bool:
         self.simplify()
         other.simplify()
-        return np.allclose(self.b, other.b, atol=settings.ATOL) and np.allclose(
+        return math.allclose(self.b, other.b, atol=settings.ATOL) and math.allclose(
             self.A, other.A, atol=settings.ATOL
         )
 
@@ -516,8 +516,8 @@ class PolyExpAnsatz(Ansatz):
 
         for d in range(1, self.batch_size):
             if not (
-                np.allclose(mat, A[d], atol=settings.ATOL)
-                and np.allclose(vec, b[d], atol=settings.ATOL)
+                math.allclose(mat, A[d], atol=settings.ATOL)
+                and math.allclose(vec, b[d], atol=settings.ATOL)
             ):
                 to_keep.append(d)
                 d0 = d
@@ -808,7 +808,7 @@ class PolyExpAnsatz(Ansatz):
     def __eq__(self, other: PolyExpAnsatz) -> bool:
         if not isinstance(other, PolyExpAnsatz):
             return False
-        return self._equal_no_array(other) and np.allclose(self.c, other.c, atol=settings.ATOL)
+        return self._equal_no_array(other) and math.allclose(self.c, other.c, atol=settings.ATOL)
 
     def __mul__(self, other: Scalar | PolyExpAnsatz) -> PolyExpAnsatz:
         if not isinstance(other, PolyExpAnsatz):  # could be a number

--- a/mrmustard/physics/ansatz/polyexp_ansatz.py
+++ b/mrmustard/physics/ansatz/polyexp_ansatz.py
@@ -45,7 +45,7 @@ from mrmustard.physics.gaussian_integrals import (
 )
 from mrmustard.physics.utils import generate_batch_str, verify_batch_triple
 
-from mrmustard import math, widgets
+from mrmustard import math, widgets, settings
 from mrmustard.math.parameters import Variable
 
 
@@ -496,7 +496,9 @@ class PolyExpAnsatz(Ansatz):
     def _equal_no_array(self, other: PolyExpAnsatz) -> bool:
         self.simplify()
         other.simplify()
-        return np.allclose(self.b, other.b) and np.allclose(self.A, other.A)
+        return np.allclose(self.b, other.b, atol=settings.ATOL) and np.allclose(
+            self.A, other.A, atol=settings.ATOL
+        )
 
     def _find_unique_terms_sorted(
         self,
@@ -513,7 +515,10 @@ class PolyExpAnsatz(Ansatz):
         mat, vec = A[d0], b[d0]
 
         for d in range(1, self.batch_size):
-            if not (np.allclose(mat, A[d]) and np.allclose(vec, b[d])):
+            if not (
+                np.allclose(mat, A[d], atol=settings.ATOL)
+                and np.allclose(vec, b[d], atol=settings.ATOL)
+            ):
                 to_keep.append(d)
                 d0 = d
                 mat, vec = A[d0], b[d0]
@@ -803,7 +808,7 @@ class PolyExpAnsatz(Ansatz):
     def __eq__(self, other: PolyExpAnsatz) -> bool:
         if not isinstance(other, PolyExpAnsatz):
             return False
-        return self._equal_no_array(other) and np.allclose(self.c, other.c)
+        return self._equal_no_array(other) and np.allclose(self.c, other.c, atol=settings.ATOL)
 
     def __mul__(self, other: Scalar | PolyExpAnsatz) -> PolyExpAnsatz:
         if not isinstance(other, PolyExpAnsatz):  # could be a number


### PR DESCRIPTION
**Context:**
sometimes we need a little flexibility when comparing CircuitComponents, Representations and Ansatze

**Description of the Change:**
the comparison operator == now supports ATOL via settings:
```python
with settings(ATOL=1e-6):
    this == that
```