### PR TITLE
Cleaning up how we skip tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,20 +70,21 @@ def set_backend(backend):
     math.change_backend(f"{backend}")
 
 
-def skip_tf():
-    if math.backend_name == "tensorflow":
-        pytest.skip("tensorflow")
-
-
-def skip_np():
-    if math.backend_name == "numpy":
-        pytest.skip("numpy")
-
-
-def skip_jax():
-    if math.backend_name == "jax":
-        pytest.skip("jax")
+@pytest.fixture(autouse=True)
+def requires_backend(request, backend):
+    r"""
+    Skips test if backend is not a required backend.
+    """
+    if request.node.get_closest_marker("requires_backend"):
+        if backend not in request.node.get_closest_marker("requires_backend").args:
+            pytest.skip(f"Skipped with this backend: {backend}")
 
 
 def pytest_configure(config):
-    pass  # your code goes here
+    r"""
+    Adds the marker ``requires_backend`` to the pytest config.
+    """
+    config.addinivalue_line(
+        "markers",
+        "requires_backend(backend): skips test if backend is not the required backend",
+    )

--- a/tests/test_math/test_compactFock.py
+++ b/tests/test_math/test_compactFock.py
@@ -1,7 +1,7 @@
 """
 Unit tests for mrmustard.math.compactFock.compactFock~
 """
-
+import pytest
 import numpy as np
 
 from mrmustard import math
@@ -9,8 +9,6 @@ from mrmustard.lab import DM, Ggate, SqueezedVacuum, Vacuum
 from mrmustard.lab.transformations.attenuator import Attenuator
 from mrmustard.physics import gaussian
 from mrmustard.training import Optimizer
-
-from ..conftest import skip_jax, skip_np, skip_tf
 
 
 def test_compactFock_diagonal():
@@ -56,14 +54,12 @@ def test_compactFock_1leftover():
     assert np.allclose(expected, G_leftover)
 
 
+@pytest.mark.requires_backend("tensorflow")
 def test_compactFock_diagonal_gradients():
     r"""
     Test getting Fock amplitudes and gradients if all modes
     are detected (math.hermite_renormalized_diagonal).
     """
-    skip_np()
-    skip_jax()
-
     G = Ggate(0, symplectic_trainable=True)
     Att = Attenuator(0, 0.9)
 
@@ -83,15 +79,12 @@ def test_compactFock_diagonal_gradients():
         assert opt.opt_history[i - 1] >= opt.opt_history[i]
 
 
+@pytest.mark.requires_backend()  # TODO: implement gradient of hermite_renormalized_1leftoverMode
 def test_compactFock_1leftover_gradients():
     r"""
     Test getting Fock amplitudes and if all but the first
     mode are detected (math.hermite_renormalized_1leftoverMode).
     """
-    skip_np()
-    skip_jax()
-    skip_tf()  # TODO: implement gradient of hermite_renormalized_1leftoverMode
-
     G = Ggate((0, 1), symplectic_trainable=True)
     Att = Attenuator(0, 0.9)
 

--- a/tests/test_math/test_jitting.py
+++ b/tests/test_math/test_jitting.py
@@ -15,14 +15,13 @@
 """Tests for the jitting functionality within JAX backend."""
 
 import time
+import pytest
 
 import jax
 import jax.numpy as jnp
 
 from mrmustard import math
 from mrmustard.lab import Attenuator, BSgate, SqueezedVacuum
-
-from ..conftest import skip_np, skip_tf
 
 
 def evaluate_circuit(params):
@@ -55,11 +54,9 @@ def evaluate_circuit(params):
     return math.real(math.trace(marginal))
 
 
+@pytest.mark.requires_backend("jax")
 def test_jit_complete_circuit():
     r"""Tests if entire circuit with component definitions can be jitted."""
-    skip_np()
-    skip_tf()
-
     unjitted_evaluate_circuit = evaluate_circuit
     start_time = time.time()
     for k in range(100):
@@ -84,11 +81,9 @@ def test_jit_complete_circuit():
     ), "Jitting should be make circuit evaluation faster."
 
 
+@pytest.mark.requires_backend("jax")
 def test_jit_circuit_with_parameters():
     r"""Tests if circuit with pre-defined elements can be jitted."""
-    skip_np()
-    skip_tf()
-
     initial_state = SqueezedVacuum(mode=0, r=0.5, phi=0.5, r_trainable=True, phi_trainable=True)
     BS_01 = BSgate(modes=(0, 1), theta=0.5, phi=0.5, theta_trainable=True, phi_trainable=True)
     BS_12 = BSgate(modes=(1, 2), theta=0.5, phi=0.5, theta_trainable=True, phi_trainable=True)

--- a/tests/test_math/test_vanilla.py
+++ b/tests/test_math/test_vanilla.py
@@ -20,8 +20,6 @@ import pytest
 from mrmustard import math
 from mrmustard.math.lattice import strategies
 
-from ..conftest import skip_jax, skip_tf
-
 
 def random_triple(n, batch=(), seed=None):
     r"""
@@ -42,13 +40,12 @@ class TestVanilla:
     Test the vanilla strategy for calculating the Fock representation of a Gaussian tensor.
     """
 
+    @pytest.mark.requires_backend("numpy")
     @pytest.mark.parametrize("n", [2, 3])
     def test_vanilla_vjp(self, n):
         r"""
         Unit test for vanilla_vjp_numba function by comparing with finite difference approximations.
         """
-        skip_tf()
-        skip_jax()
         epsilon = 1e-9
         A, b, c = random_triple(n, (), seed=673)
         shape = (4,) * n
@@ -89,12 +86,11 @@ class TestVanilla:
         assert np.allclose(dLdb, dLdb_fd)
         assert np.allclose(dLdA, (dLdA_fd + dLdA_fd.T) / 2)
 
+    @pytest.mark.requires_backend("numpy")
     def test_full_batch_vjp(self):
         r"""
         Unit test for vanilla_batch_vjp_numba function by comparing its results with finite difference approximations.
         """
-        skip_tf()
-        skip_jax()
         # Generate the output tensor G
         epsilon = 1e-9
         A, b, c = random_triple(3, (2,), seed=673)

--- a/tests/test_physics/test_wires.py
+++ b/tests/test_physics/test_wires.py
@@ -24,8 +24,6 @@ from ipywidgets import HTML
 from mrmustard.lab.states import QuadratureEigenstate
 from mrmustard.physics.wires import Wires
 
-from ..conftest import skip_jax, skip_np
-
 
 class TestWires:
     r"""
@@ -194,10 +192,9 @@ class TestWiresDisplay:
         captured = capsys.readouterr()
         assert captured.out.rstrip() == repr(wires)
 
+    @pytest.mark.requires_backend("tensorflow")
     def test_repr_params(self):
         "test that repr params change when the params change"
-        skip_np()
-        skip_jax()
         q = QuadratureEigenstate(mode=0, x=0.0, phi=1.0, phi_trainable=True)
         assert q.representation.wires.output.wires[0].repr_params[1] == 1.0
         q.parameters.phi.value.assign(2.0)

--- a/tests/test_training/test_callbacks.py
+++ b/tests/test_training/test_callbacks.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """callbacks tests"""
-
+import pytest
 import numpy as np
 import tensorflow as tf
 
@@ -21,14 +21,10 @@ from mrmustard import math, settings
 from mrmustard.lab import BSgate, Circuit, S2gate, Vacuum
 from mrmustard.training import Optimizer, TensorboardCallback
 
-from ..conftest import skip_jax, skip_np
 
-
+@pytest.mark.requires_backend("tensorflow")
 def test_tensorboard_callback(tmp_path):
     """Tests tensorboard callbacks on hong-ou-mandel optimization."""
-    skip_np()
-    skip_jax()
-
     settings.SEED = 42
     i, k = 2, 3
     r = np.arcsinh(1.0)

--- a/tests/test_training/test_opt_lab.py
+++ b/tests/test_training/test_opt_lab.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """Tests for the Optimizer class"""
-
+import pytest
 import numpy as np
 import tensorflow as tf
 from hypothesis import given
@@ -43,9 +43,8 @@ from mrmustard.physics.gaussian import number_means, von_neumann_entropy
 from mrmustard.training import Optimizer
 from mrmustard.training.callbacks import Callback
 
-from ..conftest import skip_jax, skip_np
 
-
+@pytest.mark.requires_backend("tensorflow")
 class TestOptimizer:
     r"""
     Tests for the ``Optimizer`` class.
@@ -54,9 +53,6 @@ class TestOptimizer:
     @given(n=st.integers(0, 3))
     def test_S2gate_coincidence_prob(self, n):
         """Testing the optimal probability of obtaining |n,n> from a two mode squeezed vacuum"""
-        skip_np()
-        skip_jax()
-
         settings.SEED = 40
         rng = tf.random.get_global_generator()
         rng.reset_from_seed(settings.SEED)
@@ -93,9 +89,6 @@ class TestOptimizer:
         see Eq. 20 of https://journals.aps.org/prresearch/pdf/10.1103/PhysRevResearch.3.043065
         which lacks a square root in the right hand side.
         """
-        skip_np()
-        skip_jax()
-
         settings.SEED = 42
         rng = tf.random.get_global_generator()
         rng.reset_from_seed(settings.SEED)
@@ -129,9 +122,6 @@ class TestOptimizer:
 
     def test_learning_two_mode_squeezing(self):
         """Finding the optimal beamsplitter transmission to make a pair of single photons"""
-        skip_np()
-        skip_jax()
-
         settings.SEED = 42
         rng = tf.random.get_global_generator()
         rng.reset_from_seed(settings.SEED)
@@ -164,9 +154,6 @@ class TestOptimizer:
 
     def test_learning_two_mode_Ggate(self):
         """Finding the optimal Ggate to make a pair of single photons"""
-        skip_np()
-        skip_jax()
-
         settings.SEED = 42
         rng = tf.random.get_global_generator()
         rng.reset_from_seed(settings.SEED)
@@ -184,9 +171,6 @@ class TestOptimizer:
 
     def test_learning_two_mode_Interferometer(self):
         """Finding the optimal Interferometer to make a pair of single photons"""
-        skip_np()
-        skip_jax()
-
         settings.SEED = 4
         rng = tf.random.get_global_generator()
         rng.reset_from_seed(settings.SEED)
@@ -213,9 +197,6 @@ class TestOptimizer:
 
     def test_learning_two_mode_RealInterferometer(self):
         """Finding the optimal Interferometer to make a pair of single photons"""
-        skip_np()
-        skip_jax()
-
         settings.SEED = 2
         rng = tf.random.get_global_generator()
         rng.reset_from_seed(settings.SEED)
@@ -250,9 +231,6 @@ class TestOptimizer:
 
     def test_learning_four_mode_Interferometer(self):
         """Finding the optimal Interferometer to make a NOON state with N=2"""
-        skip_np()
-        skip_jax()
-
         settings.SEED = 4
         rng = tf.random.get_global_generator()
         rng.reset_from_seed(settings.SEED)
@@ -315,9 +293,6 @@ class TestOptimizer:
 
     def test_learning_four_mode_RealInterferometer(self):
         """Finding the optimal Interferometer to make a NOON state with N=2"""
-        skip_np()
-        skip_jax()
-
         settings.SEED = 6
         rng = tf.random.get_global_generator()
         rng.reset_from_seed(settings.SEED)
@@ -387,9 +362,6 @@ class TestOptimizer:
         """Finding the optimal squeezing parameter to get Hong-Ou-Mandel dip in time
         see https://www.pnas.org/content/117/52/33107/tab-article-info
         """
-        skip_np()
-        skip_jax()
-
         settings.SEED = 42
         rng = tf.random.get_global_generator()
         rng.reset_from_seed(settings.SEED)
@@ -414,9 +386,6 @@ class TestOptimizer:
 
     def test_parameter_passthrough(self):
         """Same as the test above, but with param passthrough"""
-        skip_np()
-        skip_jax()
-
         settings.SEED = 42
         rng = tf.random.get_global_generator()
         rng.reset_from_seed(settings.SEED)
@@ -442,9 +411,6 @@ class TestOptimizer:
     def test_making_thermal_state_as_one_half_two_mode_squeezed_vacuum(self):
         """Optimizes a Ggate on two modes so as to prepare a state with the same entropy
         and mean photon number as a thermal state"""
-        skip_np()
-        skip_jax()
-
         settings.SEED = 42
         rng = tf.random.get_global_generator()
         rng.reset_from_seed(settings.SEED)
@@ -481,9 +447,6 @@ class TestOptimizer:
 
     def test_opt_backend_param(self):
         """Test the optimization of a backend parameter defined outside a gate."""
-        skip_np()
-        skip_jax()
-
         # rotated displaced squeezed state
         settings.SEED = 42
         rng = tf.random.get_global_generator()
@@ -508,9 +471,6 @@ class TestOptimizer:
 
     def test_dgate_optimization(self):
         """Test that Dgate is optimized correctly."""
-        skip_np()
-        skip_jax()
-
         settings.SEED = 24
         rng = tf.random.get_global_generator()
         rng.reset_from_seed(settings.SEED)
@@ -530,9 +490,6 @@ class TestOptimizer:
 
     def test_sgate_optimization(self):
         """Test that Sgate is optimized correctly."""
-        skip_np()
-        skip_jax()
-
         settings.SEED = 25
         rng = tf.random.get_global_generator()
         rng.reset_from_seed(settings.SEED)
@@ -552,25 +509,16 @@ class TestOptimizer:
         assert np.allclose(sgate.parameters.phi.value, 0.2, atol=0.01)
 
     def test_bsgate_optimization(self):
-        """Test that Sgate is optimized correctly."""
-        skip_np()
-        skip_jax()
-
+        """Test that BSgate is optimized correctly."""
         settings.SEED = 25
         rng = tf.random.get_global_generator()
         rng.reset_from_seed(settings.SEED)
 
-        G = GKet((0, 1))
-
         bsgate = BSgate((0, 1), 0.05, 0.1, theta_trainable=True, phi_trainable=True)
-        target_state = (G >> BSgate((0, 1), 0.1, 0.2)).fock_array((40, 40))
+        target_gate = BSgate((0, 1), 0.1, 0.2).fock_array(40)
 
         def cost_fn():
-            state_out = G >> bsgate
-
-            return (
-                -math.abs(math.sum(math.conj(state_out.fock_array((40, 40))) * target_state)) ** 2
-            )
+            return -math.abs(math.sum(math.conj(bsgate.fock_array(40)) * target_gate)) ** 2
 
         opt = Optimizer()
         opt.minimize(cost_fn, by_optimizing=[bsgate])
@@ -580,9 +528,6 @@ class TestOptimizer:
 
     def test_squeezing_grad_from_fock(self):
         """Test that the gradient of a squeezing gate is computed from the fock representation."""
-        skip_np()
-        skip_jax()
-
         squeezing = Sgate(0, r=1.0, r_trainable=True)
         og_r = math.asnumpy(squeezing.parameters.r.value)
 
@@ -596,8 +541,6 @@ class TestOptimizer:
 
     def test_displacement_grad_from_fock(self):
         """Test that the gradient of a displacement gate is computed from the fock representation."""
-        skip_np()
-        skip_jax()
 
         disp = Dgate(0, x=1.0, y=0.5, x_trainable=True, y_trainable=True)
         og_x = math.asnumpy(disp.parameters.x.value)
@@ -613,9 +556,6 @@ class TestOptimizer:
 
     def test_bsgate_grad_from_fock(self):
         """Test that the gradient of a beamsplitter gate is computed from the fock representation."""
-        skip_np()
-        skip_jax()
-
         sq = SqueezedVacuum(0, r=1.0, r_trainable=True)
         og_r = math.asnumpy(sq.parameters.r.value)
 

--- a/tests/test_training/test_riemannian_opt.py
+++ b/tests/test_training/test_riemannian_opt.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """optimization tests"""
-
+import pytest
 import numpy as np
 from hypothesis import given
 from hypothesis import strategies as st
@@ -24,33 +24,25 @@ from thewalrus.symplectic import is_symplectic
 from mrmustard import math
 from mrmustard.math.parameters import update_orthogonal, update_symplectic, update_unitary
 
-from ..conftest import skip_jax, skip_np
 
-
+@pytest.mark.requires_backend("tensorflow")
 def is_unitary(M, rtol=1e-05, atol=1e-08):
     """Testing if the matrix M is unitary"""
-    skip_np()
-    skip_jax()
-
     M_dagger = np.transpose(M.conj())
     return math.allclose(M @ M_dagger, np.identity(M.shape[-1]), rtol=rtol, atol=atol)
 
 
+@pytest.mark.requires_backend("tensorflow")
 def is_orthogonal(M, rtol=1e-05, atol=1e-08):
     """Testing if the matrix M is orthogonal"""
-    skip_np()
-    skip_jax()
-
     M_T = np.transpose(M)
     return math.allclose(M @ M_T, np.identity(M.shape[-1]), rtol=rtol, atol=atol)
 
 
+@pytest.mark.requires_backend("tensorflow")
 @given(n=st.integers(2, 4))
 def test_update_symplectic(n):
     """Testing the update of symplectic matrix remains to be symplectic"""
-    skip_np()
-    skip_jax()
-
     S = math.new_variable(random_symplectic(n), name=None, dtype="complex128", bounds=None)
     for _ in range(20):
         dS_euclidean = math.new_variable(
@@ -65,12 +57,10 @@ def test_update_symplectic(n):
         ), "training step does not result in a symplectic matrix"
 
 
+@pytest.mark.requires_backend("tensorflow")
 @given(n=st.integers(2, 4))
 def test_update_unitary(n):
     """Testing the update of unitary matrix remains to be unitary"""
-    skip_np()
-    skip_jax()
-
     U = math.new_variable(unitary_group.rvs(dim=n), name=None, dtype="complex128", bounds=None)
     for _ in range(20):
         dU_euclidean = np.random.random((n, n)) + 1j * np.random.random((n, n))
@@ -86,12 +76,10 @@ def test_update_unitary(n):
         assert is_orthogonal(sym), "training step does not result in an orthogonal matrix"
 
 
+@pytest.mark.requires_backend("tensorflow")
 @given(n=st.integers(2, 4))
 def test_update_orthogonal(n):
     """Testing the update of orthogonal matrix remains to be orthogonal"""
-    skip_np()
-    skip_jax()
-
     O = math.new_variable(math.random_orthogonal(n), name=None, dtype="complex128", bounds=None)
     for _ in range(20):
         dO_euclidean = np.random.random((n, n)) + 1j * np.random.random((n, n))

--- a/tests/test_utils/test_serialize.py
+++ b/tests/test_utils/test_serialize.py
@@ -47,8 +47,6 @@ from mrmustard.lab import (
 )
 from mrmustard.utils.serialize import load, save
 
-from ..conftest import skip_jax, skip_np
-
 
 class Deserialize:
     """Base class with a simple deserialization implementation."""
@@ -142,19 +140,17 @@ class TestSerialize:
         ):
             save(Dummy, arrays={"val": [1]}, val=2)
 
+    @pytest.mark.requires_backend("tensorflow")
     def test_tensorflow_support(self):
         """Test that TensorFlow data is supported."""
-        skip_np()
-        skip_jax()
         x = math.astensor([1.1, 2.2])
         loaded = load(save(DummyOneNP, name="myname", arrays={"array": x}))
         assert tf.is_tensor(loaded.array)
         assert np.array_equal(loaded.array, x)
 
+    @pytest.mark.requires_backend("tensorflow")
     def test_backend_change_error(self, monkeypatch):
         """Test that data must be deserialized with the same backend."""
-        skip_np()
-        skip_jax()
         x = math.astensor([1.1, 2.2])
         path = save(DummyOneNP, name="myname", arrays={"array": x})
         # can be thought of as restarting python and not changing to tensorflow

--- a/tests/test_utils/test_settings.py
+++ b/tests/test_utils/test_settings.py
@@ -21,8 +21,6 @@ import pytest
 from mrmustard import math
 from mrmustard.utils.settings import Settings
 
-from ..conftest import skip_jax, skip_np
-
 
 class TestSettings:
     """Tests the Settings class"""
@@ -74,10 +72,9 @@ class TestSettings:
         seq1 = [settings.rng.integers(0, 2**31 - 1) for _ in range(10)]
         assert seq0 == seq1
 
+    @pytest.mark.requires_backend("tensorflow")
     def test_complex_warnings(self, caplog):
         """Tests that complex warnings can be correctly activated and deactivated."""
-        skip_np()
-        skip_jax()
 
         settings = Settings()
 


### PR DESCRIPTION
**Context:** Noticed we could improve the way we skip tests by making use of `pytest.mark`. Now instead of having `skip_np`, `skip_tf` and `skip_jax` we have a single `pytest.mark.requires_backend`.

Taken from [JAX Optimizer #594](https://github.com/XanaduAI/MrMustard/pull/594)

**Description of the Change:** Rem `skip_np`, `skip_tf` and `skip_jax` replaced with `pytest.mark.requires_backend`. Fixed opt_lab test 

**Benefits:** Cleaner implementation of skipping with more flexibility. 
