### PR TITLE
[Sc 95269] Improve linear superposition handling of built-in CircuitComponents

### DIFF
--- a/mrmustard/lab/circuit_components.py
+++ b/mrmustard/lab/circuit_components.py
@@ -811,7 +811,7 @@ class CircuitComponent:
                 other_val = other_param.value
                 self_val = [self_val] if not isinstance(self_val, Sequence) else list(self_val)
                 other_val = [other_val] if not isinstance(other_val, Sequence) else list(other_val)
-                new_params[name] = math.concat([self_val, other_val], axis=0)
+                new_params[name] = math.concat(math.astensor([self_val, other_val]), axis=0)
                 new_params[name + "_trainable"] = bool(isinstance(self_param, Variable))
             ret = self.__class__(self.modes, **new_params)
             ret.ansatz._lin_sup = True

--- a/mrmustard/lab/circuit_components.py
+++ b/mrmustard/lab/circuit_components.py
@@ -676,11 +676,7 @@ class CircuitComponent:
         cls = type(self)
         params = signature(cls).parameters
         if "mode" in params or "modes" in params:
-            ret = (
-                self.__class__(self.modes[0], **self.parameters.to_dict())
-                if "mode" in params
-                else self.__class__(self.modes, **self.parameters.to_dict())
-            )
+            ret = self.__class__(self.modes, **self.parameters.to_dict())
             ret._ansatz = ansatz
             ret._wires = wires
         else:
@@ -728,11 +724,7 @@ class CircuitComponent:
         cls = type(self)
         params = signature(cls).parameters
         if "mode" in params or "modes" in params:
-            ret = (
-                self.__class__(self.modes[0], **self.parameters.to_dict())
-                if "mode" in params
-                else self.__class__(self.modes, **self.parameters.to_dict())
-            )
+            ret = self.__class__(self.modes, **self.parameters.to_dict())
             ret._ansatz = fock
             ret._wires = wires
         else:
@@ -787,7 +779,7 @@ class CircuitComponent:
         if "modes" in params:
             serializable["modes"] = tuple(self.wires.modes)
         elif "mode" in params:
-            serializable["mode"] = next(iter(self.wires.modes))
+            serializable["mode"] = tuple(self.wires.modes)
         else:
             raise TypeError(f"{cls.__name__} does not seem to have any wires construction method")
 

--- a/mrmustard/lab/circuit_components.py
+++ b/mrmustard/lab/circuit_components.py
@@ -800,12 +800,12 @@ class CircuitComponent:
             raise ValueError("Cannot add components with different wires.")
         if self.ansatz._fn is not None and self.ansatz._fn == other.ansatz._fn:
             new_params = {}
-            for name in self.ansatz._fn_kwargs:
+            for name in self.ansatz._kwargs:
                 self_param = getattr(self.parameters, name)
                 other_param = getattr(other.parameters, name)
                 if type(self_param) is not type(other_param):
                     raise ValueError(
-                        f"Parameter '{name}' is a {type(self_param)} for one component and a {type(other_param)} for the other."
+                        f"Parameter '{name}' is a {type(self_param).__name__} for one component and a {type(other_param).__name__} for the other."
                     )
                 self_val = self_param.value
                 other_val = other_param.value

--- a/mrmustard/lab/circuit_components.py
+++ b/mrmustard/lab/circuit_components.py
@@ -33,6 +33,7 @@ from numpy.typing import ArrayLike
 from mrmustard import math, settings
 from mrmustard import widgets as mmwidgets
 from mrmustard.math.parameter_set import ParameterSet
+from mrmustard.math.parameters import Variable
 from mrmustard.physics.ansatz import Ansatz, ArrayAnsatz, PolyExpAnsatz
 from mrmustard.physics.fock_utils import oscillator_eigenstate
 from mrmustard.physics.triples import identity_Abc
@@ -811,6 +812,7 @@ class CircuitComponent:
                 self_val = [self_val] if not isinstance(self_val, Sequence) else list(self_val)
                 other_val = [other_val] if not isinstance(other_val, Sequence) else list(other_val)
                 new_params[name] = math.concat([self_val, other_val], axis=0)
+                new_params[name + "_trainable"] = bool(isinstance(self_param, Variable))
             ret = self.__class__(self.modes, **new_params)
             ret.ansatz._lin_sup = True
             return ret

--- a/mrmustard/lab/states/bargmann_eigenstate.py
+++ b/mrmustard/lab/states/bargmann_eigenstate.py
@@ -61,11 +61,12 @@ class BargmannEigenstate(Ket):
 
     def __init__(
         self,
-        mode: int,
+        mode: int | tuple[int],
         alpha: float | Sequence[float] = 0.0,
         alpha_trainable: bool = False,
         alpha_bounds: tuple[float | None, float | None] = (None, None),
     ):
+        mode = (mode,) if isinstance(mode, int) else mode
         super().__init__(name="BargmannEigenstate")
 
         self.parameters.add_parameter(
@@ -80,4 +81,4 @@ class BargmannEigenstate(Ket):
             fn=triples.bargmann_eigenstate_Abc,
             alpha=self.parameters.alpha,
         )
-        self._wires = Wires(modes_out_ket={mode})
+        self._wires = Wires(modes_out_ket=set(mode))

--- a/mrmustard/lab/states/bargmann_eigenstate.py
+++ b/mrmustard/lab/states/bargmann_eigenstate.py
@@ -75,6 +75,7 @@ class BargmannEigenstate(Ket):
                 value=alpha,
                 name="alpha",
                 bounds=alpha_bounds,
+                dtype=float,
             ),
         )
         self._ansatz = PolyExpAnsatz.from_function(

--- a/mrmustard/lab/states/coherent.py
+++ b/mrmustard/lab/states/coherent.py
@@ -75,7 +75,7 @@ class Coherent(Ket):
 
     def __init__(
         self,
-        mode: int,
+        mode: int | tuple[int],
         x: float | Sequence[float] = 0.0,
         y: float | Sequence[float] = 0.0,
         x_trainable: bool = False,
@@ -83,6 +83,7 @@ class Coherent(Ket):
         x_bounds: tuple[float | None, float | None] = (None, None),
         y_bounds: tuple[float | None, float | None] = (None, None),
     ):
+        mode = (mode,) if isinstance(mode, int) else mode
         super().__init__(name="Coherent")
         self.parameters.add_parameter(
             make_parameter(is_trainable=x_trainable, value=x, name="x", bounds=x_bounds),
@@ -96,4 +97,4 @@ class Coherent(Ket):
             x=self.parameters.x,
             y=self.parameters.y,
         )
-        self._wires = Wires(modes_out_ket={mode})
+        self._wires = Wires(modes_out_ket=set(mode))

--- a/mrmustard/lab/states/coherent.py
+++ b/mrmustard/lab/states/coherent.py
@@ -86,10 +86,14 @@ class Coherent(Ket):
         mode = (mode,) if isinstance(mode, int) else mode
         super().__init__(name="Coherent")
         self.parameters.add_parameter(
-            make_parameter(is_trainable=x_trainable, value=x, name="x", bounds=x_bounds),
+            make_parameter(
+                is_trainable=x_trainable, value=x, name="x", bounds=x_bounds, dtype=float
+            ),
         )
         self.parameters.add_parameter(
-            make_parameter(is_trainable=y_trainable, value=y, name="y", bounds=y_bounds),
+            make_parameter(
+                is_trainable=y_trainable, value=y, name="y", bounds=y_bounds, dtype=float
+            ),
         )
 
         self._ansatz = PolyExpAnsatz.from_function(

--- a/mrmustard/lab/states/displaced_squeezed.py
+++ b/mrmustard/lab/states/displaced_squeezed.py
@@ -83,16 +83,24 @@ class DisplacedSqueezed(Ket):
         mode = (mode,) if isinstance(mode, int) else mode
         super().__init__(name="DisplacedSqueezed")
         self.parameters.add_parameter(
-            make_parameter(is_trainable=x_trainable, value=x, name="x", bounds=x_bounds),
+            make_parameter(
+                is_trainable=x_trainable, value=x, name="x", bounds=x_bounds, dtype=float
+            ),
         )
         self.parameters.add_parameter(
-            make_parameter(is_trainable=y_trainable, value=y, name="y", bounds=y_bounds),
+            make_parameter(
+                is_trainable=y_trainable, value=y, name="y", bounds=y_bounds, dtype=float
+            ),
         )
         self.parameters.add_parameter(
-            make_parameter(is_trainable=r_trainable, value=r, name="r", bounds=r_bounds),
+            make_parameter(
+                is_trainable=r_trainable, value=r, name="r", bounds=r_bounds, dtype=float
+            ),
         )
         self.parameters.add_parameter(
-            make_parameter(is_trainable=phi_trainable, value=phi, name="phi", bounds=phi_bounds),
+            make_parameter(
+                is_trainable=phi_trainable, value=phi, name="phi", bounds=phi_bounds, dtype=float
+            ),
         )
 
         self._ansatz = PolyExpAnsatz.from_function(

--- a/mrmustard/lab/states/displaced_squeezed.py
+++ b/mrmustard/lab/states/displaced_squeezed.py
@@ -66,7 +66,7 @@ class DisplacedSqueezed(Ket):
 
     def __init__(
         self,
-        mode: int,
+        mode: int | tuple[int],
         x: float | Sequence[float] = 0.0,
         y: float | Sequence[float] = 0.0,
         r: float | Sequence[float] = 0.0,
@@ -80,6 +80,7 @@ class DisplacedSqueezed(Ket):
         r_bounds: tuple[float | None, float | None] = (None, None),
         phi_bounds: tuple[float | None, float | None] = (None, None),
     ):
+        mode = (mode,) if isinstance(mode, int) else mode
         super().__init__(name="DisplacedSqueezed")
         self.parameters.add_parameter(
             make_parameter(is_trainable=x_trainable, value=x, name="x", bounds=x_bounds),
@@ -101,4 +102,4 @@ class DisplacedSqueezed(Ket):
             r=self.parameters.r,
             phi=self.parameters.phi,
         )
-        self._wires = Wires(modes_out_ket={mode})
+        self._wires = Wires(modes_out_ket=set(mode))

--- a/mrmustard/lab/states/gaussian_state.py
+++ b/mrmustard/lab/states/gaussian_state.py
@@ -177,6 +177,7 @@ class GDM(DM):
                 value=betas,
                 name="beta",
                 bounds=(0, None),
+                dtype=float,
             ),
         )
         self._ansatz = PolyExpAnsatz.from_function(

--- a/mrmustard/lab/states/number.py
+++ b/mrmustard/lab/states/number.py
@@ -62,10 +62,11 @@ class Number(Ket):
 
     def __init__(
         self,
-        mode: int,
+        mode: int | tuple[int],
         n: int,
         cutoff: int | None = None,
     ) -> None:
+        mode = (mode,) if isinstance(mode, int) else mode
         cutoff = n if cutoff is None else cutoff
         super().__init__(name="N")
         self.parameters.add_parameter(make_parameter(False, n, "n", (None, None), dtype="int64"))
@@ -74,7 +75,7 @@ class Number(Ket):
         )
 
         self._ansatz = ArrayAnsatz.from_function(fock_state, n=n, cutoffs=cutoff)
-        self._wires = Wires(modes_out_ket={mode})
+        self._wires = Wires(modes_out_ket=set(mode))
         self.short_name = str(int(n))
         self.manual_shape[0] = cutoff + 1
 

--- a/mrmustard/lab/states/number.py
+++ b/mrmustard/lab/states/number.py
@@ -69,9 +69,9 @@ class Number(Ket):
         mode = (mode,) if isinstance(mode, int) else mode
         cutoff = n if cutoff is None else cutoff
         super().__init__(name="N")
-        self.parameters.add_parameter(make_parameter(False, n, "n", (None, None), dtype="int64"))
+        self.parameters.add_parameter(make_parameter(False, n, "n", (None, None), dtype=int))
         self.parameters.add_parameter(
-            make_parameter(False, cutoff, "cutoff", (None, None), dtype="int64"),
+            make_parameter(False, cutoff, "cutoff", (None, None), dtype=int),
         )
 
         self._ansatz = ArrayAnsatz.from_function(fock_state, n=n, cutoffs=cutoff)

--- a/mrmustard/lab/states/number.py
+++ b/mrmustard/lab/states/number.py
@@ -32,12 +32,10 @@ class Number(Ket):
     r"""
     The number state in Fock representation.
 
-
     Args:
         mode: The mode of the number state.
         n: The number of photons.
-        cutoffs: The cutoffs. If ``cutoffs`` is ``None``, it
-            defaults to ``n+1``.
+        cutoffs: The cutoff. If ``cutoffs`` is ``None``, it defaults to ``n+1``.
 
     .. code-block::
 
@@ -64,20 +62,20 @@ class Number(Ket):
         self,
         mode: int | tuple[int],
         n: int,
-        cutoff: int | None = None,
+        cutoffs: int | None = None,
     ) -> None:
         mode = (mode,) if isinstance(mode, int) else mode
-        cutoff = n if cutoff is None else cutoff
+        cutoffs = n if cutoffs is None else cutoffs
         super().__init__(name="N")
         self.parameters.add_parameter(make_parameter(False, n, "n", (None, None), dtype=int))
         self.parameters.add_parameter(
-            make_parameter(False, cutoff, "cutoff", (None, None), dtype=int),
+            make_parameter(False, cutoffs, "cutoffs", (None, None), dtype=int),
         )
 
-        self._ansatz = ArrayAnsatz.from_function(fock_state, n=n, cutoffs=cutoff)
+        self._ansatz = ArrayAnsatz.from_function(fock_state, n=n, cutoffs=cutoffs)
         self._wires = Wires(modes_out_ket=set(mode))
         self.short_name = str(int(n))
-        self.manual_shape[0] = cutoff + 1
+        self.manual_shape[0] = cutoffs + 1
 
         for w in self.wires.output.wires:
             w.repr = ReprEnum.FOCK

--- a/mrmustard/lab/states/quadrature_eigenstate.py
+++ b/mrmustard/lab/states/quadrature_eigenstate.py
@@ -73,10 +73,14 @@ class QuadratureEigenstate(Ket):
         super().__init__(name="QuadratureEigenstate")
 
         self.parameters.add_parameter(
-            make_parameter(is_trainable=x_trainable, value=x, name="x", bounds=x_bounds),
+            make_parameter(
+                is_trainable=x_trainable, value=x, name="x", bounds=x_bounds, dtype=float
+            ),
         )
         self.parameters.add_parameter(
-            make_parameter(is_trainable=phi_trainable, value=phi, name="phi", bounds=phi_bounds),
+            make_parameter(
+                is_trainable=phi_trainable, value=phi, name="phi", bounds=phi_bounds, dtype=float
+            ),
         )
         self.manual_shape = (50,)
 

--- a/mrmustard/lab/states/quadrature_eigenstate.py
+++ b/mrmustard/lab/states/quadrature_eigenstate.py
@@ -61,7 +61,7 @@ class QuadratureEigenstate(Ket):
 
     def __init__(
         self,
-        mode: int,
+        mode: int | tuple[int],
         x: float | Sequence[float] = 0.0,
         phi: float | Sequence[float] = 0.0,
         x_trainable: bool = False,
@@ -69,6 +69,7 @@ class QuadratureEigenstate(Ket):
         x_bounds: tuple[float | None, float | None] = (None, None),
         phi_bounds: tuple[float | None, float | None] = (None, None),
     ):
+        mode = (mode,) if isinstance(mode, int) else mode
         super().__init__(name="QuadratureEigenstate")
 
         self.parameters.add_parameter(
@@ -84,7 +85,7 @@ class QuadratureEigenstate(Ket):
             x=self.parameters.x,
             phi=self.parameters.phi,
         )
-        self._wires = Wires(modes_out_ket={mode})
+        self._wires = Wires(modes_out_ket=set(mode))
 
         for w in self.wires.output.wires:
             w.repr = ReprEnum.QUADRATURE

--- a/mrmustard/lab/states/sauron.py
+++ b/mrmustard/lab/states/sauron.py
@@ -55,7 +55,8 @@ class Sauron(Ket):
         >>> assert psi.modes == (0,)
     """
 
-    def __init__(self, mode: int, n: int, epsilon: float = 0.1):
+    def __init__(self, mode: int | tuple[int], n: int, epsilon: float = 0.1):
+        mode = (mode,) if isinstance(mode, int) else mode
         super().__init__(name=f"Sauron-{n}")
 
         self.parameters.add_parameter(make_parameter(False, n, "n", (None, None), dtype="int64"))
@@ -66,5 +67,5 @@ class Sauron(Ket):
             n=self.parameters.n,
             epsilon=self.parameters.epsilon,
         )
-        self._wires = Wires(modes_out_ket={mode})
+        self._wires = Wires(modes_out_ket=set(mode))
         self.ansatz._lin_sup = True

--- a/mrmustard/lab/states/sauron.py
+++ b/mrmustard/lab/states/sauron.py
@@ -59,8 +59,10 @@ class Sauron(Ket):
         mode = (mode,) if isinstance(mode, int) else mode
         super().__init__(name=f"Sauron-{n}")
 
-        self.parameters.add_parameter(make_parameter(False, n, "n", (None, None), dtype="int64"))
-        self.parameters.add_parameter(make_parameter(False, epsilon, "epsilon", (None, None)))
+        self.parameters.add_parameter(make_parameter(False, n, "n", (None, None), dtype=int))
+        self.parameters.add_parameter(
+            make_parameter(False, epsilon, "epsilon", (None, None), dtype=float)
+        )
 
         self._ansatz = PolyExpAnsatz.from_function(
             triples.sauron_state_Abc,

--- a/mrmustard/lab/states/squeezed_vacuum.py
+++ b/mrmustard/lab/states/squeezed_vacuum.py
@@ -56,7 +56,7 @@ class SqueezedVacuum(Ket):
 
     def __init__(
         self,
-        mode: int,
+        mode: int | tuple[int],
         r: float | Sequence[float] = 0.0,
         phi: float | Sequence[float] = 0.0,
         r_trainable: bool = False,
@@ -64,6 +64,7 @@ class SqueezedVacuum(Ket):
         r_bounds: tuple[float | None, float | None] = (None, None),
         phi_bounds: tuple[float | None, float | None] = (None, None),
     ):
+        mode = (mode,) if isinstance(mode, int) else mode
         super().__init__(name="SqueezedVacuum")
         self.parameters.add_parameter(
             make_parameter(is_trainable=r_trainable, value=r, name="r", bounds=r_bounds),
@@ -77,4 +78,4 @@ class SqueezedVacuum(Ket):
             r=self.parameters.r,
             phi=self.parameters.phi,
         )
-        self._wires = Wires(modes_out_ket={mode})
+        self._wires = Wires(modes_out_ket=set(mode))

--- a/mrmustard/lab/states/squeezed_vacuum.py
+++ b/mrmustard/lab/states/squeezed_vacuum.py
@@ -67,10 +67,14 @@ class SqueezedVacuum(Ket):
         mode = (mode,) if isinstance(mode, int) else mode
         super().__init__(name="SqueezedVacuum")
         self.parameters.add_parameter(
-            make_parameter(is_trainable=r_trainable, value=r, name="r", bounds=r_bounds),
+            make_parameter(
+                is_trainable=r_trainable, value=r, name="r", bounds=r_bounds, dtype=float
+            ),
         )
         self.parameters.add_parameter(
-            make_parameter(is_trainable=phi_trainable, value=phi, name="phi", bounds=phi_bounds),
+            make_parameter(
+                is_trainable=phi_trainable, value=phi, name="phi", bounds=phi_bounds, dtype=float
+            ),
         )
 
         self._ansatz = PolyExpAnsatz.from_function(

--- a/mrmustard/lab/states/thermal.py
+++ b/mrmustard/lab/states/thermal.py
@@ -56,11 +56,12 @@ class Thermal(DM):
 
     def __init__(
         self,
-        mode: int,
+        mode: int | tuple[int],
         nbar: int | Sequence[int] = 0,
         nbar_trainable: bool = False,
         nbar_bounds: tuple[float | None, float | None] = (0, None),
     ) -> None:
+        mode = (mode,) if isinstance(mode, int) else mode
         super().__init__(name="Thermal")
         self.parameters.add_parameter(
             make_parameter(
@@ -74,4 +75,4 @@ class Thermal(DM):
             fn=triples.thermal_state_Abc,
             nbar=self.parameters.nbar,
         )
-        self._wires = Wires(modes_out_bra={mode}, modes_out_ket={mode})
+        self._wires = Wires(modes_out_bra=set(mode), modes_out_ket=set(mode))

--- a/mrmustard/lab/states/two_mode_squeezed_vacuum.py
+++ b/mrmustard/lab/states/two_mode_squeezed_vacuum.py
@@ -68,10 +68,14 @@ class TwoModeSqueezedVacuum(Ket):
     ):
         super().__init__(name="TwoModeSqueezedVacuum")
         self.parameters.add_parameter(
-            make_parameter(is_trainable=r_trainable, value=r, name="r", bounds=r_bounds),
+            make_parameter(
+                is_trainable=r_trainable, value=r, name="r", bounds=r_bounds, dtype=float
+            ),
         )
         self.parameters.add_parameter(
-            make_parameter(is_trainable=phi_trainable, value=phi, name="phi", bounds=phi_bounds),
+            make_parameter(
+                is_trainable=phi_trainable, value=phi, name="phi", bounds=phi_bounds, dtype=float
+            ),
         )
         self._ansatz = PolyExpAnsatz.from_function(
             fn=triples.two_mode_squeezed_vacuum_state_Abc,

--- a/mrmustard/lab/transformations/amplifier.py
+++ b/mrmustard/lab/transformations/amplifier.py
@@ -79,11 +79,12 @@ class Amplifier(Channel):
 
     def __init__(
         self,
-        mode: int,
+        mode: int | tuple[int],
         gain: float | Sequence[float] = 1.0,
         gain_trainable: bool = False,
         gain_bounds: tuple[float | None, float | None] = (1.0, None),
     ):
+        mode = (mode,) if isinstance(mode, int) else mode
         super().__init__(name="Amp~")
         self.parameters.add_parameter(
             make_parameter(
@@ -95,8 +96,8 @@ class Amplifier(Channel):
         )
         self._ansatz = PolyExpAnsatz.from_function(fn=triples.amplifier_Abc, g=self.parameters.gain)
         self._wires = Wires(
-            modes_in_bra={mode},
-            modes_out_bra={mode},
-            modes_in_ket={mode},
-            modes_out_ket={mode},
+            modes_in_bra=set(mode),
+            modes_out_bra=set(mode),
+            modes_in_ket=set(mode),
+            modes_out_ket=set(mode),
         )

--- a/mrmustard/lab/transformations/amplifier.py
+++ b/mrmustard/lab/transformations/amplifier.py
@@ -92,6 +92,7 @@ class Amplifier(Channel):
                 value=gain,
                 name="gain",
                 bounds=gain_bounds,
+                dtype=float,
             ),
         )
         self._ansatz = PolyExpAnsatz.from_function(fn=triples.amplifier_Abc, g=self.parameters.gain)

--- a/mrmustard/lab/transformations/attenuator.py
+++ b/mrmustard/lab/transformations/attenuator.py
@@ -92,6 +92,7 @@ class Attenuator(Channel):
                 value=transmissivity,
                 name="transmissivity",
                 bounds=transmissivity_bounds,
+                dtype=float,
             ),
         )
 

--- a/mrmustard/lab/transformations/attenuator.py
+++ b/mrmustard/lab/transformations/attenuator.py
@@ -79,11 +79,12 @@ class Attenuator(Channel):
 
     def __init__(
         self,
-        mode: int,
+        mode: int | tuple[int],
         transmissivity: float | Sequence[float] = 1.0,
         transmissivity_trainable: bool = False,
         transmissivity_bounds: tuple[float | None, float | None] = (0.0, 1.0),
     ):
+        mode = (mode,) if isinstance(mode, int) else mode
         super().__init__(name="Att~")
         self.parameters.add_parameter(
             make_parameter(
@@ -99,8 +100,8 @@ class Attenuator(Channel):
             eta=self.parameters.transmissivity,
         )
         self._wires = Wires(
-            modes_in_bra={mode},
-            modes_out_bra={mode},
-            modes_in_ket={mode},
-            modes_out_ket={mode},
+            modes_in_bra=set(mode),
+            modes_out_bra=set(mode),
+            modes_in_ket=set(mode),
+            modes_out_ket=set(mode),
         )

--- a/mrmustard/lab/transformations/bsgate.py
+++ b/mrmustard/lab/transformations/bsgate.py
@@ -98,8 +98,12 @@ class BSgate(Unitary):
         phi_bounds: tuple[float | None, float | None] = (None, None),
     ):
         super().__init__(name="BSgate")
-        self.parameters.add_parameter(make_parameter(theta_trainable, theta, "theta", theta_bounds))
-        self.parameters.add_parameter(make_parameter(phi_trainable, phi, "phi", phi_bounds))
+        self.parameters.add_parameter(
+            make_parameter(theta_trainable, theta, "theta", theta_bounds, dtype=float)
+        )
+        self.parameters.add_parameter(
+            make_parameter(phi_trainable, phi, "phi", phi_bounds, dtype=float)
+        )
         self._ansatz = PolyExpAnsatz.from_function(
             fn=triples.beamsplitter_gate_Abc,
             theta=self.parameters.theta,

--- a/mrmustard/lab/transformations/bsgate.py
+++ b/mrmustard/lab/transformations/bsgate.py
@@ -147,6 +147,8 @@ class BSgate(Unitary):
                 [math.beamsplitter(t, p, shape=shape, method=method) for t, p in zip(theta, phi)],
             )
             ret = math.reshape(ret, self.ansatz.batch_shape + shape)
+            if self.ansatz._lin_sup:
+                ret = math.sum(ret, axis=self.ansatz.batch_dims - 1)
         else:
             ret = math.beamsplitter(
                 self.parameters.theta.value,

--- a/mrmustard/lab/transformations/bsgate.py
+++ b/mrmustard/lab/transformations/bsgate.py
@@ -19,14 +19,13 @@ The class representing a beam splitter gate.
 from __future__ import annotations
 
 from collections.abc import Sequence
-from dataclasses import replace
 
 from mrmustard import math
 from mrmustard.utils.typing import ComplexTensor
 
 from ...physics import triples
-from ...physics.ansatz import ArrayAnsatz, PolyExpAnsatz
-from ...physics.wires import ReprEnum, Wires
+from ...physics.ansatz import PolyExpAnsatz
+from ...physics.wires import Wires
 from ..utils import make_parameter
 from .base import Unitary
 
@@ -155,17 +154,4 @@ class BSgate(Unitary):
                 shape=shape,
                 method=method,
             )
-        return ret
-
-    def to_fock(self, shape: int | Sequence[int] | None = None) -> BSgate:
-        batch_dims = self.ansatz.batch_dims - self.ansatz._lin_sup
-        fock = ArrayAnsatz(self.fock_array(shape), batch_dims=batch_dims)
-        fock._original_abc_data = self.ansatz.triple
-        ret = self.__class__(self.modes, **self.parameters.to_dict())
-        wires = Wires.from_wires(
-            quantum={replace(w, repr=ReprEnum.FOCK) for w in self.wires.quantum},
-            classical={replace(w, repr=ReprEnum.FOCK) for w in self.wires.classical},
-        )
-        ret._ansatz = fock
-        ret._wires = wires
         return ret

--- a/mrmustard/lab/transformations/cxgate.py
+++ b/mrmustard/lab/transformations/cxgate.py
@@ -68,7 +68,9 @@ class CXgate(Unitary):
     ):
         super().__init__(name="CXgate")
         self.parameters.add_parameter(
-            make_parameter(is_trainable=s_trainable, value=s, name="s", bounds=s_bounds),
+            make_parameter(
+                is_trainable=s_trainable, value=s, name="s", bounds=s_bounds, dtype=float
+            ),
         )
 
         self._ansatz = PolyExpAnsatz.from_function(

--- a/mrmustard/lab/transformations/czgate.py
+++ b/mrmustard/lab/transformations/czgate.py
@@ -69,7 +69,9 @@ class CZgate(Unitary):
     ):
         super().__init__(name="CZgate")
         self.parameters.add_parameter(
-            make_parameter(is_trainable=s_trainable, value=s, name="s", bounds=s_bounds),
+            make_parameter(
+                is_trainable=s_trainable, value=s, name="s", bounds=s_bounds, dtype=float
+            ),
         )
         self._ansatz = PolyExpAnsatz.from_function(
             fn=lambda s: Unitary.from_symplectic(

--- a/mrmustard/lab/transformations/dgate.py
+++ b/mrmustard/lab/transformations/dgate.py
@@ -81,7 +81,7 @@ class Dgate(Unitary):
 
     def __init__(
         self,
-        mode: int,
+        mode: int | tuple[int],
         x: float | Sequence[float] = 0.0,
         y: float | Sequence[float] = 0.0,
         x_trainable: bool = False,
@@ -89,6 +89,7 @@ class Dgate(Unitary):
         x_bounds: tuple[float | None, float | None] = (None, None),
         y_bounds: tuple[float | None, float | None] = (None, None),
     ) -> None:
+        mode = (mode,) if isinstance(mode, int) else mode
         super().__init__(name="Dgate")
         self.parameters.add_parameter(make_parameter(x_trainable, x, "x", x_bounds))
         self.parameters.add_parameter(make_parameter(y_trainable, y, "y", y_bounds))
@@ -97,7 +98,7 @@ class Dgate(Unitary):
             x=self.parameters.x,
             y=self.parameters.y,
         )
-        self._wires = Wires(set(), set(), {mode}, {mode})
+        self._wires = Wires(set(), set(), set(mode), set(mode))
 
     def fock_array(self, shape: int | Sequence[int] | None = None) -> ComplexTensor:
         r"""

--- a/mrmustard/lab/transformations/dgate.py
+++ b/mrmustard/lab/transformations/dgate.py
@@ -91,8 +91,8 @@ class Dgate(Unitary):
     ) -> None:
         mode = (mode,) if isinstance(mode, int) else mode
         super().__init__(name="Dgate")
-        self.parameters.add_parameter(make_parameter(x_trainable, x, "x", x_bounds))
-        self.parameters.add_parameter(make_parameter(y_trainable, y, "y", y_bounds))
+        self.parameters.add_parameter(make_parameter(x_trainable, x, "x", x_bounds, dtype=float))
+        self.parameters.add_parameter(make_parameter(y_trainable, y, "y", y_bounds, dtype=float))
         self._ansatz = PolyExpAnsatz.from_function(
             fn=triples.displacement_gate_Abc,
             x=self.parameters.x,

--- a/mrmustard/lab/transformations/dgate.py
+++ b/mrmustard/lab/transformations/dgate.py
@@ -19,14 +19,13 @@ The class representing a displacement gate.
 from __future__ import annotations
 
 from collections.abc import Sequence
-from dataclasses import replace
 
 from mrmustard import math
 from mrmustard.utils.typing import ComplexTensor
 
 from ...physics import triples
-from ...physics.ansatz import ArrayAnsatz, PolyExpAnsatz
-from ...physics.wires import ReprEnum, Wires
+from ...physics.ansatz import PolyExpAnsatz
+from ...physics.wires import Wires
 from ..utils import make_parameter
 from .base import Unitary
 
@@ -126,19 +125,8 @@ class Dgate(Unitary):
             y = math.reshape(y, (-1,))
             ret = math.astensor([math.displacement(xi, yi, shape=shape) for xi, yi in zip(x, y)])
             ret = math.reshape(ret, self.ansatz.batch_shape + shape)
+            if self.ansatz._lin_sup:
+                ret = math.sum(ret, axis=self.ansatz.batch_dims - 1)
         else:
             ret = math.displacement(self.parameters.x.value, self.parameters.y.value, shape=shape)
-        return ret
-
-    def to_fock(self, shape: int | Sequence[int] | None = None) -> Dgate:
-        batch_dims = self.ansatz.batch_dims - self.ansatz._lin_sup
-        fock = ArrayAnsatz(self.fock_array(shape), batch_dims=batch_dims)
-        fock._original_abc_data = self.ansatz.triple
-        ret = self.__class__(self.modes[0], **self.parameters.to_dict())
-        wires = Wires.from_wires(
-            quantum={replace(w, repr=ReprEnum.FOCK) for w in self.wires.quantum},
-            classical={replace(w, repr=ReprEnum.FOCK) for w in self.wires.classical},
-        )
-        ret._ansatz = fock
-        ret._wires = wires
         return ret

--- a/mrmustard/lab/transformations/fockdamping.py
+++ b/mrmustard/lab/transformations/fockdamping.py
@@ -68,11 +68,12 @@ class FockDamping(Operation):
 
     def __init__(
         self,
-        mode: int,
+        mode: int | tuple[int],
         damping: float | Sequence[float] = 0.0,
         damping_trainable: bool = False,
         damping_bounds: tuple[float | None, float | None] = (0.0, None),
     ):
+        mode = (mode,) if isinstance(mode, int) else mode
         super().__init__(name="FockDamping")
         self.parameters.add_parameter(
             make_parameter(
@@ -87,4 +88,4 @@ class FockDamping(Operation):
             fn=triples.fock_damping_Abc,
             beta=self.parameters.damping,
         )
-        self._wires = Wires(modes_in_ket={mode}, modes_out_ket={mode})
+        self._wires = Wires(modes_in_ket=set(mode), modes_out_ket=set(mode))

--- a/mrmustard/lab/transformations/fockdamping.py
+++ b/mrmustard/lab/transformations/fockdamping.py
@@ -82,6 +82,7 @@ class FockDamping(Operation):
                 "damping",
                 damping_bounds,
                 None,
+                dtype=float,
             ),
         )
         self._ansatz = PolyExpAnsatz.from_function(

--- a/mrmustard/lab/transformations/mzgate.py
+++ b/mrmustard/lab/transformations/mzgate.py
@@ -72,8 +72,12 @@ class MZgate(Unitary):
         internal: bool = False,
     ):
         super().__init__(name="MZgate")
-        self.parameters.add_parameter(make_parameter(phi_a_trainable, phi_a, "phi_a", phi_a_bounds))
-        self.parameters.add_parameter(make_parameter(phi_b_trainable, phi_b, "phi_b", phi_b_bounds))
+        self.parameters.add_parameter(
+            make_parameter(phi_a_trainable, phi_a, "phi_a", phi_a_bounds, dtype=float)
+        )
+        self.parameters.add_parameter(
+            make_parameter(phi_b_trainable, phi_b, "phi_b", phi_b_bounds, dtype=float)
+        )
 
         self._ansatz = PolyExpAnsatz.from_function(
             fn=lambda phi_a, phi_b, internal: Unitary.from_symplectic(

--- a/mrmustard/lab/transformations/pgate.py
+++ b/mrmustard/lab/transformations/pgate.py
@@ -54,11 +54,12 @@ class Pgate(Unitary):
 
     def __init__(
         self,
-        mode: int,
+        mode: int | tuple[int],
         shearing: float | Sequence[float] = 0.0,
         shearing_trainable: bool = False,
         shearing_bounds: tuple[float | None, float | None] = (None, None),
     ):
+        mode = (mode,) if isinstance(mode, int) else mode
         super().__init__(name="Pgate")
         self.parameters.add_parameter(
             make_parameter(
@@ -75,4 +76,4 @@ class Pgate(Unitary):
             ).bargmann_triple(),
             shearing=self.parameters.shearing,
         )
-        self._wires = Wires(modes_in_ket={mode}, modes_out_ket={mode})
+        self._wires = Wires(modes_in_ket=set(mode), modes_out_ket=set(mode))

--- a/mrmustard/lab/transformations/pgate.py
+++ b/mrmustard/lab/transformations/pgate.py
@@ -67,6 +67,7 @@ class Pgate(Unitary):
                 value=shearing,
                 name="shearing",
                 bounds=shearing_bounds,
+                dtype=float,
             ),
         )
         self._ansatz = PolyExpAnsatz.from_function(

--- a/mrmustard/lab/transformations/phasenoise.py
+++ b/mrmustard/lab/transformations/phasenoise.py
@@ -58,21 +58,22 @@ class PhaseNoise(Channel):
 
     def __init__(
         self,
-        mode: int,
+        mode: int | tuple[int],
         phase_stdev: float = 0.0,
         phase_stdev_trainable: bool = False,
         phase_stdev_bounds: tuple[float | None, float | None] = (0.0, None),
     ):
+        mode = (mode,) if isinstance(mode, int) else mode
         super().__init__(name="PhaseNoise")
         self.parameters.add_parameter(
             make_parameter(phase_stdev_trainable, phase_stdev, "phase_stdev", phase_stdev_bounds),
         )
         self._ansatz = None
         self._wires = Wires(
-            modes_in_bra={mode},
-            modes_out_bra={mode},
-            modes_in_ket={mode},
-            modes_out_ket={mode},
+            modes_in_bra=set(mode),
+            modes_out_bra=set(mode),
+            modes_in_ket=set(mode),
+            modes_out_ket=set(mode),
         )
 
     def __custom_rrshift__(self, other: CircuitComponent) -> CircuitComponent:

--- a/mrmustard/lab/transformations/phasenoise.py
+++ b/mrmustard/lab/transformations/phasenoise.py
@@ -66,7 +66,9 @@ class PhaseNoise(Channel):
         mode = (mode,) if isinstance(mode, int) else mode
         super().__init__(name="PhaseNoise")
         self.parameters.add_parameter(
-            make_parameter(phase_stdev_trainable, phase_stdev, "phase_stdev", phase_stdev_bounds),
+            make_parameter(
+                phase_stdev_trainable, phase_stdev, "phase_stdev", phase_stdev_bounds, dtype=float
+            ),
         )
         self._ansatz = None
         self._wires = Wires(

--- a/mrmustard/lab/transformations/rgate.py
+++ b/mrmustard/lab/transformations/rgate.py
@@ -53,15 +53,16 @@ class Rgate(Unitary):
 
     def __init__(
         self,
-        mode: int,
+        mode: int | tuple[int],
         theta: float | Sequence[float] = 0.0,
         theta_trainable: bool = False,
         theta_bounds: tuple[float | None, float | None] = (0.0, None),
     ):
+        mode = (mode,) if isinstance(mode, int) else mode
         super().__init__(name="Rgate")
         self.parameters.add_parameter(make_parameter(theta_trainable, theta, "theta", theta_bounds))
         self._ansatz = PolyExpAnsatz.from_function(
             fn=triples.rotation_gate_Abc,
             theta=self.parameters.theta,
         )
-        self._wires = Wires(modes_in_ket={mode}, modes_out_ket={mode})
+        self._wires = Wires(modes_in_ket=set(mode), modes_out_ket=set(mode))

--- a/mrmustard/lab/transformations/rgate.py
+++ b/mrmustard/lab/transformations/rgate.py
@@ -60,7 +60,9 @@ class Rgate(Unitary):
     ):
         mode = (mode,) if isinstance(mode, int) else mode
         super().__init__(name="Rgate")
-        self.parameters.add_parameter(make_parameter(theta_trainable, theta, "theta", theta_bounds))
+        self.parameters.add_parameter(
+            make_parameter(theta_trainable, theta, "theta", theta_bounds, dtype=float)
+        )
         self._ansatz = PolyExpAnsatz.from_function(
             fn=triples.rotation_gate_Abc,
             theta=self.parameters.theta,

--- a/mrmustard/lab/transformations/s2gate.py
+++ b/mrmustard/lab/transformations/s2gate.py
@@ -80,10 +80,14 @@ class S2gate(Unitary):
     ):
         super().__init__(name="S2gate")
         self.parameters.add_parameter(
-            make_parameter(is_trainable=r_trainable, value=r, name="r", bounds=r_bounds),
+            make_parameter(
+                is_trainable=r_trainable, value=r, name="r", bounds=r_bounds, dtype=float
+            ),
         )
         self.parameters.add_parameter(
-            make_parameter(is_trainable=phi_trainable, value=phi, name="phi", bounds=phi_bounds),
+            make_parameter(
+                is_trainable=phi_trainable, value=phi, name="phi", bounds=phi_bounds, dtype=float
+            ),
         )
         self._ansatz = PolyExpAnsatz.from_function(
             fn=triples.twomode_squeezing_gate_Abc,

--- a/mrmustard/lab/transformations/sgate.py
+++ b/mrmustard/lab/transformations/sgate.py
@@ -81,7 +81,7 @@ class Sgate(Unitary):
 
     def __init__(
         self,
-        mode: int,
+        mode: int | tuple[int],
         r: float | Sequence[float] = 0.0,
         phi: float | Sequence[float] = 0.0,
         r_trainable: bool = False,
@@ -89,6 +89,7 @@ class Sgate(Unitary):
         r_bounds: tuple[float | None, float | None] = (0.0, None),
         phi_bounds: tuple[float | None, float | None] = (None, None),
     ):
+        mode = (mode,) if isinstance(mode, int) else mode
         super().__init__(name="Sgate")
         self.parameters.add_parameter(
             make_parameter(is_trainable=r_trainable, value=r, name="r", bounds=r_bounds),
@@ -104,6 +105,6 @@ class Sgate(Unitary):
         self._wires = Wires(
             modes_in_bra=set(),
             modes_out_bra=set(),
-            modes_in_ket={mode},
-            modes_out_ket={mode},
+            modes_in_ket=set(mode),
+            modes_out_ket=set(mode),
         )

--- a/mrmustard/lab/transformations/sgate.py
+++ b/mrmustard/lab/transformations/sgate.py
@@ -92,10 +92,14 @@ class Sgate(Unitary):
         mode = (mode,) if isinstance(mode, int) else mode
         super().__init__(name="Sgate")
         self.parameters.add_parameter(
-            make_parameter(is_trainable=r_trainable, value=r, name="r", bounds=r_bounds),
+            make_parameter(
+                is_trainable=r_trainable, value=r, name="r", bounds=r_bounds, dtype=float
+            ),
         )
         self.parameters.add_parameter(
-            make_parameter(is_trainable=phi_trainable, value=phi, name="phi", bounds=phi_bounds),
+            make_parameter(
+                is_trainable=phi_trainable, value=phi, name="phi", bounds=phi_bounds, dtype=float
+            ),
         )
         self._ansatz = PolyExpAnsatz.from_function(
             fn=triples.squeezing_gate_Abc,

--- a/mrmustard/math/backend_manager.py
+++ b/mrmustard/math/backend_manager.py
@@ -445,6 +445,7 @@ class BackendManager:
         Returns:
             The concatenated values.
         """
+        values = self.astensor(values)
         return self._apply("concat", (values, axis))
 
     def conj(self, array: Tensor) -> Tensor:

--- a/mrmustard/math/backend_manager.py
+++ b/mrmustard/math/backend_manager.py
@@ -445,7 +445,6 @@ class BackendManager:
         Returns:
             The concatenated values.
         """
-        values = self.astensor(values)
         return self._apply("concat", (values, axis))
 
     def conj(self, array: Tensor) -> Tensor:

--- a/mrmustard/math/parameter_set.py
+++ b/mrmustard/math/parameter_set.py
@@ -57,25 +57,18 @@ class ParameterSet:
         self._variables: dict[str, Variable] = {}
 
     @property
-    def constants(self) -> dict[str, Constant]:
-        r"""
-        The constant parameters in this parameter set.
-        """
-        return self._constants
-
-    @property
-    def variables(self) -> dict[str, Variable]:
-        r"""
-        The variable parameters in this parameter set.
-        """
-        return self._variables
-
-    @property
     def all_parameters(self) -> dict[str, Constant | Variable]:
         r"""
         The constant and variable parameters in this parameter set.
         """
         return self.constants | self.variables
+
+    @property
+    def constants(self) -> dict[str, Constant]:
+        r"""
+        The constant parameters in this parameter set.
+        """
+        return self._constants
 
     @property
     def names(self) -> Sequence[str]:
@@ -84,6 +77,13 @@ class ParameterSet:
         were added.
         """
         return self._names
+
+    @property
+    def variables(self) -> dict[str, Variable]:
+        r"""
+        The variable parameters in this parameter set.
+        """
+        return self._variables
 
     def add_parameter(self, parameter: Constant | Variable) -> None:
         r"""
@@ -158,6 +158,24 @@ class ParameterSet:
             strings.append(string)
         return ", ".join(strings)
 
+    def __bool__(self) -> bool:
+        r"""
+        ``False`` if this parameter set is empty, ``True`` otherwise.
+        """
+        return bool(self._constants or self._variables)
+
+    def __eq__(self, other: object) -> bool:
+        r"""
+        Returns whether ``other`` is equivalent to this parameter set.
+        """
+        if not isinstance(other, ParameterSet):
+            return False
+        return (
+            self._names == other._names
+            and self._constants == other._constants
+            and self._variables == other._variables
+        )
+
     def __getitem__(self, items: int | Sequence[int]):
         r"""
         Returns a parameter set that contains slices of the parameters in this parameter set.
@@ -216,21 +234,3 @@ class ParameterSet:
                 ret.add_parameter(var)
 
         return ret
-
-    def __bool__(self) -> bool:
-        r"""
-        ``False`` if this parameter set is empty, ``True`` otherwise.
-        """
-        return bool(self._constants or self._variables)
-
-    def __eq__(self, other: object) -> bool:
-        r"""
-        Returns whether ``other`` is equivalent to this parameter set.
-        """
-        if not isinstance(other, ParameterSet):
-            return False
-        return (
-            self._names == other._names
-            and self._constants == other._constants
-            and self._variables == other._variables
-        )

--- a/mrmustard/physics/ansatz/polyexp_ansatz.py
+++ b/mrmustard/physics/ansatz/polyexp_ansatz.py
@@ -123,8 +123,6 @@ class PolyExpAnsatz(Ansatz):
 
         self.name = name
         self._simplified = False
-        self._fn = None
-        self._fn_kwargs = {}
         self._lin_sup = lin_sup
 
     @property
@@ -285,7 +283,7 @@ class PolyExpAnsatz(Ansatz):
         """
         ansatz = cls(None, None, None, None)
         ansatz._fn = fn
-        ansatz._fn_kwargs = kwargs
+        ansatz._kwargs = kwargs
         return ansatz
 
     def contract(
@@ -678,7 +676,7 @@ class PolyExpAnsatz(Ansatz):
         """
         if self._should_regenerate():
             params = {}
-            for name, param in self._fn_kwargs.items():
+            for name, param in self._kwargs.items():
                 try:
                     params[name] = param.value
                 except AttributeError:
@@ -808,7 +806,7 @@ class PolyExpAnsatz(Ansatz):
             self._A is None
             or self._b is None
             or self._c is None
-            or Variable in {type(param) for param in self._fn_kwargs.values()}
+            or Variable in {type(param) for param in self._kwargs.values()}
         )
 
     def __add__(self, other: PolyExpAnsatz) -> PolyExpAnsatz:
@@ -1005,8 +1003,8 @@ class PolyExpAnsatz(Ansatz):
         if self._fn is not None:
             fn_name = getattr(self._fn, "__name__", str(self._fn))
             repr_str.append(f"  Generated from: {fn_name}")
-            if self._fn_kwargs:
-                param_str = ", ".join(f"{k}={v}" for k, v in self._fn_kwargs.items())
+            if self._kwargs:
+                param_str = ", ".join(f"{k}={v}" for k, v in self._kwargs.items())
                 repr_str.append(f"  Parameters: {param_str}")
 
         return "\n".join(repr_str)

--- a/tests/test_lab/test_circuit_components.py
+++ b/tests/test_lab/test_circuit_components.py
@@ -219,11 +219,36 @@ class TestCircuitComponent:
         assert math.allclose(barg_cc.ansatz.c, fock_cc.ansatz.data)
 
     def test_add(self):
+        cc1 = CircuitComponent.from_bargmann(Abc_triple(1), modes_out_ket=(0,))
+        cc2 = CircuitComponent.from_bargmann(Abc_triple(1), modes_out_ket=(0,))
+
+        cc12 = cc1 + cc2
+
+        assert cc12.ansatz == cc1.ansatz + cc2.ansatz
+        assert cc12.ansatz._lin_sup is True
+
+    def test_add_built_in(self):
         d1 = Dgate(1, x=0.1, y=0.1)
         d2 = Dgate(1, x=0.2, y=0.2)
 
         d12 = d1 + d2
+
+        assert isinstance(d12, Dgate)
+        assert math.allclose(d12.parameters.x.value, [0.1, 0.2])
+        assert math.allclose(d12.parameters.y.value, [0.1, 0.2])
+        assert d12.ansatz._lin_sup is True
         assert d12.ansatz == d1.ansatz + d2.ansatz
+
+    def test_add_error(self):
+        d1 = Dgate(1, x=0.1, y=0.1)
+        d2 = Dgate(2, x=0.2, y=0.2)
+        d3 = Dgate(1, x=0.1, y=0.1, x_trainable=True)
+
+        with pytest.raises(ValueError):
+            d1 + d2
+
+        with pytest.raises(ValueError, match="Parameter 'x' is a Constant"):
+            d1 + d3
 
     def test_sub(self):
         s1 = DisplacedSqueezed(1, x=1.0, y=0.5, r=0.1)
@@ -243,13 +268,6 @@ class TestCircuitComponent:
 
         assert (d1 / 3).ansatz == d1.ansatz / 3
         assert isinstance(d1 / 3, Unitary)
-
-    def test_add_error(self):
-        d1 = Dgate(1, x=0.1, y=0.1)
-        d2 = Dgate(2, x=0.2, y=0.2)
-
-        with pytest.raises(ValueError):
-            d1 + d2
 
     def test_eq(self):
         d1 = Dgate(1, x=0.1, y=0.1)

--- a/tests/test_lab/test_circuit_components.py
+++ b/tests/test_lab/test_circuit_components.py
@@ -243,12 +243,16 @@ class TestCircuitComponent:
         d1 = Dgate(1, x=0.1, y=0.1)
         d2 = Dgate(2, x=0.2, y=0.2)
         d3 = Dgate(1, x=0.1, y=0.1, x_trainable=True)
+        d4 = Dgate(1, x=0.1, y=0.1, x_trainable=True, x_bounds=(0, 1))
 
         with pytest.raises(ValueError):
             d1 + d2
 
-        with pytest.raises(ValueError, match="Parameter 'x' is a Constant"):
+        with pytest.raises(ValueError, match="Parameter 'x' is a"):
             d1 + d3
+
+        with pytest.raises(ValueError, match="Parameter 'x' has bounds"):
+            d3 + d4
 
     def test_sub(self):
         s1 = DisplacedSqueezed(1, x=1.0, y=0.5, r=0.1)

--- a/tests/test_lab/test_transformations/test_bsgate.py
+++ b/tests/test_lab/test_transformations/test_bsgate.py
@@ -89,3 +89,9 @@ class TestBSgate:
 
         bs_with_batch = BSgate((0, 1), math.astensor([[1, 2]]), math.astensor([[3], [4], [5]]))
         assert bs_with_batch.fock_array(5, method="stable").shape == (3, 2, 5, 5, 5, 5)
+
+    def test_to_fock_lin_sup(self):
+        dgate = (BSgate((0, 1), 2, 3) + BSgate((0, 1), -2, -3)).to_fock(5)
+        assert dgate.ansatz.batch_dims == 0
+        assert dgate.ansatz.batch_shape == ()
+        assert dgate.ansatz.array.shape == (5, 5, 5, 5)

--- a/tests/test_physics/test_symplectics.py
+++ b/tests/test_physics/test_symplectics.py
@@ -161,9 +161,7 @@ def test_MZgate_internal_tms(phi_a, phi_b):
 def test_amplifier_on_coherent_is_thermal_coherent(g, x, y):
     """Tests that amplifying a coherent state is equivalent to preparing a thermal state displaced state"""
     assert Vacuum(0) >> Dgate(0, x, y) >> Amplifier(0, g) == Thermal(0, g - 1) >> Dgate(
-        0,
-        np.sqrt(g) * x,
-        np.sqrt(g) * y,
+        0, np.sqrt(g) * x, np.sqrt(g) * y
     )
 
 
@@ -171,6 +169,5 @@ def test_amplifier_on_coherent_is_thermal_coherent(g, x, y):
 def test_amplifier_attenuator_on_coherent_coherent(eta, x, y):
     """Tests that amplifying and the attenuating a coherent state is equivalent to preparing a thermal state displaced state"""
     assert Vacuum(0) >> Dgate(0, x, y) >> Amplifier(0, 1 / eta) >> Attenuator(0, eta) == Thermal(
-        0,
-        ((1 / eta) - 1) * eta,
+        0, ((1 / eta) - 1) * eta
     ) >> Dgate(0, x, y)

--- a/tests/test_training/test_opt_lab_jax.py
+++ b/tests/test_training/test_opt_lab_jax.py
@@ -267,14 +267,14 @@ class TestOptimizerJax:
 
     def test_cat_state_optimization(self):
         # Note: we need to intitialize the cat state with a non-zero value. This is because
-        # the gradients are zero when
+        # the gradients are zero when x is zero.
         cat_state = Coherent(0, x=0.1, x_trainable=True) + Coherent(0, x=-0.1, x_trainable=True)
         expected_cat = Coherent(0, x=np.sqrt(np.pi)) + Coherent(0, x=-np.sqrt(np.pi))
         expected_cat_fock = expected_cat.fock_array(50)
 
         def cost_fn(cat_state):
-            return (
-                -(math.abs(math.sum(math.conj(cat_state.fock_array(50)) * expected_cat_fock)) ** 2)
+            return -(
+                math.abs(math.sum(math.conj(cat_state.fock_array(50)) * expected_cat_fock)) ** 2
             )
 
         opt = OptimizerJax(learning_rate=0.001)

--- a/tests/test_training/test_opt_lab_jax.py
+++ b/tests/test_training/test_opt_lab_jax.py
@@ -280,7 +280,7 @@ class TestOptimizerJax:
         opt = OptimizerJax(learning_rate=0.001)
         opt.minimize(cost_fn, by_optimizing=[cat_state], max_steps=3000)
 
-        # TODO: test this when sc-94940 is completed to see if we get more accurate results
+        # TODO: [sc-94940]
         assert math.allclose(
             cat_state.parameters.x.value, expected_cat.parameters.x.value, atol=1e-2
         )

--- a/tests/test_training/test_opt_lab_jax.py
+++ b/tests/test_training/test_opt_lab_jax.py
@@ -23,6 +23,7 @@ from mrmustard import math, settings
 from mrmustard.lab import (
     BSgate,
     Circuit,
+    Coherent,
     Dgate,
     DisplacedSqueezed,
     Number,
@@ -263,3 +264,23 @@ class TestOptimizerJax:
         opt.minimize(cost_fn, by_optimizing=[sq], max_steps=100)
 
         assert math.all(og_r != sq.parameters.r.value)
+
+    def test_cat_state_optimization(self):
+        # Note: we need to intitialize the cat state with a non-zero value. This is because
+        # the gradients are zero when
+        cat_state = Coherent(0, x=0.1, x_trainable=True) + Coherent(0, x=-0.1, x_trainable=True)
+        expected_cat = Coherent(0, x=np.sqrt(np.pi)) + Coherent(0, x=-np.sqrt(np.pi))
+        expected_cat_fock = expected_cat.fock_array(50)
+
+        def cost_fn(cat_state):
+            return (
+                -(math.abs(math.sum(math.conj(cat_state.fock_array(50)) * expected_cat_fock)) ** 2)
+            )
+
+        opt = OptimizerJax(learning_rate=0.001)
+        opt.minimize(cost_fn, by_optimizing=[cat_state], max_steps=3000)
+
+        # TODO: test this when sc-94940 is completed to see if we get more accurate results
+        assert math.allclose(
+            cat_state.parameters.x.value, expected_cat.parameters.x.value, atol=1e-2
+        )


### PR DESCRIPTION
**Context:**
To be merged after #626.

Our current approach for handling linear superpositions of built in CircuitComponents is not ideal and does not work with optimizations. In this PR, we update `CircuitComponent.__add__` to handle the case appropriately thus enabling us to optimize e.g. cat states. Specifically, what happens now is the parameters of the built-in are concatenated and a new component of the same type is initialized with the `_lin_sup` flag set to `True`. This should also be more efficient as we avoid generating the triple and (possibly) padding things. 

**Description of the Change:** Updated `CircuitComponent.__add__` to handle the case of built-in CircuitComponents. `Dgate.fock_array` and `BSgate.fock_array` are fixed to work with lin sup. Removed `to_fock` on `Dgate` and `BSgate` as they were redundant. `PolyExpAnsatz._fn_kwargs` is renamed to the same attribute as the `Ansatz` i.e. `_kwargs`. Reordered `ParameterSet`. Tests.

**Benefits:** More efficient approach to linear superposition for built-ins that supports optimizations. Some cleanup.

**Possible Drawbacks:** `Number` is still not supported as it isn't batchable (see sc-95331). `normalize` does not work with the optimizations (see sc-95330)