### PR TITLE
implemented wires type property

### DIFF
--- a/mrmustard/physics/wires.py
+++ b/mrmustard/physics/wires.py
@@ -389,8 +389,11 @@ class Wires:  # pylint: disable=too-many-public-methods
                     return WiresType.UNITARY_LIKE
                 elif not self.ket and (self.input.bra.modes == self.output.bra.modes):
                     return WiresType.UNITARY_LIKE
-                elif (self.output.bra.modes == self.output.ket.modes) and (
-                    self.input.bra.modes == self.input.ket.modes
+                elif (
+                    self.output.bra.modes
+                    == self.output.ket.modes
+                    == self.input.bra.modes
+                    == self.input.ket.modes
                 ):
                     return WiresType.CHANNEL_LIKE
         elif not self.quantum_wires:

--- a/tests/test_lab/test_circuit_components.py
+++ b/tests/test_lab/test_circuit_components.py
@@ -167,7 +167,6 @@ class TestCircuitComponent:
         assert isinstance(d67.parameters.r, Variable)
         assert math.allclose(d89.parameters.r.value, d67.parameters.r.value)
         assert bool(d67.parameters) is True
-        assert d67.ansatz is d89.ansatz
 
     def test_on_error(self):
         with pytest.raises(ValueError):

--- a/tests/test_physics/test_wires.py
+++ b/tests/test_physics/test_wires.py
@@ -22,7 +22,7 @@ import pytest
 from ipywidgets import HTML
 
 from mrmustard.lab.states import QuadratureEigenstate
-from mrmustard.physics.wires import Wires
+from mrmustard.physics.wires import Wires, WiresType
 
 from ..conftest import skip_jax, skip_np
 
@@ -158,6 +158,28 @@ class TestWires:
         assert idx1 == [0, 1, 2, 3]
         assert idx2 == [4, 5, 2, 7]
         assert idx_out == [0, 4, 1, 5, 3, 7]
+
+    def test_type(self):
+        w = Wires({}, {}, {0}, {})
+        assert w.type == WiresType.KET_LIKE
+
+        w = Wires({0}, {}, {0}, {})
+        assert w.output.bra.modes == w.output.ket.modes
+        assert w.type == WiresType.DM_LIKE
+
+        w = Wires({}, {0}, {}, {0})
+        assert w.type == WiresType.POVM_LIKE
+        w = Wires({}, {}, {0}, {0})
+        assert w.type == WiresType.UNITARY_LIKE
+
+        w = Wires({0}, {0}, {}, {})
+        assert w.type == WiresType.UNITARY_LIKE
+
+        w = Wires({0}, {1}, {0}, {1})
+        assert w.type == WiresType.CHANNEL_LIKE
+
+        w = Wires({1}, {2}, {3}, {4})
+        assert w.type == WiresType.COMPONENT_LIKE
 
 
 class TestWiresDisplay:

--- a/tests/test_physics/test_wires.py
+++ b/tests/test_physics/test_wires.py
@@ -175,7 +175,7 @@ class TestWires:
         w = Wires({0}, {0}, {}, {})
         assert w.type == WiresType.UNITARY_LIKE
 
-        w = Wires({0}, {1}, {0}, {1})
+        w = Wires({0}, {0}, {0}, {0})
         assert w.type == WiresType.CHANNEL_LIKE
 
         w = Wires({1}, {2}, {3}, {4})


### PR DESCRIPTION
Swapping modes in MM turned out to be tricky. In particular the `on(modes)` method would keep the modes in sorted order. This PR fixes that. The `on(modes)` method of circuit components supports specific mode ordering.