### PR TITLE
improved stellar decomposition

### DIFF
--- a/mrmustard/lab/states/dm.py
+++ b/mrmustard/lab/states/dm.py
@@ -523,7 +523,7 @@ class DM(State):
         new_order = math.astensor(core_indices + other_indices)
 
         batch_shape = self.ansatz.batch_shape
-        A, b, _ = self.ansatz.reorder(new_order).triple
+        A, b, c = self.ansatz.reorder(new_order).triple
 
         m_modes = A.shape[-1] // 2
 
@@ -535,6 +535,8 @@ class DM(State):
         M = len(core_modes)
         Am = A[..., : 2 * M, : 2 * M]
         An = A[..., 2 * M :, 2 * M :]
+        bm = b[..., : 2 * M]
+        bn = b[..., 2 * M :]
         R = A[..., 2 * M :, : 2 * M]
         R_transpose = math.einsum("...ij->...ji", R)
         # computing the core state:
@@ -570,24 +572,44 @@ class DM(State):
         renorm = phi.contract(TraceOut(self.modes))
         phi = phi / renorm.ansatz.c
 
-        # fixing bs
-        rho_p = self.contract(phi.inverse(), mode="zip")
-        c_tmp = math.ones_like(rho_p.ansatz.c)
-        rho_p = DM.from_bargmann(self.modes, (rho_p.ansatz.A, rho_p.ansatz.b, c_tmp))
+        a = reduced_A[..., M:, M:]
+        Acore = math.block(
+            [
+                [math.zeros(batch_shape + (M, M), dtype=math.complex128), r_core_transpose],
+                [r_core, a],
+            ]
+        )
+        bcore_m = math.einsum("...ij,...j->...i", math.inv(Gamma_phi_transpose), bm)
+        bcore_m_ket = bcore_m[..., M:]
+        bcore_n = bn - math.einsum("...ij,...jk,...k->...i", temp, Aphi_in, bcore_m)
+        bcore_n_ket = bcore_n[..., (m_modes - M) :]
 
-        alpha = rho_p.ansatz.b[..., core_ket_indices]
-        for i, m in enumerate(core_modes):
-            d_g = Dgate(m, -math.real(alpha[..., i]), -math.imag(alpha[..., i]))
-            d_g_inv = d_g.inverse()
-            d_ch = d_g.contract(d_g.adjoint, mode="zip")
-            d_ch_inverse = d_g_inv.contract(d_g_inv.adjoint, mode="zip")
+        inverse_order = np.argsort(core_ket_indices + other_ket_indices)
+        Acore = Acore[..., inverse_order, :][..., :, inverse_order]
+        bcore = math.concat([bcore_m_ket, bcore_n_ket], -1)[..., inverse_order]
+        c_core = math.ones_like(c)
 
-            rho_p = rho_p.contract(d_ch, mode="zip")
-            phi = (d_ch_inverse).contract(phi, mode="zip")
-        A, b, _ = rho_p.ansatz.triple
-        core = Ket.from_bargmann(self.modes, (A[..., m_modes:, m_modes:], b[..., m_modes:], c_tmp))
-        phi = Channel.from_bargmann(core_modes, core_modes, phi.ansatz.triple)
-        return core.normalize(), phi
+        core = Ket.from_bargmann(self.modes, (Acore, bcore, c_core))
+        for i in range(M):
+            core = core.contract(
+                Dgate(
+                    core_modes[i], -math.real(bcore_m_ket[..., i]), -math.imag(bcore_m_ket[..., i])
+                ),
+                mode="zip",
+            )
+            dgate_u = Dgate(
+                core_modes[i], math.real(bcore_m_ket[..., i]), math.imag(bcore_m_ket[..., i])
+            )
+            dgate_ch = dgate_u.contract(dgate_u.adjoint, mode="zip")
+            phi = dgate_ch.contract(phi, mode="zip")
+        c_core = math.ones_like(c)
+        phi = Channel.from_bargmann(core_modes, core_modes, (phi.ansatz.A, phi.ansatz.b, c_core))
+        renorm = phi.contract(TraceOut(self.modes))
+        phi = phi / renorm.ansatz.c
+        return (
+            Ket.from_bargmann(core.modes, (core.ansatz.A, core.ansatz.b, c_core)).normalize(),
+            phi,
+        )
 
     def physical_stellar_decomposition_mixed(  # pylint: disable=too-many-statements
         self, core_modes: Collection[int]

--- a/mrmustard/lab/states/ket.py
+++ b/mrmustard/lab/states/ket.py
@@ -41,7 +41,7 @@ from .base import State, _validate_operator, OperatorType
 from .dm import DM
 from ..circuit_components import CircuitComponent
 from ..circuit_components_utils import TraceOut
-from ..transformations import Unitary, Operation, Dgate
+from ..transformations import Unitary, Operation
 from ..utils import shape_check
 
 __all__ = ["Ket"]

--- a/tests/test_lab/test_states/test_dm.py
+++ b/tests/test_lab/test_states/test_dm.py
@@ -534,7 +534,7 @@ class TestDM:  # pylint:disable=too-many-public-methods
         core, phi = rho.formal_stellar_decomposition([0, 3])
 
         # displacement test
-        rho = DM.random([0, 1]) >> Dgate(0, 0.5)
+        rho = DM.random([0, 1]) >> Dgate(0, 0.5) >> Dgate(1, 0.2)
         core, phi = rho.formal_stellar_decomposition([0])
         assert (core >> Vacuum(1).dual).normalize() == Vacuum((0,)).dm()
         assert rho == core >> phi


### PR DESCRIPTION
**Context:**
There are flaky tests in our current implementations of stellar decomposition for `DM`s. Moreover, our current implementation of physical stellar decomposition on `Ket`s makes uses of `contract` which can be circumvented, and hence, improving the speed.

**Description of the Change:**
Addressing the issues above.

**Benefits:**
Having no flaky tests + faster decomposer

**Possible Drawbacks:**
None.

**Related GitHub Issues:**
None.
