### PR TITLE
Adding a comment to binomial_subspace_basis for numba caching issues

### DIFF
--- a/mrmustard/math/lattice/paths.py
+++ b/mrmustard/math/lattice/paths.py
@@ -52,6 +52,8 @@ def _binomial_subspace_basis(
             _binomial_subspace_basis(cutoffs, weight - photons, mode + 1, basis_element, basis)
 
 
+# Note: we do not cache this and ``_binomial_subspace_basis`` as caching recursive numba functions
+# has known issues. See https://github.com/numba/numba/issues/6061
 @njit
 def binomial_subspace_basis(cutoffs: tuple[int, ...], weight: int):
     r"""Returns all indices of a tensor with given weight.


### PR DESCRIPTION
### **User description**
**Context:** Thanks to @aplund for the deep dive into the caching issues for `binomial_subspace_basis`. Turns out it's a known issue for recursive functions https://github.com/numba/numba/issues/6061

**Description of the Change:** Added a comment so that in the future we know why certain methods are not cached


___

### **PR Type**
Documentation


___

### **Description**
- Added comment explaining numba caching limitation for recursive functions


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>paths.py</strong><dd><code>Added numba caching limitation comment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mrmustard/math/lattice/paths.py

<li>Added comment above <code>binomial_subspace_basis</code> function explaining why it <br>and <code>_binomial_subspace_basis</code> are not cached<br> <li> References GitHub issue about known numba caching problems with <br>recursive functions


</details>


  </td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/630/files#diff-0ab8b6de2c4a187c653ee95dc72b64c381fdf0f96bff332d0e45d0be6fde5eea">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>