### PR TITLE
Backend argument in math.einsum

### DIFF
--- a/mrmustard/math/backend_jax.py
+++ b/mrmustard/math/backend_jax.py
@@ -27,6 +27,7 @@ import jax.scipy as jsp
 import numpy as np
 import equinox as eqx
 import optax
+from opt_einsum import contract
 
 from .backend_base import BackendBase
 from .jax_vjps import beamsplitter_jax, displacement_jax, hermite_renormalized_unbatched_jax
@@ -286,7 +287,7 @@ class BackendJax(BackendBase):
         return jnp.diagonal(array, offset=k, axis1=-2, axis2=-1)
 
     def einsum(self, string: str, *tensors, optimize: bool | str) -> jnp.ndarray:
-        return jnp.einsum(string, *tensors, optimize=optimize)
+        return contract(string, *tensors, optimize=optimize, backend="jax")
 
     @jax.jit
     def exp(self, array: jnp.ndarray) -> jnp.ndarray:

--- a/mrmustard/math/backend_manager.py
+++ b/mrmustard/math/backend_manager.py
@@ -105,15 +105,31 @@ class BackendManager:  # pylint: disable=too-many-public-methods, fixme
         # binding types and decorators of numpy backend
         self._bind()
 
-    def _apply(self, fn: str, args: Sequence[Any] | None = (), kwargs: dict | None = None) -> Any:
+    def _apply(
+        self,
+        fn: str,
+        args: Sequence[Any] | None = (),
+        kwargs: dict | None = None,
+        backend_name: str | None = None,
+    ) -> Any:
         r"""
         Applies a function ``fn`` from the backend in use to the given ``args`` and ``kwargs``.
+
+        Args:
+            fn: The function to apply.
+            args: The arguments to pass to the function.
+            kwargs: The keyword arguments to pass to the function.
+            backend_name: The name of the backend to use. If ``None``, the set backend is used.
+
+        Returns:
+            The result of the function application.
         """
         kwargs = kwargs or {}
+        backend = self.get_backend(backend_name) if backend_name else self.backend
         try:
-            attr = getattr(self.backend, fn)
+            attr = getattr(backend, fn)
         except AttributeError:
-            msg = f"Function ``{fn}`` not implemented for backend ``{self.backend_name}``."
+            msg = f"Function ``{fn}`` not implemented for backend ``{backend.name}``."
             # pylint: disable=raise-missing-from
             raise NotImplementedError(msg)
         return attr(*args, **kwargs)
@@ -181,14 +197,29 @@ class BackendManager:  # pylint: disable=too-many-public-methods, fixme
         Args:
             name: The name of the new backend.
         """
+        if self.backend_name != name:
+            # switch backend
+            self._backend = self.get_backend(name)
+            # bind
+            self._bind()
+
+    def get_backend(self, name: str | None = None) -> BackendBase:
+        r"""
+        Returns the backend with the given name.
+
+        Args:
+            name: The name of the backend.
+
+        Returns:
+            The backend with the given name.
+
+        Raises:
+            ValueError: If the backend name is not a supported one.
+        """
         if name not in ["numpy", "tensorflow", "jax"]:
-            msg = (
-                "Backend must be either ``numpy`` or ``tensorflow`` or ``jax``"  # pragma: no cover
-            )
-            raise ValueError(msg)
+            raise ValueError("Backend must be either ``numpy`` or ``tensorflow`` or ``jax``.")
 
         if self.backend_name != name:
-
             module = all_modules[name]["module"]
             object = all_modules[name]["object"]
             try:
@@ -198,12 +229,10 @@ class BackendManager:  # pylint: disable=too-many-public-methods, fixme
                 loader = all_modules[name]["loader"]
                 loader.exec_module(module)
                 backend = getattr(module, object)()
+        else:
+            backend = self.backend
 
-            # switch backend
-            self._backend = backend
-
-            # bind
-            self._bind()
+        return backend
 
     # ~~~~~~~
     # Methods
@@ -614,7 +643,9 @@ class BackendManager:  # pylint: disable=too-many-public-methods, fixme
         """
         return self._apply("eigh", (tensor,))
 
-    def einsum(self, string: str, *tensors, optimize: bool | str = "greedy") -> Tensor:
+    def einsum(
+        self, string: str, *tensors, optimize: bool | str = "greedy", backend: str | None = None
+    ) -> Tensor:
         r"""The result of the Einstein summation convention on the tensors.
 
         Args:
@@ -624,12 +655,15 @@ class BackendManager:  # pylint: disable=too-many-public-methods, fixme
                 Allowed values are True, False, "greedy", "optimal" or "auto".
                 Note the TF backend does not support False and converts it to "greedy".
                 If None, ``settings.EINSUM_OPTIMIZE`` is used.
+            backend: The name of the backend to use. If ``None``, the set backend is used.
 
         Returns:
             The result of the Einstein summation convention.
         """
         optimize = optimize or settings.EINSUM_OPTIMIZE
-        return self._apply("einsum", (string, *tensors), {"optimize": optimize})
+        return self._apply(
+            "einsum", (string, *tensors), {"optimize": optimize}, backend_name=backend
+        )
 
     def exp(self, array: Tensor) -> Tensor:
         r"""The exponential of array element-wise.

--- a/mrmustard/math/backend_numpy.py
+++ b/mrmustard/math/backend_numpy.py
@@ -233,7 +233,7 @@ class BackendNumpy(BackendBase):
         return array
 
     def einsum(self, string: str, *tensors, optimize: bool | str) -> np.ndarray:
-        return contract(string, *tensors, optimize=optimize)
+        return contract(string, *tensors, optimize=optimize, backend="numpy")
 
     def exp(self, array: np.ndarray) -> np.ndarray:
         return np.exp(array)

--- a/mrmustard/math/backend_tensorflow.py
+++ b/mrmustard/math/backend_tensorflow.py
@@ -23,6 +23,7 @@ from importlib import metadata
 import os
 
 import numpy as np
+from opt_einsum import contract
 from semantic_version import Version
 import tensorflow_probability as tfp
 
@@ -188,9 +189,7 @@ class BackendTensorflow(BackendBase):
 
     @Autocast()
     def einsum(self, string: str, *tensors, optimize: str | bool) -> tf.Tensor:
-        if optimize is False:
-            optimize = "greedy"
-        return tf.einsum(string, *tensors, optimize=optimize)
+        return contract(string, *tensors, optimize=optimize, backend="tensorflow")
 
     def exp(self, array: tf.Tensor) -> tf.Tensor:
         return tf.math.exp(array)

--- a/tests/test_math/test_backend_manager.py
+++ b/tests/test_math/test_backend_manager.py
@@ -49,6 +49,24 @@ class TestBackendManager:
         """
         assert math.BackendError is TracerArrayConversionError
 
+    def test_get_backend(self):
+        r"""
+        Tests the ``get_backend`` method.
+        """
+        assert math.get_backend("numpy").name == "numpy"
+        assert math.get_backend("tensorflow").name == "tensorflow"
+        assert math.get_backend("jax").name == "jax"
+
+    def test_einsum(self):
+        r"""
+        Tests the ``einsum`` method.
+        """
+        ar = math.astensor([[1, 2], [3, 4]])
+        res = math.astensor([[7, 10], [15, 22]])
+
+        assert math.allclose(math.einsum("ij,jk->ik", ar, ar), res)
+        assert math.allclose(math.einsum("ij,jk->ik", ar, ar, backend="tensorflow"), res)
+
     def test_error(self):
         r"""
         Tests the error on `_apply`.


### PR DESCRIPTION
### **User description**
**Context:** Sometimes it may be useful to change the backend of `opt_einsum.contract` independent of what the mrmustard math backend is set to (e.g. using `backend=tensorflow` when the backend is set to numpy). Here we allow for an optional backend argument that can override the set backend. 

**Description of the Change:** 
- Added the `get_backend` method to retrieve a backend given a name. 
- Added the `backend_name` argument to `BackendManager._apply`. This is a general solution that allows us to override any backend call if exposed to the user. 
- Added the `backend` argument to `math.einsum` and changed all einsum calls to `opt_einsum.contract` with appropriate backends.

**Benefits:** More flexibility with the backend.


___

### **PR Type**
Enhancement


___

### **Description**
- Add backend override parameter to `math.einsum` function

- Implement `get_backend` method for backend retrieval

- Replace native einsum calls with `opt_einsum.contract` across backends

- Add comprehensive tests for new backend functionality


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>backend_manager.py</strong><dd><code>Backend override functionality in BackendManager</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mrmustard/math/backend_manager.py

<li>Add <code>backend_name</code> parameter to <code>_apply</code> method for backend override<br> <li> Add <code>backend</code> parameter to <code>einsum</code> method<br> <li> Implement <code>get_backend</code> method to retrieve specific backends<br> <li> Refactor <code>change_backend</code> to use new <code>get_backend</code> method


</details>


  </td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/611/files#diff-272a316cdf15707ddb7384f13258135f593fc560e21dc19cf17c16cfb5d0aa1c">+49/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>backend_jax.py</strong><dd><code>Switch to opt_einsum contract in JAX backend</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mrmustard/math/backend_jax.py

<li>Import <code>opt_einsum.contract</code><br> <li> Replace <code>jnp.einsum</code> with <code>contract</code> using JAX backend


</details>


  </td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/611/files#diff-277d6b9d9077473e0fca45c03a82a1503f283442e0b7503da968e5330ec3c242">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>backend_numpy.py</strong><dd><code>Explicit numpy backend in einsum contract</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mrmustard/math/backend_numpy.py

- Update `contract` call to explicitly specify numpy backend


</details>


  </td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/611/files#diff-c949c22a107a6cbdc038de07d7b8f9c9c5b3445a876d530ab2ee4780ca00e7a2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>backend_tensorflow.py</strong><dd><code>Switch to opt_einsum contract in TensorFlow backend</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mrmustard/math/backend_tensorflow.py

<li>Import <code>opt_einsum.contract</code><br> <li> Replace <code>tf.einsum</code> with <code>contract</code> using TensorFlow backend<br> <li> Remove optimize parameter handling logic


</details>


  </td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/611/files#diff-9b9d2f0045f871a5f865532687c4b9733e960270cfdb405a5688c2e62568feb0">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_backend_manager.py</strong><dd><code>Tests for backend override functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_math/test_backend_manager.py

<li>Add test for <code>get_backend</code> method functionality<br> <li> Add test for <code>einsum</code> with backend override parameter


</details>


  </td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/611/files#diff-b5f4030019d4b93690c2dc5eedc39069778bb3b175bd65b92a9a951249af1acb">+18/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>