### PR TITLE
OptimizerJax bugfix: reset opt_history 

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,6 +5,11 @@
 * Added a ``rich`` based repr to ``ParameterSet``.
 [(#616)](https://github.com/XanaduAI/MrMustard/pull/616)
 
+### Bug fixes
+
+* Fixed a bug in `OptimizerJax` that would make the optimizer think it reached a stable optimum upon repeat calls to `minimize`.
+[(#634)](https://github.com/XanaduAI/MrMustard/pull/634)
+
 ---
 
 # Release 1.0.0a1

--- a/mrmustard/training/optimizer_jax.py
+++ b/mrmustard/training/optimizer_jax.py
@@ -121,6 +121,7 @@ class OptimizerJax:
         Returns:
             The list of elements optimized.
         """
+        self.opt_history = [0]
         if settings.PROGRESSBAR:
             progress_bar = ProgressBar(max_steps)
             with progress_bar:

--- a/tests/test_training/test_opt_lab_jax.py
+++ b/tests/test_training/test_opt_lab_jax.py
@@ -49,23 +49,89 @@ class TestOptimizerJax:
     Tests for the ``OptimizerJax`` class.
     """
 
-    @given(n=st.integers(0, 3))
-    def test_S2gate_coincidence_prob(self, n):
-        """Testing the optimal probability of obtaining |n,n> from a two mode squeezed vacuum"""
-        S = TwoModeSqueezedVacuum(
-            (0, 1),
-            r=abs(settings.rng.normal(loc=1.0, scale=0.1)),
-            r_trainable=True,
-        )
+    @pytest.mark.parametrize("batch_shape", [(), (2,), (3, 2)])
+    def test_bsgate_grad_from_fock(self, batch_shape):
+        """Test that the gradient of a beamsplitter gate is computed from the fock representation."""
+        sq = SqueezedVacuum(0, r=math.ones(batch_shape), r_trainable=True)
+        og_r = math.asnumpy(sq.parameters.r.value)
+        num = Number(1, 1)
+        vac = Vacuum(0)
+        bs = BSgate((0, 1), 0.5)
 
-        def cost_fn(S):
-            return -(math.abs(S.fock_array((n + 1, n + 1))[n, n]) ** 2)
+        def cost_fn(sq):
+            norm = 1 / sq.ansatz.batch_size if sq.ansatz.batch_shape else 1
+            return -math.real(
+                norm * math.sum(sq >> num >> bs >> (vac >> num).dual) ** 2,
+            )
 
-        opt = OptimizerJax(euclidean_lr=0.01)
-        (S,) = opt.minimize(cost_fn, by_optimizing=[S], max_steps=300)
+        opt = OptimizerJax(euclidean_lr=0.05)
+        (sq,) = opt.minimize(cost_fn, by_optimizing=[sq], max_steps=100)
 
-        expected = 1 / (n + 1) * (n / (n + 1)) ** n
-        assert math.allclose(-cost_fn(S), expected, atol=1e-5)
+        assert math.all(og_r != sq.parameters.r.value)
+
+    def test_bsgate_optimization(self):
+        """Test that BSgate is optimized correctly."""
+        bsgate = BSgate((0, 1), 0.05, 0.1, theta_trainable=True, phi_trainable=True)
+        target_gate = BSgate((0, 1), 0.1, 0.2).fock_array(40)
+
+        def cost_fn(bsgate):
+            return -(math.abs(math.sum(math.conj(bsgate.fock_array(40)) * target_gate)) ** 2)
+
+        opt = OptimizerJax()
+        (bsgate,) = opt.minimize(cost_fn, by_optimizing=[bsgate])
+
+        assert math.allclose(bsgate.parameters.theta.value, 0.1, atol=0.01)
+        assert math.allclose(bsgate.parameters.phi.value, 0.2, atol=0.01)
+
+    def test_cat_state_optimization(self):
+        # Note: we need to intitialize the cat state with a non-zero value. This is because
+        # the gradients are zero when x is zero.
+        cat_state = Coherent(0, x=0.1, x_trainable=True) + Coherent(0, x=-0.1, x_trainable=True)
+        expected_cat = Coherent(0, x=np.sqrt(np.pi)) + Coherent(0, x=-np.sqrt(np.pi))
+
+        def cost_fn(cat_state):
+            cat_state = cat_state.normalize()
+            return -math.abs(cat_state.fidelity(expected_cat.normalize()))
+
+        # stable_threshold and max_steps are set to whatever gives us optimized parameters
+        # that are within the default ATOL=1e-8 of the expected values
+        opt = OptimizerJax(stable_threshold=1e-12)
+        (cat_state,) = opt.minimize(cost_fn, by_optimizing=[cat_state], max_steps=6000)
+
+        assert math.allclose(cat_state.parameters.x.value, expected_cat.parameters.x.value)
+
+    def test_dgate_optimization(self):
+        """Test that Dgate is optimized correctly."""
+        dgate = Dgate(0, x_trainable=True, y_trainable=True)
+        target_state = DisplacedSqueezed(0, r=0.0, x=0.1, y=0.2).fock_array((40,))
+
+        def cost_fn(dgate):
+            state_out = Vacuum(0) >> dgate
+            return -(math.abs(math.sum(math.conj(state_out.fock_array((40,))) * target_state)) ** 2)
+
+        opt = OptimizerJax()
+        (dgate,) = opt.minimize(cost_fn, by_optimizing=[dgate])
+
+        assert math.allclose(dgate.parameters.x.value, 0.1, atol=0.01)
+        assert math.allclose(dgate.parameters.y.value, 0.2, atol=0.01)
+
+    @pytest.mark.parametrize("batch_shape", [(), (2,), (3, 2)])
+    def test_displacement_grad_from_fock(self, batch_shape):
+        """Test that the gradient of a displacement gate is computed from the fock representation."""
+        disp = Dgate(0, x=math.ones(batch_shape), y=0.5, x_trainable=True, y_trainable=True)
+        og_x = math.asnumpy(disp.parameters.x.value)
+        og_y = math.asnumpy(disp.parameters.y.value)
+        num = Number(0, 2)
+        vac = Vacuum(0).dual
+
+        def cost_fn(disp):
+            norm = 1 / disp.ansatz.batch_size if disp.ansatz.batch_shape else 1
+            return -math.real(norm * math.sum(num >> disp >> vac) ** 2)
+
+        opt = OptimizerJax(euclidean_lr=0.05)
+        (disp,) = opt.minimize(cost_fn, by_optimizing=[disp], max_steps=100)
+        assert math.all(og_x != disp.parameters.x.value)
+        assert math.all(og_y != disp.parameters.y.value)
 
     @given(i=st.integers(1, 5), k=st.integers(1, 5))
     def test_hong_ou_mandel_optimizer(self, i, k):
@@ -98,99 +164,6 @@ class TestOptimizerJax:
         )
         bs = circ.components[2]
         assert math.allclose(math.cos(bs.parameters.theta.value) ** 2, k / (i + k), atol=1e-2)
-
-    def test_learning_two_mode_squeezing(self):
-        """Finding the optimal beamsplitter transmission to make a pair of single photons"""
-        state_in = Vacuum((0, 1))
-        s_gate = Sgate(
-            0,
-            r=abs(settings.rng.normal()),
-            phi=settings.rng.normal(),
-            r_trainable=True,
-            phi_trainable=True,
-        )
-        bs_gate = BSgate(
-            (0, 1),
-            theta=settings.rng.normal(),
-            phi=settings.rng.normal(),
-            theta_trainable=True,
-            phi_trainable=True,
-        )
-        circ = Circuit([state_in, s_gate, s_gate.on(1), bs_gate])
-
-        def cost_fn(circ):
-            amps = circ.contract().fock_array((2, 2))
-            return -(math.abs(amps[1, 1]) ** 2) + math.abs(amps[0, 1]) ** 2
-
-        opt = OptimizerJax(euclidean_lr=0.05)
-
-        (circ,) = opt.minimize(cost_fn, by_optimizing=[circ], max_steps=300)
-        assert math.allclose(-cost_fn(circ), 0.25, atol=1e-5)
-
-    def test_learning_two_mode_Ggate(self):
-        """Finding the optimal Ggate to make a pair of single photons"""
-        G = GKet((0, 1), symplectic_trainable=True)
-
-        def cost_fn(G):
-            amps = G.fock_array((2, 2))
-            return -(math.abs(amps[1, 1]) ** 2) + math.abs(amps[0, 1]) ** 2
-
-        opt = OptimizerJax(symplectic_lr=0.5, euclidean_lr=0.01)
-
-        (G,) = opt.minimize(cost_fn, by_optimizing=[G], max_steps=500)
-        assert math.allclose(-cost_fn(G), 0.25, atol=1e-4)
-
-    def test_learning_two_mode_Interferometer(self):
-        """Finding the optimal Interferometer to make a pair of single photons"""
-        state_in = Vacuum((0, 1))
-        s_gate = Sgate(
-            0,
-            r=settings.rng.normal() ** 2,
-            phi=settings.rng.normal(),
-            r_trainable=True,
-            phi_trainable=True,
-        )
-        interferometer = Interferometer((0, 1), unitary_trainable=True)
-        circ = Circuit([state_in, s_gate, s_gate.on(1), interferometer])
-
-        def cost_fn(circ):
-            amps = circ.contract().fock_array((2, 2))
-            return -(math.abs(amps[1, 1]) ** 2) + math.abs(amps[0, 1]) ** 2
-
-        opt = OptimizerJax(unitary_lr=0.5, euclidean_lr=0.01)
-
-        (circ,) = opt.minimize(cost_fn, by_optimizing=[circ], max_steps=1000)
-        assert math.allclose(-cost_fn(circ), 0.25, atol=1e-5)
-
-    def test_learning_two_mode_RealInterferometer(self):
-        """Finding the optimal Interferometer to make a pair of single photons"""
-        state_in = Vacuum((0, 1))
-        s_gate0 = Sgate(
-            0,
-            r=settings.rng.normal() ** 2,
-            phi=settings.rng.normal(),
-            r_trainable=True,
-            phi_trainable=True,
-        )
-        s_gate1 = Sgate(
-            1,
-            r=settings.rng.normal() ** 2,
-            phi=settings.rng.normal(),
-            r_trainable=True,
-            phi_trainable=True,
-        )
-        r_inter = RealInterferometer((0, 1), orthogonal_trainable=True)
-
-        circ = Circuit([state_in, s_gate0, s_gate1, r_inter])
-
-        def cost_fn(circ):
-            amps = circ.contract().fock_array((2, 2))
-            return -(math.abs(amps[1, 1]) ** 2) + math.abs(amps[0, 1]) ** 2
-
-        opt = OptimizerJax(orthogonal_lr=0.5, euclidean_lr=0.01)
-
-        (circ,) = opt.minimize(cost_fn, by_optimizing=[circ], max_steps=1000)
-        assert math.allclose(-cost_fn(circ), 0.25, atol=1e-5)
 
     def test_learning_four_mode_Interferometer(self):
         """Finding the optimal Interferometer to make a NOON state with N=2"""
@@ -321,53 +294,98 @@ class TestOptimizerJax:
         (circ,) = opt.minimize(cost_fn, by_optimizing=[circ], max_steps=200)
         assert math.allclose(-cost_fn(circ), 0.0625, atol=1e-5)
 
-    def test_squeezing_hong_ou_mandel_optimizer(self):
-        """Finding the optimal squeezing parameter to get Hong-Ou-Mandel dip in time
-        see https://www.pnas.org/content/117/52/33107/tab-article-info
-        """
-        r = np.arcsinh(1.0)
+    def test_learning_two_mode_Ggate(self):
+        """Finding the optimal Ggate to make a pair of single photons"""
+        G = GKet((0, 1), symplectic_trainable=True)
 
-        state_in = Vacuum((0, 1, 2, 3))
-        S_01 = S2gate((0, 1), r=r, phi=0.0, phi_trainable=True)
-        S_23 = S2gate((2, 3), r=r, phi=0.0, phi_trainable=True)
-        S_12 = S2gate(
-            (1, 2),
-            r=1.0,
+        def cost_fn(G):
+            amps = G.fock_array((2, 2))
+            return -(math.abs(amps[1, 1]) ** 2) + math.abs(amps[0, 1]) ** 2
+
+        opt = OptimizerJax(symplectic_lr=0.5, euclidean_lr=0.01)
+
+        (G,) = opt.minimize(cost_fn, by_optimizing=[G], max_steps=500)
+        assert math.allclose(-cost_fn(G), 0.25, atol=1e-4)
+
+    def test_learning_two_mode_Interferometer(self):
+        """Finding the optimal Interferometer to make a pair of single photons"""
+        state_in = Vacuum((0, 1))
+        s_gate = Sgate(
+            0,
+            r=settings.rng.normal() ** 2,
             phi=settings.rng.normal(),
             r_trainable=True,
             phi_trainable=True,
         )
-
-        circ = Circuit([state_in, S_01, S_23, S_12])
-
-        def cost_fn(circ):
-            return math.abs(circ.contract().fock_array((2, 2, 2, 2))[1, 1, 1, 1]) ** 2
-
-        opt = OptimizerJax(euclidean_lr=0.001)
-        (circ,) = opt.minimize(cost_fn, by_optimizing=[circ], max_steps=300)
-        S_12 = circ.components[3]
-        assert math.allclose(math.sinh(S_12.parameters.r.value) ** 2, 1, atol=1e-2)
-
-    def test_parameter_passthrough(self):
-        """Same as the test above, but with param passthrough"""
-        r = np.arcsinh(1.0)
-        r_var = Variable(r, "r", (0.0, None))
-        phi_var = Variable(settings.rng.normal(), "phi", (None, None))
-
-        state_in = Vacuum((0, 1, 2, 3))
-        s2_gate0 = S2gate((0, 1), r=r, phi=0.0, phi_trainable=True)
-        s2_gate1 = S2gate((2, 3), r=r, phi=0.0, phi_trainable=True)
-        s2_gate2 = S2gate((1, 2), r=r_var, phi=phi_var)
-
-        circ = Circuit([state_in, s2_gate0, s2_gate1, s2_gate2])
+        interferometer = Interferometer((0, 1), unitary_trainable=True)
+        circ = Circuit([state_in, s_gate, s_gate.on(1), interferometer])
 
         def cost_fn(circ):
-            return math.abs(circ.contract().fock_array((2, 2, 2, 2))[1, 1, 1, 1]) ** 2
+            amps = circ.contract().fock_array((2, 2))
+            return -(math.abs(amps[1, 1]) ** 2) + math.abs(amps[0, 1]) ** 2
 
-        opt = OptimizerJax(euclidean_lr=0.001)
+        opt = OptimizerJax(unitary_lr=0.5, euclidean_lr=0.01)
+
+        (circ,) = opt.minimize(cost_fn, by_optimizing=[circ], max_steps=1000)
+        assert math.allclose(-cost_fn(circ), 0.25, atol=1e-5)
+
+    def test_learning_two_mode_RealInterferometer(self):
+        """Finding the optimal Interferometer to make a pair of single photons"""
+        state_in = Vacuum((0, 1))
+        s_gate0 = Sgate(
+            0,
+            r=settings.rng.normal() ** 2,
+            phi=settings.rng.normal(),
+            r_trainable=True,
+            phi_trainable=True,
+        )
+        s_gate1 = Sgate(
+            1,
+            r=settings.rng.normal() ** 2,
+            phi=settings.rng.normal(),
+            r_trainable=True,
+            phi_trainable=True,
+        )
+        r_inter = RealInterferometer((0, 1), orthogonal_trainable=True)
+
+        circ = Circuit([state_in, s_gate0, s_gate1, r_inter])
+
+        def cost_fn(circ):
+            amps = circ.contract().fock_array((2, 2))
+            return -(math.abs(amps[1, 1]) ** 2) + math.abs(amps[0, 1]) ** 2
+
+        opt = OptimizerJax(orthogonal_lr=0.5, euclidean_lr=0.01)
+
+        (circ,) = opt.minimize(cost_fn, by_optimizing=[circ], max_steps=1000)
+        assert math.allclose(-cost_fn(circ), 0.25, atol=1e-5)
+
+    def test_learning_two_mode_squeezing(self):
+        """Finding the optimal beamsplitter transmission to make a pair of single photons"""
+        state_in = Vacuum((0, 1))
+        s_gate = Sgate(
+            0,
+            r=abs(settings.rng.normal()),
+            phi=settings.rng.normal(),
+            r_trainable=True,
+            phi_trainable=True,
+        )
+        bs_gate = BSgate(
+            (0, 1),
+            theta=settings.rng.normal(),
+            phi=settings.rng.normal(),
+            theta_trainable=True,
+            phi_trainable=True,
+        )
+        circ = Circuit([state_in, s_gate, s_gate.on(1), bs_gate])
+
+        def cost_fn(circ):
+            amps = circ.contract().fock_array((2, 2))
+            return -(math.abs(amps[1, 1]) ** 2) + math.abs(amps[0, 1]) ** 2
+
+        opt = OptimizerJax(euclidean_lr=0.05)
+
         (circ,) = opt.minimize(cost_fn, by_optimizing=[circ], max_steps=300)
-        r_var = circ.components[3].parameters.r
-        assert math.allclose(math.sinh(r_var.value) ** 2, 1, atol=1e-2)
+        assert math.allclose(-cost_fn(circ), 0.25, atol=1e-5)
 
     def test_making_thermal_state_as_one_half_two_mode_squeezed_vacuum(self):
         """Optimizes a Ggate on two modes so as to prepare a state with the same entropy
@@ -403,20 +421,65 @@ class TestOptimizerJax:
         cov = S @ S.T
         assert math.allclose(cov, two_mode_squeezing(2 * np.arcsinh(np.sqrt(nbar)), 0.0))
 
-    def test_dgate_optimization(self):
-        """Test that Dgate is optimized correctly."""
-        dgate = Dgate(0, x_trainable=True, y_trainable=True)
-        target_state = DisplacedSqueezed(0, r=0.0, x=0.1, y=0.2).fock_array((40,))
+    def test_parameter_passthrough(self):
+        """Same as the test above, but with param passthrough"""
+        r = np.arcsinh(1.0)
+        r_var = Variable(r, "r", (0.0, None))
+        phi_var = Variable(settings.rng.normal(), "phi", (None, None))
 
-        def cost_fn(dgate):
-            state_out = Vacuum(0) >> dgate
+        state_in = Vacuum((0, 1, 2, 3))
+        s2_gate0 = S2gate((0, 1), r=r, phi=0.0, phi_trainable=True)
+        s2_gate1 = S2gate((2, 3), r=r, phi=0.0, phi_trainable=True)
+        s2_gate2 = S2gate((1, 2), r=r_var, phi=phi_var)
+
+        circ = Circuit([state_in, s2_gate0, s2_gate1, s2_gate2])
+
+        def cost_fn(circ):
+            return math.abs(circ.contract().fock_array((2, 2, 2, 2))[1, 1, 1, 1]) ** 2
+
+        opt = OptimizerJax(euclidean_lr=0.001)
+        (circ,) = opt.minimize(cost_fn, by_optimizing=[circ], max_steps=300)
+        r_var = circ.components[3].parameters.r
+        assert math.allclose(math.sinh(r_var.value) ** 2, 1, atol=1e-2)
+
+    def test_reuse_optimizer(self):
+        """Test that the same optimizer instance can be reused."""
+        sgate = Sgate(0, r=0.2, phi=0.1, r_trainable=True, phi_trainable=True)
+        target_state = SqueezedVacuum(0, r=0.1, phi=0.2).fock_array((40,))
+
+        def cost_fn(sgate):
+            state_out = Vacuum(0) >> sgate
             return -(math.abs(math.sum(math.conj(state_out.fock_array((40,))) * target_state)) ** 2)
 
         opt = OptimizerJax()
-        (dgate,) = opt.minimize(cost_fn, by_optimizing=[dgate])
+        (sgate,) = opt.minimize(cost_fn, by_optimizing=[sgate])
 
-        assert math.allclose(dgate.parameters.x.value, 0.1, atol=0.01)
-        assert math.allclose(dgate.parameters.y.value, 0.2, atol=0.01)
+        assert math.allclose(sgate.parameters.r.value, 0.1, atol=0.01)
+        assert math.allclose(sgate.parameters.phi.value, 0.2, atol=0.01)
+
+        sgate_reused = Sgate(0, r=0.2, phi=0.1, r_trainable=True, phi_trainable=True)
+        (sgate_reused,) = opt.minimize(cost_fn, by_optimizing=[sgate_reused])
+
+        assert math.allclose(sgate_reused.parameters.r.value, sgate.parameters.r.value)
+        assert math.allclose(sgate_reused.parameters.phi.value, sgate.parameters.phi.value)
+
+    @given(n=st.integers(0, 3))
+    def test_S2gate_coincidence_prob(self, n):
+        """Testing the optimal probability of obtaining |n,n> from a two mode squeezed vacuum"""
+        S = TwoModeSqueezedVacuum(
+            (0, 1),
+            r=abs(settings.rng.normal(loc=1.0, scale=0.1)),
+            r_trainable=True,
+        )
+
+        def cost_fn(S):
+            return -(math.abs(S.fock_array((n + 1, n + 1))[n, n]) ** 2)
+
+        opt = OptimizerJax(euclidean_lr=0.01)
+        (S,) = opt.minimize(cost_fn, by_optimizing=[S], max_steps=300)
+
+        expected = 1 / (n + 1) * (n / (n + 1)) ** n
+        assert math.allclose(-cost_fn(S), expected, atol=1e-5)
 
     def test_sgate_optimization(self):
         """Test that Sgate is optimized correctly."""
@@ -432,20 +495,6 @@ class TestOptimizerJax:
 
         assert math.allclose(sgate.parameters.r.value, 0.1, atol=0.01)
         assert math.allclose(sgate.parameters.phi.value, 0.2, atol=0.01)
-
-    def test_bsgate_optimization(self):
-        """Test that BSgate is optimized correctly."""
-        bsgate = BSgate((0, 1), 0.05, 0.1, theta_trainable=True, phi_trainable=True)
-        target_gate = BSgate((0, 1), 0.1, 0.2).fock_array(40)
-
-        def cost_fn(bsgate):
-            return -(math.abs(math.sum(math.conj(bsgate.fock_array(40)) * target_gate)) ** 2)
-
-        opt = OptimizerJax()
-        (bsgate,) = opt.minimize(cost_fn, by_optimizing=[bsgate])
-
-        assert math.allclose(bsgate.parameters.theta.value, 0.1, atol=0.01)
-        assert math.allclose(bsgate.parameters.phi.value, 0.2, atol=0.01)
 
     @pytest.mark.parametrize("batch_shape", [(), (2,), (3, 2)])
     def test_squeezing_grad_from_fock(self, batch_shape):
@@ -464,57 +513,29 @@ class TestOptimizerJax:
 
         assert math.all(squeezing.parameters.r.value != og_r)
 
-    @pytest.mark.parametrize("batch_shape", [(), (2,), (3, 2)])
-    def test_displacement_grad_from_fock(self, batch_shape):
-        """Test that the gradient of a displacement gate is computed from the fock representation."""
-        disp = Dgate(0, x=math.ones(batch_shape), y=0.5, x_trainable=True, y_trainable=True)
-        og_x = math.asnumpy(disp.parameters.x.value)
-        og_y = math.asnumpy(disp.parameters.y.value)
-        num = Number(0, 2)
-        vac = Vacuum(0).dual
+    def test_squeezing_hong_ou_mandel_optimizer(self):
+        """Finding the optimal squeezing parameter to get Hong-Ou-Mandel dip in time
+        see https://www.pnas.org/content/117/52/33107/tab-article-info
+        """
+        r = np.arcsinh(1.0)
 
-        def cost_fn(disp):
-            norm = 1 / disp.ansatz.batch_size if disp.ansatz.batch_shape else 1
-            return -math.real(norm * math.sum(num >> disp >> vac) ** 2)
+        state_in = Vacuum((0, 1, 2, 3))
+        S_01 = S2gate((0, 1), r=r, phi=0.0, phi_trainable=True)
+        S_23 = S2gate((2, 3), r=r, phi=0.0, phi_trainable=True)
+        S_12 = S2gate(
+            (1, 2),
+            r=1.0,
+            phi=settings.rng.normal(),
+            r_trainable=True,
+            phi_trainable=True,
+        )
 
-        opt = OptimizerJax(euclidean_lr=0.05)
-        (disp,) = opt.minimize(cost_fn, by_optimizing=[disp], max_steps=100)
-        assert math.all(og_x != disp.parameters.x.value)
-        assert math.all(og_y != disp.parameters.y.value)
+        circ = Circuit([state_in, S_01, S_23, S_12])
 
-    @pytest.mark.parametrize("batch_shape", [(), (2,), (3, 2)])
-    def test_bsgate_grad_from_fock(self, batch_shape):
-        """Test that the gradient of a beamsplitter gate is computed from the fock representation."""
-        sq = SqueezedVacuum(0, r=math.ones(batch_shape), r_trainable=True)
-        og_r = math.asnumpy(sq.parameters.r.value)
-        num = Number(1, 1)
-        vac = Vacuum(0)
-        bs = BSgate((0, 1), 0.5)
+        def cost_fn(circ):
+            return math.abs(circ.contract().fock_array((2, 2, 2, 2))[1, 1, 1, 1]) ** 2
 
-        def cost_fn(sq):
-            norm = 1 / sq.ansatz.batch_size if sq.ansatz.batch_shape else 1
-            return -math.real(
-                norm * math.sum(sq >> num >> bs >> (vac >> num).dual) ** 2,
-            )
-
-        opt = OptimizerJax(euclidean_lr=0.05)
-        (sq,) = opt.minimize(cost_fn, by_optimizing=[sq], max_steps=100)
-
-        assert math.all(og_r != sq.parameters.r.value)
-
-    def test_cat_state_optimization(self):
-        # Note: we need to intitialize the cat state with a non-zero value. This is because
-        # the gradients are zero when x is zero.
-        cat_state = Coherent(0, x=0.1, x_trainable=True) + Coherent(0, x=-0.1, x_trainable=True)
-        expected_cat = Coherent(0, x=np.sqrt(np.pi)) + Coherent(0, x=-np.sqrt(np.pi))
-
-        def cost_fn(cat_state):
-            cat_state = cat_state.normalize()
-            return -math.abs(cat_state.fidelity(expected_cat.normalize()))
-
-        # stable_threshold and max_steps are set to whatever gives us optimized parameters
-        # that are within the default ATOL=1e-8 of the expected values
-        opt = OptimizerJax(stable_threshold=1e-12)
-        (cat_state,) = opt.minimize(cost_fn, by_optimizing=[cat_state], max_steps=6000)
-
-        assert math.allclose(cat_state.parameters.x.value, expected_cat.parameters.x.value)
+        opt = OptimizerJax(euclidean_lr=0.001)
+        (circ,) = opt.minimize(cost_fn, by_optimizing=[circ], max_steps=300)
+        S_12 = circ.components[3]
+        assert math.allclose(math.sinh(S_12.parameters.r.value) ** 2, 1, atol=1e-2)


### PR DESCRIPTION
**Context:** An `OptimizerJax` instance should be reusable but currently is not due to the population of `opt_history` which tricks the optimizer into thinking that it has finished optimizing on subsequent runs. This PR introduces a bugfix that allows users to reuse a single `OptimizerJax` instance 

**Description of the Change:** `OptimizerJax.minimize` now clears `opt_history`. Added `test_reuse_optimizer`. Reorganized the tests in `test_opt_lab_jax.py` in alphabetical order.

**Benefits:** Can reuse the same Jax instance which potentially allows us to avoid some recompilation. 