### PR TITLE
Wigner function for states

### DIFF
--- a/mrmustard/lab_dev/states/ket.py
+++ b/mrmustard/lab_dev/states/ket.py
@@ -37,7 +37,7 @@ from mrmustard.utils.typing import (
 from .base import State, _validate_operator, OperatorType
 from .dm import DM
 from ..circuit_components import CircuitComponent
-from ..circuit_components_utils import TraceOut
+from ..circuit_components_utils import BtoPS, TraceOut
 from ..utils import shape_check
 
 __all__ = ["Ket"]
@@ -285,6 +285,20 @@ class Ket(State):
         if self.modes != other.modes:
             raise ValueError("Cannot compute fidelity between states with different modes.")
         return self.expectation(other)
+
+    @property
+    def wigner(self) -> PolyExpAnsatz:
+        r"""
+        The Wigner representation of this ket.
+        """
+        if self.ansatz._lin_sup:
+            raise NotImplementedError(
+                "Wigner representation is not implemented for linear superposition."
+            )
+        if isinstance(self.ansatz, ArrayAnsatz):
+            raise NotImplementedError("Wigner representation is not implemented for ArrayAnsatz.")
+
+        return (self >> BtoPS(self.modes, s=0)).ansatz.PS
 
     def _ipython_display_(self):  # pragma: no cover
         if widgets.IN_INTERACTIVE_SHELL:

--- a/mrmustard/physics/ansatz/polyexp_ansatz.py
+++ b/mrmustard/physics/ansatz/polyexp_ansatz.py
@@ -209,6 +209,24 @@ class PolyExpAnsatz(Ansatz):
         return self.A.shape[-1]
 
     @property
+    def PS(self) -> PolyExpAnsatz:
+        r"""
+        The ansatz acting on real (i.e., phase-space) variables.
+        """
+        n = self.A.shape[-1]
+        if n % 2:
+            raise ValueError(
+                f"A phase space ansatz must have even number of indices. (n={n} is odd)"
+            )
+        In = math.eye(n // 2, dtype=math.complex128)
+        W = math.block([[In, -1j * In], [In, 1j * In]]) / complex(math.sqrt(2) * settings.HBAR)
+
+        A = math.einsum("ij, ...jk, kl-> ...il", W.T, self.A, W)
+        b = math.einsum("ij, ...j-> ...i", W, self.b)
+        c = self.c / (2 * settings.HBAR) ** (n // 2)
+        return PolyExpAnsatz(A, b, c, lin_sup=self._lin_sup)
+
+    @property
     def scalar(self) -> Scalar:
         r"""
         The scalar part of the ansatz, i.e. F(0)

--- a/tests/test_lab_dev/test_states/test_ket.py
+++ b/tests/test_lab_dev/test_states/test_ket.py
@@ -550,3 +550,12 @@ class TestKet:  # pylint: disable=too-many-public-methods
     def test_is_physical(self):
         assert Ket.random((0, 1)).is_physical
         assert Coherent(0, x=[1, 1, 1]).is_physical
+
+    def test_wigner(self):
+
+        ans = Vacuum(0).wigner
+        x = np.linspace(0, 1, 100)
+
+        solution = np.exp(-(x**2)) / 2
+
+        assert math.allclose(ans(x), solution)

--- a/tests/test_physics/test_ansatz/test_polyexp_ansatz.py
+++ b/tests/test_physics/test_ansatz/test_polyexp_ansatz.py
@@ -29,6 +29,7 @@ from mrmustard.physics.gaussian_integrals import (
     complex_gaussian_integral_1,
     complex_gaussian_integral_2,
 )
+from mrmustard.lab_dev.transformations import Identity
 
 from ...random import Abc_triple
 
@@ -624,3 +625,11 @@ class TestPolyExpAnsatz:
         assert ansatz_and.A.shape == (2, 5, 3, 4, 3, 3)
         assert ansatz_and.b.shape == (2, 5, 3, 4, 3)
         assert ansatz_and.c.shape == (2, 5, 3, 4)
+
+    def test_PS(self):
+        ans = Identity(0).ansatz
+
+        x = np.linspace(0, 1, 10)
+        gaussian = np.exp(-(x**2)) / np.pi
+
+        assert math.allclose(ans.PS(x, 0), gaussian)


### PR DESCRIPTION
**Context:**
Our current implementation of ``BtoPS`` is in the complex domain, and has extra factors one should be careful about. This unconventional description makes things less intuitive. 

**Description of the Change:**
This PR creates a wigner ansatz for states that can be called by using ordinary phase space (x,p) conventions.

**Benefits:**
Making Wigner function calculations more intuitive and simple.

**Possible Drawbacks:**
Could be unstable for ``ArraysAnsatz``.

**Related GitHub Issues:**
None.