### PR TITLE
Changed np.array --> np.asarray to reduce memory overhead

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -41,6 +41,9 @@
 * Updated CI to allow for manual running of test timings before merging to develop.
   [(#612)](https://github.com/XanaduAI/MrMustard/pull/612)
 
+* Changed np.array -> np.asarray to reduce memory overhead.
+  [(#600)](https://github.com/XanaduAI/MrMustard/pull/600)
+
 ### Bug fixes
 * Fix the bug in the order of indices of the triples for DsMap CircuitComponent.
   [(#385)](https://github.com/XanaduAI/MrMustard/pull/385)
@@ -76,6 +79,7 @@
 [Matthew Silverman](https://github.com/timmysilv)
 [Ali Asadi](https://github.com/maliasadi)
 [Hitarth Choubisa](https://github.com/hitarth64)
+[Garett Brown](https://github.com/zyrxvo)
 
 ---
 

--- a/mrmustard/math/backend_jax.py
+++ b/mrmustard/math/backend_jax.py
@@ -88,7 +88,7 @@ class BackendJax(BackendBase):
         return jnp.arange(start, limit, delta, dtype=dtype)
 
     def asnumpy(self, tensor: jnp.ndarray) -> np.ndarray:
-        return np.array(tensor)
+        return np.asarray(tensor)
 
     @partial(jax.jit, static_argnames=["shape"])
     def broadcast_to(self, array: jnp.ndarray, shape: tuple[int]) -> jnp.ndarray:
@@ -146,7 +146,7 @@ class BackendJax(BackendBase):
         try:
             return jnp.concatenate(values, axis)
         except ValueError:
-            return jnp.array(values)
+            return jnp.asarray(values)
 
     @partial(jax.jit, static_argnames=["axis"])
     def sort(self, array: jnp.ndarray, axis: int = -1) -> jnp.ndarray:
@@ -266,7 +266,7 @@ class BackendJax(BackendBase):
             return jnp.diag(array, k=k)
         else:
             # fallback into more complex algorithm
-            original_sh = jnp.array(array.shape)
+            original_sh = jnp.asarray(array.shape)
 
             ravelled_sh = (jnp.prod(original_sh[:-1]), original_sh[-1])
             array = array.ravel().reshape(*ravelled_sh)
@@ -275,7 +275,7 @@ class BackendJax(BackendBase):
             for line in array:
                 ret.append(jnp.diag(line, k))
 
-            ret = jnp.array(ret)
+            ret = jnp.asarray(ret)
             inner_shape = (
                 original_sh[-1] + abs(k),
                 original_sh[-1] + abs(k),
@@ -550,7 +550,7 @@ class BackendJax(BackendBase):
             raise ValueError("'out' keyword is not supported in the JAX backend")
         G = jax.pure_callback(
             lambda A, b, c: strategies.vanilla_batch_numba(
-                shape, np.array(A), np.array(b), np.array(c), stable, None
+                shape, np.asarray(A), np.asarray(b), np.asarray(c), stable, None
             ),
             jax.ShapeDtypeStruct(output_shape, jnp.complex128),
             A,
@@ -591,7 +591,7 @@ class BackendJax(BackendBase):
         """
         function = partial(hermite_multidimensional_diagonal, cutoffs=tuple(cutoffs))
         poly0 = jax.pure_callback(
-            lambda A, B, C: function(np.array(A), np.array(B), np.array(C))[0],
+            lambda A, B, C: function(np.asarray(A), np.asarray(B), np.asarray(C))[0],
             jax.ShapeDtypeStruct(cutoffs, jnp.complex128),
             A,
             B,
@@ -624,7 +624,7 @@ class BackendJax(BackendBase):
         """
         function = partial(hermite_multidimensional_diagonal_batch, cutoffs=tuple(cutoffs))
         poly0 = jax.pure_callback(
-            lambda A, B, C: function(np.array(A), np.array(B), np.array(C))[0],
+            lambda A, B, C: function(np.asarray(A), np.asarray(B), np.asarray(C))[0],
             jax.ShapeDtypeStruct(cutoffs + (B.shape[1],), jnp.complex128),
             A,
             B,
@@ -663,7 +663,7 @@ class BackendJax(BackendBase):
         function = partial(strategies.binomial, tuple(shape))
         G = jax.pure_callback(
             lambda A, B, C, max_l2, global_cutoff: function(
-                np.array(A), np.array(B), np.array(C), max_l2, global_cutoff
+                np.asarray(A), np.asarray(B), np.asarray(C), max_l2, global_cutoff
             )[0],
             jax.ShapeDtypeStruct(shape, jnp.complex128),
             A,
@@ -703,7 +703,7 @@ class BackendJax(BackendBase):
         """
         function = partial(hermite_multidimensional_1leftoverMode, cutoffs=cutoffs)
         poly0 = jax.pure_callback(
-            lambda A, B, C: function(np.array(A), np.array(B), np.array(C))[0],
+            lambda A, B, C: function(np.asarray(A), np.asarray(B), np.asarray(C))[0],
             jax.ShapeDtypeStruct((cutoffs[0],) + cutoffs, jnp.complex128),
             A,
             B,

--- a/mrmustard/math/backend_jax.py
+++ b/mrmustard/math/backend_jax.py
@@ -88,7 +88,7 @@ class BackendJax(BackendBase):
         return jnp.arange(start, limit, delta, dtype=dtype)
 
     def asnumpy(self, tensor: jnp.ndarray) -> np.ndarray:
-        return np.asarray(tensor)
+        return np.array(tensor)
 
     @partial(jax.jit, static_argnames=["shape"])
     def broadcast_to(self, array: jnp.ndarray, shape: tuple[int]) -> jnp.ndarray:

--- a/mrmustard/math/backend_numpy.py
+++ b/mrmustard/math/backend_numpy.py
@@ -89,7 +89,7 @@ class BackendNumpy(BackendBase):
         return tensor
 
     def astensor(self, array: np.ndarray, dtype=None) -> np.ndarray:
-        array = np.asarray(array, dtype=dtype)
+        return np.asarray(array, dtype=dtype)
 
     def atleast_nd(self, array: np.ndarray, n: int, dtype=None) -> np.ndarray:
         return np.array(array, ndmin=n, dtype=dtype)

--- a/mrmustard/math/backend_numpy.py
+++ b/mrmustard/math/backend_numpy.py
@@ -82,8 +82,6 @@ class BackendNumpy(BackendBase):
         return np.arange(start, limit, delta, dtype=dtype)
 
     def asnumpy(self, tensor: np.ndarray) -> np.ndarray:
-        if isinstance(tensor, np.ndarray):
-            return tensor
         return np.asarray(tensor)
 
     def assign(self, tensor: np.ndarray, value: np.ndarray) -> np.ndarray:
@@ -91,8 +89,7 @@ class BackendNumpy(BackendBase):
         return tensor
 
     def astensor(self, array: np.ndarray, dtype=None) -> np.ndarray:
-        array = np.asarray(array)
-        return self.cast(array, dtype=dtype or array.dtype)
+        array = np.asarray(array, dtype=dtype)
 
     def atleast_nd(self, array: np.ndarray, n: int, dtype=None) -> np.ndarray:
         return np.array(array, ndmin=n, dtype=dtype)
@@ -425,7 +422,7 @@ class BackendNumpy(BackendBase):
         return np.zeros(shape, dtype=dtype)
 
     def zeros_like(self, array: np.ndarray) -> np.ndarray:
-        return np.zeros(np.asarray(array).shape, dtype=array.dtype)
+        return np.zeros_like(array, dtype=array.dtype)
 
     def map_fn(self, func, elements):
         # Is this done like this?

--- a/mrmustard/math/backend_numpy.py
+++ b/mrmustard/math/backend_numpy.py
@@ -84,14 +84,14 @@ class BackendNumpy(BackendBase):
     def asnumpy(self, tensor: np.ndarray) -> np.ndarray:
         if isinstance(tensor, np.ndarray):
             return tensor
-        return np.array(tensor)
+        return np.asarray(tensor)
 
     def assign(self, tensor: np.ndarray, value: np.ndarray) -> np.ndarray:
         tensor = value
         return tensor
 
     def astensor(self, array: np.ndarray, dtype=None) -> np.ndarray:
-        array = np.array(array)
+        array = np.asarray(array)
         return self.cast(array, dtype=dtype or array.dtype)
 
     def atleast_nd(self, array: np.ndarray, n: int, dtype=None) -> np.ndarray:
@@ -107,14 +107,14 @@ class BackendNumpy(BackendBase):
         return sp.linalg.block_diag(*blocks)
 
     def boolean_mask(self, tensor: np.ndarray, mask: np.ndarray) -> np.ndarray:
-        return np.array([t for i, t in enumerate(tensor) if mask[i]])
+        return np.asarray([t for i, t in enumerate(tensor) if mask[i]])
 
     def cast(self, array: np.ndarray, dtype=None) -> np.ndarray:
         if dtype is None:
             return array
         if dtype not in [self.complex64, self.complex128, "complex64", "complex128"]:
             array = self.real(array)
-        return np.array(array, dtype=dtype)
+        return np.asarray(array, dtype=dtype)
 
     def clip(self, array, a_min, a_max) -> np.ndarray:
         return np.clip(array, a_min, a_max)
@@ -124,7 +124,7 @@ class BackendNumpy(BackendBase):
         try:
             return np.concatenate(values, axis)
         except ValueError:
-            return np.array(values)
+            return np.asarray(values)
 
     def conj(self, array: np.ndarray) -> np.ndarray:
         return np.conj(array)
@@ -207,7 +207,7 @@ class BackendNumpy(BackendBase):
             for line in array:
                 ret.append(np.diag(line, k))
 
-            ret = np.array(ret)
+            ret = np.asarray(ret)
             inner_shape = (
                 original_sh[-1] + abs(k),
                 original_sh[-1] + abs(k),
@@ -266,7 +266,7 @@ class BackendNumpy(BackendBase):
         return False
 
     def lgamma(self, x: np.ndarray) -> np.ndarray:
-        return np.array([mlgamma(v) for v in x])
+        return np.asarray([mlgamma(v) for v in x])
 
     def log(self, x: np.ndarray) -> np.ndarray:
         return np.log(x)
@@ -301,10 +301,10 @@ class BackendNumpy(BackendBase):
         name: str,
         dtype=np.float64,
     ):  # pylint: disable=unused-argument
-        return np.array(value, dtype=dtype)
+        return np.asarray(value, dtype=dtype)
 
     def new_constant(self, value, name: str, dtype=np.float64):  # pylint: disable=unused-argument
-        return np.array(value, dtype=dtype)
+        return np.asarray(value, dtype=dtype)
 
     def norm(self, array: np.ndarray) -> np.ndarray:
         return np.linalg.norm(array)
@@ -425,11 +425,11 @@ class BackendNumpy(BackendBase):
         return np.zeros(shape, dtype=dtype)
 
     def zeros_like(self, array: np.ndarray) -> np.ndarray:
-        return np.zeros(np.array(array).shape, dtype=array.dtype)
+        return np.zeros(np.asarray(array).shape, dtype=array.dtype)
 
     def map_fn(self, func, elements):
         # Is this done like this?
-        return np.array([func(e) for e in elements])
+        return np.asarray([func(e) for e in elements])
 
     def squeeze(self, tensor, axis=None):
         return np.squeeze(tensor, axis=axis)

--- a/mrmustard/math/backend_numpy.py
+++ b/mrmustard/math/backend_numpy.py
@@ -298,7 +298,7 @@ class BackendNumpy(BackendBase):
         name: str,
         dtype=np.float64,
     ):  # pylint: disable=unused-argument
-        return np.asarray(value, dtype=dtype)
+        return np.array(value, dtype=dtype)
 
     def new_constant(self, value, name: str, dtype=np.float64):  # pylint: disable=unused-argument
         return np.asarray(value, dtype=dtype)


### PR DESCRIPTION
### **User description**
**Context:**
Looking for optimizations and improvements to reduce memory usage.

**Description of the Change:**
Changed `np.array` ——> `np.asarray` in the numpy backend.
This defaults to converting a list into a numpy array in-place (if possible).

**Benefits:**
Reduced the memory usage of the test suite by 44% (from 3.986 GB to 2.209 GB)

**Possible Drawbacks:**
None

**Related GitHub Issues:**
N/A


___

### **PR Type**
Enhancement


___

### **Description**
- Replaced `np.array` with `np.asarray` to reduce memory overhead.

- Updated multiple tensor conversion methods in `backend_numpy.py`.

- Added changelog entry documenting the memory optimization.

- Updated contributors list in the changelog.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>backend_numpy.py</strong><dd><code>Use np.asarray instead of np.array for efficient tensor conversion</code></dd></summary>
<hr>

mrmustard/math/backend_numpy.py

<li>Replaced all uses of <code>np.array</code> with <code>np.asarray</code> for tensor conversions.<br> <li> Updated methods like <code>asnumpy</code>, <code>astensor</code>, <code>boolean_mask</code>, <code>cast</code>, <code>concat</code>, <br><code>diag</code>, <code>lgamma</code>, <code>new_variable</code>, <code>new_constant</code>, <code>zeros_like</code>, <code>map_fn</code>, <code>getitem</code>, <br>and <code>setitem</code>.<br> <li> Aimed to reduce unnecessary memory copying and improve efficiency.


</details>


  </td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/600/files#diff-c949c22a107a6cbdc038de07d7b8f9c9c5b3445a876d530ab2ee4780ca00e7a2">+14/-14</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>fock_utils.py</strong><dd><code>Remove unused SQRT variable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mrmustard/physics/fock_utils.py

- Removed unused global variable `SQRT = np.sqrt(np.arange(1e6))`.


</details>


  </td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/600/files#diff-cac821102bf4c426e4141ccf3ae40620229504c9210b8caa86f9da8b1848dc8c">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document memory optimization and update contributors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/CHANGELOG.md

<li>Added entry describing the switch from <code>np.array</code> to <code>np.asarray</code>.<br> <li> Credited contributor for the enhancement.


</details>


  </td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/600/files#diff-2a22f598a15a364508bc9a475e6ec9df31958a753e9401fabaac8df4db5bd853">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>