### PR TITLE
Adding support for `optimize` in einsum 

### DIFF
--- a/mrmustard/lab/states/dm.py
+++ b/mrmustard/lab/states/dm.py
@@ -392,7 +392,9 @@ class DM(State):
         array = super().fock_array(shape or self.auto_shape())
         if standard_order:
             m = self.n_modes
-            batch_dims = self.ansatz.batch_dims
+            batch_dims = (
+                self.ansatz.batch_dims - 1 if self.ansatz._lin_sup else self.ansatz.batch_dims
+            )
             axes = (
                 tuple(range(batch_dims))
                 + tuple(range(batch_dims + m, 2 * m + batch_dims))

--- a/mrmustard/math/backend_jax.py
+++ b/mrmustard/math/backend_jax.py
@@ -27,7 +27,6 @@ import numpy as np  # pragma: no cover
 import equinox as eqx  # pragma: no cover
 from jax import tree_util  # pragma: no cover
 
-from sparse import COO  # pragma: no cover
 
 from .autocast import Autocast  # pragma: no cover
 from .backend_base import BackendBase  # pragma: no cover
@@ -293,7 +292,6 @@ class BackendJax(BackendBase):  # pragma: no cover
         return jnp.diagonal(array, offset=k, axis1=-2, axis2=-1)
 
     def einsum(self, string: str, *tensors, optimize: bool | str) -> jnp.ndarray:
-        tensors = [t.todense() if isinstance(t, COO) else t for t in tensors]
         return jnp.einsum(string, *tensors, optimize=optimize)
 
     @jax.jit

--- a/mrmustard/math/backend_jax.py
+++ b/mrmustard/math/backend_jax.py
@@ -27,7 +27,6 @@ import numpy as np  # pragma: no cover
 import equinox as eqx  # pragma: no cover
 from jax import tree_util  # pragma: no cover
 
-
 from .autocast import Autocast  # pragma: no cover
 from .backend_base import BackendBase  # pragma: no cover
 from .lattice import strategies  # pragma: no cover

--- a/mrmustard/math/backend_jax.py
+++ b/mrmustard/math/backend_jax.py
@@ -27,6 +27,8 @@ import numpy as np  # pragma: no cover
 import equinox as eqx  # pragma: no cover
 from jax import tree_util  # pragma: no cover
 
+from sparse import COO  # pragma: no cover
+
 from .autocast import Autocast  # pragma: no cover
 from .backend_base import BackendBase  # pragma: no cover
 from .lattice import strategies  # pragma: no cover
@@ -290,11 +292,9 @@ class BackendJax(BackendBase):  # pragma: no cover
     def diag_part(self, array: jnp.ndarray, k: int) -> jnp.ndarray:
         return jnp.diagonal(array, offset=k, axis1=-2, axis2=-1)
 
-    @partial(jax.jit, static_argnames=["string"])
-    def einsum(self, string: str, *tensors) -> jnp.ndarray:
-        if isinstance(string, str):
-            return jnp.einsum(string, *tensors)
-        return None
+    def einsum(self, string: str, *tensors, optimize: bool | str) -> jnp.ndarray:
+        tensors = [t.todense() if isinstance(t, COO) else t for t in tensors]
+        return jnp.einsum(string, *tensors, optimize=optimize)
 
     @jax.jit
     def exp(self, array: jnp.ndarray) -> jnp.ndarray:

--- a/mrmustard/math/backend_numpy.py
+++ b/mrmustard/math/backend_numpy.py
@@ -21,8 +21,10 @@ from __future__ import annotations
 from math import lgamma as mlgamma
 from typing import Sequence, Callable
 
+from opt_einsum import contract
 import numpy as np
 import scipy as sp
+
 from scipy.signal import convolve2d as scipy_convolve2d
 from scipy.linalg import expm as scipy_expm
 from scipy.linalg import sqrtm as scipy_sqrtm
@@ -33,7 +35,6 @@ from ..utils.settings import settings
 from .autocast import Autocast
 from .backend_base import BackendBase
 from .lattice import strategies
-
 from .lattice.strategies.compactFock.inputValidation import (
     hermite_multidimensional_diagonal,
     hermite_multidimensional_diagonal_batch,
@@ -232,10 +233,8 @@ class BackendNumpy(BackendBase):  # pragma: no cover
 
         return array
 
-    def einsum(self, string: str, *tensors) -> np.ndarray | None:
-        if type(string) is str:
-            return np.einsum(string, *tensors)
-        return None  # provide same functionality as numpy.einsum or upgrade to opt_einsum
+    def einsum(self, string: str, *tensors, optimize: bool | str) -> np.ndarray:
+        return contract(string, *tensors, optimize=optimize)
 
     def exp(self, array: np.ndarray) -> np.ndarray:
         return np.exp(array)

--- a/mrmustard/math/backend_tensorflow.py
+++ b/mrmustard/math/backend_tensorflow.py
@@ -153,10 +153,6 @@ class BackendTensorflow(BackendBase):  # pragma: no cover
         if bounds != (-np.inf, np.inf):
 
             def constraint(x):
-                if x.dtype in (tf.complex128, tf.complex64):
-                    return tf.clip_by_value(tf.abs(x), bounds[0], bounds[1]) * tf.exp(
-                        1j * tf.math.angle(x)
-                    )
                 return tf.clip_by_value(x, bounds[0], bounds[1])
 
         else:
@@ -191,10 +187,10 @@ class BackendTensorflow(BackendBase):  # pragma: no cover
         return tf.linalg.diag_part(array, k=k)
 
     @Autocast()
-    def einsum(self, string: str, *tensors) -> tf.Tensor:
-        if isinstance(string, str):
-            return tf.einsum(string, *tensors)
-        return None  # provide same functionality as numpy.einsum or upgrade to opt_einsum
+    def einsum(self, string: str, *tensors, optimize: str | bool) -> tf.Tensor:
+        if optimize is False:
+            optimize = "greedy"
+        return tf.einsum(string, *tensors, optimize=optimize)
 
     def exp(self, array: tf.Tensor) -> tf.Tensor:
         return tf.math.exp(array)

--- a/mrmustard/math/backend_tensorflow.py
+++ b/mrmustard/math/backend_tensorflow.py
@@ -153,6 +153,10 @@ class BackendTensorflow(BackendBase):  # pragma: no cover
         if bounds != (-np.inf, np.inf):
 
             def constraint(x):
+                if x.dtype in (tf.complex128, tf.complex64):
+                    return tf.clip_by_value(tf.abs(x), bounds[0], bounds[1]) * tf.exp(
+                        1j * tf.math.angle(x)
+                    )
                 return tf.clip_by_value(x, bounds[0], bounds[1])
 
         else:

--- a/mrmustard/utils/settings.py
+++ b/mrmustard/utils/settings.py
@@ -90,6 +90,13 @@ class Settings:
         self.DRAW_CIRCUIT_PARAMS: bool = True
         r"""Whether or not to draw the parameters of a circuit. Default is ``True``."""
 
+        self.EINSUM_OPTIMIZE: bool | str = "greedy"
+        r"""Whether to optimize the contraction order when using the Einstein summation convention.
+        Allowed values are True, False, "greedy", "optimal" or "auto".
+        Note the TF backend does not support False and converts it to "greedy".
+        Default is ``"greedy"``.
+        """
+
         self.PROGRESSBAR: bool = True
         r"""Whether or not to display the progress bar when performing training. Default is ``True``."""
 


### PR DESCRIPTION
**Context:** The `optimize` parameter in `einsum` can be quite useful but our custom backend does not current support it's use.

**Description of the Change:** Took out the `optimize` changes from [mm_einsum #571](https://github.com/XanaduAI/MrMustard/pull/571). Added an `EINSUM_OPTIMIZE` setting defaulting to greedy. Fixed a bug in DM when calling fock_array with standard ordering with a linear superposition state