### PR TITLE
Batched from XY

### DIFF
--- a/mrmustard/lab/transformations/base.py
+++ b/mrmustard/lab/transformations/base.py
@@ -513,9 +513,8 @@ class Channel(Map):
             This channel has a Bargmann triple that is computed in https://arxiv.org/pdf/2209.06069. We borrow
             the formulas from the paper to implement the corresponding channel.
         """
-        if X.shape[:-2] != ():
-            raise NotImplementedError("Batching is not implemented.")
-        if X.shape != (2 * len(modes_out), 2 * len(modes_in)):
+
+        if X.shape[-2:] != (2 * len(modes_out), 2 * len(modes_in)):
             raise ValueError(
                 f"The dimension of X matrix ({X.shape}) and number of modes ({len(modes_in), len(modes_out)}) don't match."
             )

--- a/mrmustard/physics/triples.py
+++ b/mrmustard/physics/triples.py
@@ -928,11 +928,26 @@ def XY_to_channel_Abc(
             "The dimension of X and Y matrices are not the same."
             f"X.shape = {X.shape}, Y.shape = {Y.shape}"
         )
-
-    xi = 1 / 2 * math.eye(2 * m, dtype=math.complex128) + 1 / 2 * X @ X.T + Y / settings.HBAR
+    batch_shape = X.shape[:-2]
+    if batch_shape != ():
+        Im = math.stack(
+            [math.eye(2 * m, dtype=math.complex128)] * int(math.prod(batch_shape))
+        ).reshape(batch_shape + (2 * m,) * 2)
+        im = math.stack([math.eye(m, dtype=math.complex128)] * int(math.prod(batch_shape))).reshape(
+            batch_shape + (m,) * 2
+        )
+        Xm = math.stack([math.Xmat(2 * m)] * int(math.prod(batch_shape))).reshape(
+            batch_shape + (4 * m,) * 2
+        )
+    else:
+        Im = math.eye(2 * m, dtype=math.complex128)
+        im = math.eye(m, dtype=math.complex128)
+        Xm = math.Xmat(2 * m)
+    X_transpose = math.einsum("...ij->...ji", X)
+    xi = 1 / 2 * Im + 1 / 2 * X @ X_transpose + Y / settings.HBAR
     xi_inv = math.inv(xi)
     xi_inv_in_blocks = math.block(
-        [[math.eye(2 * m) - xi_inv, xi_inv @ X], [X.T @ xi_inv, math.eye(2 * m) - X.T @ xi_inv @ X]]
+        [[Im - xi_inv, xi_inv @ X], [X_transpose @ xi_inv, Im - X_transpose @ xi_inv @ X]]
     )
     R = (
         1
@@ -940,32 +955,35 @@ def XY_to_channel_Abc(
         * math.block(
             [
                 [
-                    math.eye(m, dtype=math.complex128),
-                    1j * math.eye(m, dtype=math.complex128),
-                    math.zeros((m, 2 * m), dtype=math.complex128),
+                    im,
+                    1j * im,
+                    math.zeros(batch_shape + (m, 2 * m), dtype=math.complex128),
                 ],
                 [
-                    math.zeros((m, 2 * m), dtype=math.complex128),
-                    math.eye(m, dtype=math.complex128),
-                    -1j * math.eye(m, dtype=math.complex128),
+                    math.zeros(batch_shape + (m, 2 * m), dtype=math.complex128),
+                    im,
+                    -1j * im,
                 ],
                 [
-                    math.eye(m, dtype=math.complex128),
-                    -1j * math.eye(m, dtype=math.complex128),
-                    math.zeros((m, 2 * m), dtype=math.complex128),
+                    im,
+                    -1j * im,
+                    math.zeros(batch_shape + (m, 2 * m), dtype=math.complex128),
                 ],
                 [
-                    math.zeros((m, 2 * m), dtype=math.complex128),
-                    math.eye(m, dtype=math.complex128),
-                    1j * math.eye(m, dtype=math.complex128),
+                    math.zeros(batch_shape + (m, 2 * m), dtype=math.complex128),
+                    im,
+                    1j * im,
                 ],
             ]
         )
     )
-
-    A = math.Xmat(2 * m) @ R @ xi_inv_in_blocks @ math.conj(R).T
-    temp = math.block([[(xi_inv @ d).reshape(2 * m, 1)], [(-X.T @ xi_inv @ d).reshape((2 * m, 1))]])
-    b = 1 / math.sqrt(complex(settings.HBAR)) * math.conj(R) @ temp
-    c = math.exp(-0.5 / settings.HBAR * d @ xi_inv @ d) / math.sqrt(math.det(xi))
+    R_transpose = math.einsum("...ij->...ji", R)
+    A = Xm @ R @ xi_inv_in_blocks @ math.conj(R_transpose)
+    temp_1 = math.einsum("...ij,...j->...i", xi_inv, d)
+    temp_2 = math.einsum("...ij,...jk,...k->...i", X_transpose, xi_inv, d)
+    temp = math.concat([temp_1, temp_2], -1)
+    b = 1 / math.sqrt(complex(settings.HBAR)) * math.einsum("...ij,...j->...i", math.conj(R), temp)
+    sandwiched_xi_inv = math.einsum("...i,...ij,...j->...", d, xi_inv, d)
+    c = math.exp(-0.5 / settings.HBAR * sandwiched_xi_inv) / math.sqrt(math.det(xi))
 
     return A, b, c

--- a/tests/test_lab/test_transformations/test_transformations_base.py
+++ b/tests/test_lab/test_transformations/test_transformations_base.py
@@ -242,6 +242,15 @@ class TestChannel:
         assert math.allclose(x, X)
         assert math.allclose(y, Y)
 
+    @pytest.mark.parametrize("nmodes", [1, 2, 3])
+    def test_from_XY_batched(self, nmodes):
+
+        ch1 = Channel.random(list(range(nmodes))) + Channel.random(list(range(nmodes)))
+        X, Y = ch1.XY
+
+        ch2 = Channel.from_XY(tuple(range(nmodes)), tuple(range(nmodes)), X, Y)
+        assert ch1 == ch2
+
     def test_from_fock(self):
         # Here we test our from_fock method by a PhaseNoise example
         cutoff = 6

--- a/tests/test_physics/test_triples.py
+++ b/tests/test_physics/test_triples.py
@@ -419,5 +419,32 @@ class TestTriples:
         assert math.allclose(
             A, A_by_hand, atol=1e-7
         )  # TODO: remove atol when tensorflow is removed
-        assert math.allclose(b, math.zeros((4, 1)))
+        assert math.allclose(b, math.zeros((4,)))
+        assert b.shape == (4,)
         assert math.allclose(c, 1.0)
+
+    def test_XY_to_channel_Abc_batched(self):
+        eta = np.random.random(2)[:, None, None]
+        X = math.sqrt(eta) * math.eye(2)[None, :, :]
+        # Now X has shape (2, 2, 2)
+        Y = settings.HBAR / 2 * (1 - eta) * math.eye(2)[None, :, :]
+
+        A, b, c = triples.XY_to_channel_Abc(X, Y)
+
+        A_by_hand = (
+            math.sqrt(eta)
+            * math.astensor(
+                [[0, 1, 0, 0], [1, 0, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]], dtype=math.complex128
+            )[None, :, :]
+            + (1 - eta)
+            * math.astensor(
+                [[0, 0, 0, 0], [0, 0, 0, 1], [0, 0, 0, 0], [0, 1, 0, 0]], dtype=math.complex128
+            )[None, :, :]
+        )
+
+        assert math.allclose(
+            A, A_by_hand, atol=1e-7
+        )  # TODO: remove atol when tensorflow is removed
+        assert math.allclose(b, math.zeros((2, 4)))
+        assert math.allclose(c, math.astensor([1.0, 1.0], dtype=math.complex128))
+        assert c.shape == (2,)


### PR DESCRIPTION
**Context:**
We have not currently implemented `from_XY` with batches. Also, the computations in `XY_to_channel_Abc` are not compatible with our batching conventions. The shape of `b` also has an extra dimension.

**Description of the Change:**
We now allow batched initialization via `.from_XY`.

**Benefits:**
Consistency

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None