### PR TITLE
feat: [sc-96057] Better README bagdes

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -55,4 +55,4 @@ jobs:
           uv pip install --pre mrmustard
 
       - name: Print about
-        run: uv run python -c "import mrmustard; print(mrmustard.about())"
+        run: python -c "import mrmustard; print(mrmustard.about())"

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Uninstall MrMustard and reinstall from PyPI
         run: |
           uv pip uninstall mrmustard
-          uv pip install --pre mrmustard
+          uv pip install --no-cache-dir --prerelease=allow mrmustard
 
       - name: Print about
         run: python -c "import mrmustard; print(mrmustard.about())"

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -1,14 +1,7 @@
 name: Upload
 on:
-  push:
-    branches:
-      - develop
-      - main
-  pull_request:
-  workflow_call:
-
-  # release:
-  #   types: [published]
+  release:
+    types: [published]
 
 jobs:
   upload:
@@ -43,11 +36,11 @@ jobs:
       - name: Run tests
         run: uv run --no-project pytest tests -p no:warnings --tb=native --backend=tensorflow
 
-      # - name: Publish
-      #   uses: pypa/gh-action-pypi-publish@release/v1
-      #   with:
-      #     user: __token__
-      #     password: ${{ secrets.PIPY_TOKEN }}
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PIPY_TOKEN }}
 
       - name: Install MrMustard from pypi
         run: uv pip install --pre --upgrade mrmustard

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -21,6 +21,8 @@ jobs:
 
       - name: Build and install Mr Mustard
         run: |
+          uv venv
+          source .venv/bin/activate
           uv build
           uv pip install dist/mrmustard*.whl
           # Move to 'src' to properly test only installed package
@@ -29,19 +31,19 @@ jobs:
           mv mrmustard src
 
       - name: Install only test dependencies
-        run: uv sync --inexact --no-install-project --all-extras
+        run: uv sync --only-dev --inexact --no-install-project
 
       - name: Run tests
         run: uv run --no-project pytest tests -p no:warnings --tb=native --backend=tensorflow
 
-      - name: Publish
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PIPY_TOKEN }}
+      # - name: Publish
+      #   uses: pypa/gh-action-pypi-publish@release/v1
+      #   with:
+      #     user: __token__
+      #     password: ${{ secrets.PIPY_TOKEN }}
 
       - name: Install MrMustard from pypi
-        run: uv pip install mrmustard
+        run: uv pip install --pre --upgrade mrmustard
 
       - name: Print about
         run: python -c "import mrmustard; print(mrmustard.about())"

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -1,14 +1,7 @@
 name: Upload
 on:
-  push:
-    branches:
-      - develop
-      - main
-  pull_request:
-  workflow_call:
-
-  # release:
-  #   types: [published]
+  release:
+    types: [published]
 
 jobs:
   upload:
@@ -43,11 +36,11 @@ jobs:
       - name: Run tests
         run: uv run --no-project pytest tests -p no:warnings --tb=native --backend=numpy
 
-      # - name: Publish
-      #   uses: pypa/gh-action-pypi-publish@release/v1
-      #   with:
-      #     user: __token__
-      #     password: ${{ secrets.PIPY_TOKEN }}
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PIPY_TOKEN }}
 
       - name: Uninstall MrMustard and reinstall from PyPI
         run: |

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -44,5 +44,4 @@ jobs:
         run: uv pip install mrmustard
 
       - name: Print about
-        run: |
-          uv run python -c "import mrmustard; print(mrmustard.about())"
+        run: python -c "import mrmustard; print(mrmustard.about())"

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -1,7 +1,8 @@
 name: Upload
-on:
-  release:
-    types: [published]
+on: workflow_dispatch
+
+  # release:
+  #   types: [published]
 
 jobs:
   upload:

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Uninstall MrMustard and reinstall from PyPI
         run: |
           uv pip uninstall mrmustard
-          uv pip install --no-cache-dir --prerelease=allow mrmustard
+          uv pip install --no-cache --prerelease=allow mrmustard
 
       - name: Print about
         run: python -c "import mrmustard; print(mrmustard.about())"

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -1,5 +1,11 @@
 name: Upload
-on: workflow_dispatch
+on:
+  push:
+    branches:
+      - develop
+      - main
+  pull_request:
+  workflow_call:
 
   # release:
   #   types: [published]

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -1,7 +1,14 @@
 name: Upload
 on:
-  release:
-    types: [published]
+  push:
+    branches:
+      - develop
+      - main
+  pull_request:
+  workflow_call:
+
+  # release:
+  #   types: [published]
 
 jobs:
   upload:
@@ -34,16 +41,18 @@ jobs:
         run: uv sync --only-dev --inexact --no-install-project
 
       - name: Run tests
-        run: uv run --no-project pytest tests -p no:warnings --tb=native --backend=tensorflow
+        run: uv run --no-project pytest tests -p no:warnings --tb=native --backend=jax
 
-      - name: Publish
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PIPY_TOKEN }}
+      # - name: Publish
+      #   uses: pypa/gh-action-pypi-publish@release/v1
+      #   with:
+      #     user: __token__
+      #     password: ${{ secrets.PIPY_TOKEN }}
 
-      - name: Install MrMustard from pypi
-        run: uv pip install --pre --upgrade mrmustard
+      - name: Uninstall MrMustard and reinstall from PyPI
+        run: |
+          uv pip uninstall mrmustard
+          uv pip install --pre mrmustard
 
       - name: Print about
-        run: python -c "import mrmustard; print(mrmustard.about())"
+        run: uv run python -c "import mrmustard; print(mrmustard.about())"

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -41,7 +41,7 @@ jobs:
         run: uv sync --only-dev --inexact --no-install-project
 
       - name: Run tests
-        run: uv run --no-project pytest tests -p no:warnings --tb=native --backend=jax
+        run: uv run --no-project pytest tests -p no:warnings --tb=native --backend=numpy
 
       # - name: Publish
       #   uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/XanaduAI/MrMustard/main/mm_white.png">
   <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/XanaduAI/MrMustard/main/mm_white.png">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/XanaduAI/MrMustard/main/mm_white.png">
   <img alt="Logo">
 </picture>
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <picture>
   <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/XanaduAI/MrMustard/main/mm_white.png">
   <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/XanaduAI/MrMustard/main/mm_dark.png">
-  <img alt="Logo">
+  <img alt="Logo" src="https://raw.githubusercontent.com/XanaduAI/MrMustard/main/mm_white.png">
 </picture>
 
 [![Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue)](https://opensource.org/licenses/Apache-2.0)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <picture>
   <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/XanaduAI/MrMustard/main/mm_white.png">
-  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/XanaduAI/MrMustard/main/mm_white.png">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/XanaduAI/MrMustard/main/mm_dark.png">
   <img alt="Logo">
 </picture>
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
-![Logo](https://raw.githubusercontent.com/XanaduAI/MrMustard/blob/main/mm_white.png#gh-light-mode-only)
-![Logo](https://raw.githubusercontent.com/XanaduAI/MrMustard/blob/main/mm_dark.png#gh-dark-mode-only)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/GiorgosXou/Random-stuff/main/Programming/StackOverflow/Answers/70200610_11465149/w.png">
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/GiorgosXou/Random-stuff/main/Programming/StackOverflow/Answers/70200610_11465149/b.png">
+  <img alt="Logo">
+</picture>
 
 [![Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue)](https://opensource.org/licenses/Apache-2.0)
 [![Numpy tests](https://github.com/XanaduAI/MrMustard/actions/workflows/tests_numpy.yml/badge.svg?branch=main)](https://github.com/XanaduAI/MrMustard/actions/workflows/tests_numpy.yml)

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 ![Logo](https://github.com/XanaduAI/MrMustard/blob/main/mm_dark.png#gh-dark-mode-only)
 
 [![Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue)](https://opensource.org/licenses/Apache-2.0)
-[![Actions Status](https://github.com/XanaduAI/MrMustard/workflows/Numpy%20tests/badge.svg)](https://github.com/XanaduAI/MrMustard/actions/workflows/tests_numpy.yml)
-[![Actions Status](https://github.com/XanaduAI/MrMustard/workflows/Jax%20tests/badge.svg)](https://github.com/XanaduAI/MrMustard/actions/workflows/tests_jax.yml)
-[![Actions Status](https://github.com/XanaduAI/MrMustard/workflows/Tensorflow%20tests/badge.svg)](https://github.com/XanaduAI/MrMustard/actions/workflows/tests_tensorflow.yml)
-[![Python version](https://img.shields.io/pypi/pyversions/mrmustard.svg?style=popout-square)](https://pypi.org/project/MrMustard/)
+[![Numpy tests](https://github.com/XanaduAI/MrMustard/actions/workflows/tests_numpy.yml/badge.svg?branch=main)](https://github.com/XanaduAI/MrMustard/actions/workflows/tests_numpy.yml)
+[![Jax tests](https://github.com/XanaduAI/MrMustard/actions/workflows/tests_jax.yml/badge.svg?branch=main)](https://github.com/XanaduAI/MrMustard/actions/workflows/tests_jax.yml)
+[![Tensorflow tests](https://github.com/XanaduAI/MrMustard/actions/workflows/tests_tensorflow.yml/badge.svg?branch=main)](https://github.com/XanaduAI/MrMustard/actions/workflows/tests_tensorflow.yml)
+[![Python version](https://img.shields.io/python/required-version-toml?tomlFilePath=https%3A%2F%2Fraw.githubusercontent.com%2FXanaduAI%2FMrMustard%2Fmain%2Fpyproject.toml)](https://pypi.org/project/MrMustard/)
 
 # Mr Mustard: Your Universal Differentiable Toolkit for Quantum Optics
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/XanaduAI/MrMustard/blob/main/mm_white.png">
-  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/XanaduAI/MrMustard/blob/main/mm_white.png">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/XanaduAI/MrMustard/main/mm_white.png">
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/XanaduAI/MrMustard/main/mm_white.png">
   <img alt="Logo">
 </picture>
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-![Logo](https://github.com/XanaduAI/MrMustard/blob/main/mm_white.png#gh-light-mode-only)
-![Logo](https://github.com/XanaduAI/MrMustard/blob/main/mm_dark.png#gh-dark-mode-only)
+![Logo](https://raw.githubusercontent.com/XanaduAI/MrMustard/blob/main/mm_white.png#gh-light-mode-only)
+![Logo](https://raw.githubusercontent.com/XanaduAI/MrMustard/blob/main/mm_dark.png#gh-dark-mode-only)
 
 [![Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue)](https://opensource.org/licenses/Apache-2.0)
 [![Numpy tests](https://github.com/XanaduAI/MrMustard/actions/workflows/tests_numpy.yml/badge.svg?branch=main)](https://github.com/XanaduAI/MrMustard/actions/workflows/tests_numpy.yml)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/GiorgosXou/Random-stuff/main/Programming/StackOverflow/Answers/70200610_11465149/w.png">
-  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/GiorgosXou/Random-stuff/main/Programming/StackOverflow/Answers/70200610_11465149/b.png">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/XanaduAI/MrMustard/blob/main/mm_white.png">
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/XanaduAI/MrMustard/blob/main/mm_white.png">
   <img alt="Logo">
 </picture>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,13 +9,12 @@ description = "Differentiable quantum Gaussian circuits"
 authors = [
     {name= "Xanadu", email= "filippo@xanadu.ai"},
 ]
-license = {text = "Apache License 2.0"}
+license = "Apache-2.0"
 readme = "README.md"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Environment :: Console",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: Apache Software License",
     "Natural Language :: English",
     "Operating System :: POSIX",
     "Operating System :: MacOS :: MacOS X",


### PR DESCRIPTION
The GitHub Workflow badges were for all branches instead of just `main` and the PyPI Python version badge only works for full releases and not pre-releases.

This PR:
- updates workflow badges to only change state if workflows fail/succeed on `main`
- updates Python version badge to rely on `pyproject.toml` and not PyPI
- updates logo images with new syntax (see https://github.com/orgs/community/discussions/16910)

Story details: https://app.shortcut.com/xanaduai/story/96057