### PR TITLE
Fixing flaky `test_full_batch_vjp`

### DIFF
--- a/mrmustard/math/backend_jax.py
+++ b/mrmustard/math/backend_jax.py
@@ -374,6 +374,9 @@ class BackendJax(BackendBase):
     def sum(self, array: jnp.ndarray, axes: Sequence[int] | None = None):
         return jnp.sum(array, axis=axes)
 
+    def swapaxes(self, array: jnp.ndarray, axis1: int, axis2: int) -> jnp.ndarray:
+        return jnp.swapaxes(array, axis1, axis2)
+
     @jax.jit
     def norm(self, array: jnp.ndarray) -> jnp.ndarray:
         return jnp.linalg.norm(array)

--- a/mrmustard/math/backend_jax.py
+++ b/mrmustard/math/backend_jax.py
@@ -264,6 +264,9 @@ class BackendJax(BackendBase):
     def inv(self, tensor: jnp.ndarray) -> jnp.ndarray:
         return jnp.linalg.inv(tensor)
 
+    def isnan(self, array: jnp.ndarray) -> jnp.ndarray:
+        return jnp.isnan(array)
+
     def is_trainable(self, tensor: jnp.ndarray) -> bool:
         return False
 

--- a/mrmustard/math/backend_manager.py
+++ b/mrmustard/math/backend_manager.py
@@ -853,6 +853,17 @@ class BackendManager:
         """
         return self._apply("inv", (tensor,))
 
+    def isnan(self, array: Tensor) -> Tensor:
+        r"""Whether the given array contains any NaN values.
+
+        Args:
+            array: The array to check for NaN values.
+
+        Returns:
+            Whether the given array contains any NaN values.
+        """
+        return self._apply("isnan", (array,))
+
     def is_trainable(self, tensor: Tensor) -> bool:
         r"""Whether the given tensor is trainable.
 

--- a/mrmustard/math/backend_manager.py
+++ b/mrmustard/math/backend_manager.py
@@ -1266,6 +1266,20 @@ class BackendManager:
             axis = tuple(sorted(neg) + sorted(pos)[::-1])
         return self._apply("sum", (array, axis))
 
+    def swapaxes(self, array: Tensor, axis1: int, axis2: int) -> Tensor:
+        r"""
+        Swap two axes of an array.
+
+        Args:
+            array: The array to swap axes of.
+            axis1: The first axis to swap.
+            axis2: The second axis to swap.
+
+        Returns:
+            The array with the axes swapped.
+        """
+        return self._apply("swapaxes", (array, axis1, axis2))
+
     def tensordot(self, a: Tensor, b: Tensor, axes: Sequence[int]) -> Tensor:
         r"""The tensordot product of ``a`` and ``b``.
 

--- a/mrmustard/math/backend_numpy.py
+++ b/mrmustard/math/backend_numpy.py
@@ -312,6 +312,9 @@ class BackendNumpy(BackendBase):
     def sum(self, array: np.ndarray, axis: int | tuple[int] | None = None):
         return np.sum(array, axis=axis)
 
+    def swapaxes(self, array: np.ndarray, axis1: int, axis2: int) -> np.ndarray:
+        return np.swapaxes(array, axis1, axis2)
+
     def tensordot(self, a: np.ndarray, b: np.ndarray, axes: list[int]) -> np.ndarray:
         return np.tensordot(a, b, axes)
 

--- a/mrmustard/math/backend_numpy.py
+++ b/mrmustard/math/backend_numpy.py
@@ -178,6 +178,9 @@ class BackendNumpy(BackendBase):
     def inv(self, tensor: np.ndarray) -> np.ndarray:
         return np.linalg.inv(tensor)
 
+    def isnan(self, array: np.ndarray) -> np.ndarray:
+        return np.isnan(array)
+
     def is_trainable(self, tensor: np.ndarray) -> bool:
         return False
 

--- a/mrmustard/math/backend_tensorflow.py
+++ b/mrmustard/math/backend_tensorflow.py
@@ -346,6 +346,9 @@ class BackendTensorflow(BackendBase):
     def sum(self, array: tf.Tensor, axis: int | tuple[int] | None = None):
         return tf.reduce_sum(array, axis)
 
+    def swapaxes(self, array: tf.Tensor, axis1: int, axis2: int) -> tf.Tensor:
+        return tf.experimental.numpy.swapaxes(array, axis1, axis2)
+
     @Autocast()
     def tensordot(self, a: tf.Tensor, b: tf.Tensor, axes: list[int]) -> tf.Tensor:
         return tf.tensordot(a, b, axes)

--- a/mrmustard/math/backend_tensorflow.py
+++ b/mrmustard/math/backend_tensorflow.py
@@ -209,6 +209,9 @@ class BackendTensorflow(BackendBase):
     def inv(self, tensor: tf.Tensor) -> tf.Tensor:
         return tf.linalg.inv(tensor)
 
+    def isnan(self, array: tf.Tensor) -> tf.Tensor:
+        return tf.math.is_nan(array)
+
     def is_trainable(self, tensor: tf.Tensor) -> bool:
         return isinstance(tensor, tf.Variable)
 

--- a/tests/test_math/test_backend_manager.py
+++ b/tests/test_math/test_backend_manager.py
@@ -433,6 +433,16 @@ class TestBackendManager:
         inv = math.inv(arr)
         assert math.allclose(math.asnumpy(arr @ inv), np.eye(2))
 
+    def test_isnan(self):
+        r"""
+        Tests the ``isnan`` method.
+        """
+        arr = np.array([1.0, 2.0, 3.0, 4.0])
+        assert not math.any(math.isnan(arr))
+
+        arr_nan = np.array([1.0, 2.0, np.nan, 4.0])
+        assert math.any(math.isnan(arr_nan))
+
     def test_is_trainable(self):
         r"""
         Tests the ``is_trainable`` method.

--- a/tests/test_math/test_backend_manager.py
+++ b/tests/test_math/test_backend_manager.py
@@ -666,6 +666,14 @@ class TestBackendManager:
         res = math.asnumpy(math.sum(arr))
         assert math.allclose(res, 12)
 
+    def test_swapaxes(self):
+        r"""
+        Tests the ``swapaxes`` method.
+        """
+        arr = np.array([[1.0, 1.0, 1.0], [2.0, 2.0, 2.0]])
+        res = np.array([[1.0, 2.0], [1.0, 2.0], [1.0, 2.0]])
+        assert math.allclose(res, math.swapaxes(arr, 0, 1))
+
     def test_displacement(self):
         r"""
         Tests the ``displacement`` method.

--- a/tests/test_math/test_lattice/test_vanilla.py
+++ b/tests/test_math/test_lattice/test_vanilla.py
@@ -28,8 +28,8 @@ def random_triple(n, batch=(), seed=None):
     rng = np.random.RandomState(seed) if seed is not None else np.random
 
     A = rng.random((*batch, n, n)) + 1j * rng.random((*batch, n, n))
-    A = A + np.swapaxes(A, -1, -2)
-    A /= np.abs(np.linalg.eigvals(A)).max() + 0.2
+    A = A + math.swapaxes(A, -1, -2)
+    A /= math.abs(math.eigvals(A)).max() + 0.2
     b = rng.random((*batch, n)) + 1j * rng.random((*batch, n))
     c = rng.random(batch) + 1j * rng.random(batch)
     return A, b, c
@@ -57,29 +57,29 @@ class TestVanilla:
 
         # Compute finite difference for c
         dGdc_fd = (strategies.vanilla_numba(shape, A, b, c + epsilon) - G) / epsilon
-        dLdc_fd = np.sum(dLdG * dGdc_fd)
+        dLdc_fd = math.sum(dLdG * dGdc_fd)
 
         # Compute finite differences for b
-        dGdb_fd = np.zeros(G.shape + b.shape, dtype=np.complex128)
+        dGdb_fd = math.zeros(G.shape + b.shape, dtype=math.complex128)
         for i in range(b.shape[0]):
-            eps = np.zeros_like(b)
+            eps = math.zeros_like(b)
             eps[i] = epsilon
             dGdb_fd[..., i] = (strategies.vanilla_numba(shape, A, b + eps, c) - G) / epsilon
-        dLdb_fd = np.zeros_like(b)
+        dLdb_fd = math.zeros_like(b)
         for i in range(b.shape[0]):
-            dLdb_fd[i] = np.sum(dLdG * dGdb_fd[..., i])
+            dLdb_fd[i] = math.sum(dLdG * dGdb_fd[..., i])
 
         # Compute finite differences for A
-        dGdA_fd = np.zeros(G.shape + A.shape, dtype=np.complex128)
+        dGdA_fd = math.zeros(G.shape + A.shape, dtype=math.complex128)
         for i in range(A.shape[0]):
             for j in range(A.shape[1]):
-                eps = np.zeros_like(A)
+                eps = math.zeros_like(A)
                 eps[i, j] = epsilon
                 dGdA_fd[..., i, j] = (strategies.vanilla_numba(shape, A + eps, b, c) - G) / epsilon
-        dLdA_fd = np.zeros_like(A)
+        dLdA_fd = math.zeros_like(A)
         for i in range(A.shape[0]):
             for j in range(A.shape[1]):
-                dLdA_fd[i, j] = np.sum(dLdG * dGdA_fd[..., i, j])
+                dLdA_fd[i, j] = math.sum(dLdG * dGdA_fd[..., i, j])
 
         dLdA, dLdb, dLdc = strategies.vanilla_vjp_numba(G, c, dLdG)
         assert math.allclose(dLdc, dLdc_fd)
@@ -103,50 +103,50 @@ class TestVanilla:
         )  # upstream gradient
 
         # Compute finite difference for c
-        dGdc_fd = np.zeros(G.shape + c.shape, dtype=np.complex128)
+        dGdc_fd = math.zeros(G.shape + c.shape, dtype=math.complex128)
         for i in range(c.shape[0]):
-            eps = np.zeros_like(c)
+            eps = math.zeros_like(c)
             eps[i] = epsilon
             dGdc_fd[..., i] = (strategies.vanilla_batch_numba(shape, A, b, c + eps) - G) / epsilon
 
         # Contract with upstream gradient
-        dLdc_fd = np.zeros_like(c)
+        dLdc_fd = math.zeros_like(c)
         for i in range(c.shape[0]):
-            dLdc_fd[i] = np.sum(dLdG * dGdc_fd[..., i])
+            dLdc_fd[i] = math.sum(dLdG * dGdc_fd[..., i])
 
         # Compute finite differences for b
-        dGdb_fd = np.zeros(G.shape + b.shape, dtype=np.complex128)  # shape: G.shape + b.shape
+        dGdb_fd = math.zeros(G.shape + b.shape, dtype=math.complex128)  # shape: G.shape + b.shape
         for i in range(b.shape[0]):
             for j in range(b.shape[1]):
-                eps = np.zeros_like(b)
+                eps = math.zeros_like(b)
                 eps[i, j] = epsilon
                 dGdb_fd[..., i, j] = (
                     strategies.vanilla_batch_numba(shape, A, b + eps, c) - G
                 ) / epsilon
 
         # Contract with upstream gradient
-        dLdb_fd = np.zeros_like(b)
+        dLdb_fd = math.zeros_like(b)
         for i in range(b.shape[0]):
             for j in range(b.shape[1]):
-                dLdb_fd[i, j] = np.sum(dLdG * dGdb_fd[..., i, j])
+                dLdb_fd[i, j] = math.sum(dLdG * dGdb_fd[..., i, j])
 
         # Compute finite differences for A
-        dGdA_fd = np.zeros(G.shape + A.shape, dtype=np.complex128)  # shape: G.shape + A.shape
+        dGdA_fd = math.zeros(G.shape + A.shape, dtype=math.complex128)  # shape: G.shape + A.shape
         for i in range(A.shape[0]):
             for j in range(A.shape[1]):
                 for k in range(A.shape[2]):
-                    eps = np.zeros_like(A)
+                    eps = math.zeros_like(A)
                     eps[i, j, k] = epsilon
                     dGdA_fd[..., i, j, k] = (
                         strategies.vanilla_batch_numba(shape, A + eps, b, c) - G
                     ) / epsilon
 
         # Contract with upstream gradient
-        dLdA_fd = np.zeros_like(A)
+        dLdA_fd = math.zeros_like(A)
         for i in range(A.shape[0]):
             for j in range(A.shape[1]):
                 for k in range(A.shape[2]):
-                    dLdA_fd[i, j, k] = np.sum(dLdG * dGdA_fd[..., i, j, k])
+                    dLdA_fd[i, j, k] = math.sum(dLdG * dGdA_fd[..., i, j, k])
 
         # Use the VJP function to compute gradients
         assert not math.any(math.isnan(G))
@@ -160,7 +160,7 @@ class TestVanilla:
         # Verify results
         assert math.allclose(dLdc, dLdc_fd, atol=2e-7)
         assert math.allclose(dLdb, dLdb_fd, atol=2e-7)
-        assert math.allclose(dLdA, (dLdA_fd + np.swapaxes(dLdA_fd, -1, -2)) / 2, atol=2e-7)
+        assert math.allclose(dLdA, (dLdA_fd + math.swapaxes(dLdA_fd, -1, -2)) / 2, atol=2e-7)
 
     @pytest.mark.parametrize("stable", [True, False])
     def test_hermite_renormalized_unbatched(self, stable):

--- a/tests/test_math/test_lattice/test_vanilla.py
+++ b/tests/test_math/test_lattice/test_vanilla.py
@@ -82,9 +82,9 @@ class TestVanilla:
                 dLdA_fd[i, j] = np.sum(dLdG * dGdA_fd[..., i, j])
 
         dLdA, dLdb, dLdc = strategies.vanilla_vjp_numba(G, c, dLdG)
-        assert np.allclose(dLdc, dLdc_fd)
-        assert np.allclose(dLdb, dLdb_fd)
-        assert np.allclose(dLdA, (dLdA_fd + dLdA_fd.T) / 2)
+        assert math.allclose(dLdc, dLdc_fd)
+        assert math.allclose(dLdb, dLdb_fd)
+        assert math.allclose(dLdA, (dLdA_fd + dLdA_fd.T) / 2)
 
     @pytest.mark.requires_backend("numpy")
     def test_full_batch_vjp(self):  # noqa: C901
@@ -149,18 +149,18 @@ class TestVanilla:
                     dLdA_fd[i, j, k] = np.sum(dLdG * dGdA_fd[..., i, j, k])
 
         # Use the VJP function to compute gradients
-        assert not np.isnan(G).any()
-        assert not np.isnan(dLdG).any()
-        assert not np.isnan(c).any()
+        assert not math.any(math.isnan(G))
+        assert not math.any(math.isnan(dLdG))
+        assert not math.any(math.isnan(c))
         dLdA, dLdb, dLdc = strategies.vanilla_batch_vjp_numba(G, c, dLdG)
-        assert not np.isnan(dLdA).any()
-        assert not np.isnan(dLdb).any()
-        assert not np.isnan(dLdc).any()
+        assert not math.any(math.isnan(dLdA))
+        assert not math.any(math.isnan(dLdb))
+        assert not math.any(math.isnan(dLdc))
 
         # Verify results
-        assert np.allclose(dLdc, dLdc_fd)
-        assert np.allclose(dLdb, dLdb_fd)
-        assert np.allclose(dLdA, (dLdA_fd + np.swapaxes(dLdA_fd, -1, -2)) / 2)
+        assert math.allclose(dLdc, dLdc_fd, atol=2e-7)
+        assert math.allclose(dLdb, dLdb_fd, atol=2e-7)
+        assert math.allclose(dLdA, (dLdA_fd + np.swapaxes(dLdA_fd, -1, -2)) / 2, atol=2e-7)
 
     @pytest.mark.parametrize("stable", [True, False])
     def test_hermite_renormalized_unbatched(self, stable):


### PR DESCRIPTION
**Context:** `test_full_batch_vjp` was sometimes (although fairly infrequently) flaky. This was fixed by increasing the tolerances. Specific tolerances were selected by using `pytest-repeat` with a high count of `100000` increasing the atol until it would pass each time.

**Description of the Change:** Increased `atol` on `test_full_batch_vjp` to `2e-7` such that it no longer fails. Additionally, cleaned up test_vanilla.py to use the math backend. Added `isnan` and `swapaxes` to the backend to support this. 

**Benefits:** This should be the last flaky test we have in Mr Mustard

**Possible Drawbacks:** We might still have some really rare flaky tests. We should keep track of these as we encounter them. 
