### PR TITLE
[Sc 96349] Port Missing vjps to JAXBackend

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,6 +10,9 @@
 * Added a ``rich`` based repr to ``ParameterSet``.
 [(#616)](https://github.com/XanaduAI/MrMustard/pull/616)
 
+* Added vjps to the JAX backend.
+[(#636)](https://github.com/XanaduAI/MrMustard/pull/636)
+
 ### Bug fixes
 
 * Fixed a bug in `OptimizerJax` that would make the optimizer think it reached a stable optimum upon repeat calls to `minimize`.

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Removed `tensorflow` as a dependency as well as any legacy `tensorflow` code. Renamed `OptimizerJax` to `Optimizer`.
 [(#633)](https://github.com/XanaduAI/MrMustard/pull/633)
 
+* Changed the API of `Coherent`, `DisplacedSqueezed`, `Dgate` from real `x`, `y` parameters to a complex `alpha`.
+[(#617)](https://github.com/XanaduAI/MrMustard/pull/617)
+
 ### Improvements
 
 * Added a ``rich`` based repr to ``ParameterSet``.
@@ -20,6 +23,9 @@
 
 * Fixed a bug in `OptimizerJax` that would make the optimizer think it reached a stable optimum upon repeat calls to `minimize`.
 [(#634)](https://github.com/XanaduAI/MrMustard/pull/634)
+
+* Fixed a bug in `Optimizer` where complex gradients were the conjugate of the expected.
+[(#617)](https://github.com/XanaduAI/MrMustard/pull/617)
 
 ---
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,7 +10,7 @@
 * Added a ``rich`` based repr to ``ParameterSet``.
 [(#616)](https://github.com/XanaduAI/MrMustard/pull/616)
 
-* Added vjps to the JAX backend.
+* Added vjps to the JAX backend. Added ``numba`` based Fock lattice strategies to `SqueezedVacuum` and `Sgate`.
 [(#636)](https://github.com/XanaduAI/MrMustard/pull/636)
 
 ### Bug fixes

--- a/mrmustard/lab/circuit_components.py
+++ b/mrmustard/lab/circuit_components.py
@@ -495,20 +495,14 @@ class CircuitComponent:
         Args:
             shape: The shape of the returned representation. If ``shape`` is given as an ``int``,
                 it is broadcasted to all the dimensions. If not given, it is generated via ``auto_shape``.
+
         Returns:
             array: The Fock representation of this component.
+
+        Raises:
+            ValueError: If the shape is not valid for the component.
         """
-        shape = shape or self.auto_shape()
-        num_vars = (
-            self.ansatz.num_CV_vars
-            if isinstance(self.ansatz, PolyExpAnsatz)
-            else self.ansatz.num_vars
-        )
-        if isinstance(shape, int):
-            shape = (shape,) * num_vars
-        shape = tuple(shape)
-        if len(shape) != num_vars:
-            raise ValueError(f"Expected Fock shape of length {num_vars}, got {len(shape)}")
+        shape = self._check_fock_shape(shape)
         try:
             A, b, c = self.ansatz.triple
             G = math.hermite_renormalized(
@@ -758,6 +752,33 @@ class CircuitComponent:
         return BtoQ_ib.contract(BtoQ_ik.contract(object_to_convert).contract(BtoQ_ok)).contract(
             BtoQ_ob,
         )
+
+    def _check_fock_shape(self, shape: int | Sequence[int] | None = None) -> tuple[int, ...]:
+        r"""
+        Checks that the given shape is valid for the component and returns the final Fock shape.
+        If the shape is not given, it defaults to the ``auto_shape`` of the component.
+
+        Args:
+            shape: The FOck shape of the returned representation. If ``shape`` is given as an ``int``,
+                it is broadcasted to all the dimensions. If not given, it is generated via ``auto_shape``.
+        Returns:
+            The shape of the Fock representation of this component.
+
+        Raises:
+            ValueError: If the shape is not valid for the component.
+        """
+        shape = shape or self.auto_shape()
+        num_vars = (
+            self.ansatz.num_CV_vars
+            if isinstance(self.ansatz, PolyExpAnsatz)
+            else self.ansatz.num_vars
+        )
+        if isinstance(shape, int):
+            shape = (shape,) * num_vars
+        shape = tuple(shape)
+        if len(shape) != num_vars:
+            raise ValueError(f"Expected Fock shape of length {num_vars}, got {len(shape)}")
+        return shape
 
     def _light_copy(self, wires: Wires | None = None) -> CircuitComponent:
         r"""

--- a/mrmustard/lab/circuit_components.py
+++ b/mrmustard/lab/circuit_components.py
@@ -768,17 +768,19 @@ class CircuitComponent:
             The shape of the Fock representation of this component.
 
         Raises:
-            ValueError: If the shape is not valid for the component.
+            ValueError: If the shape either contains 0 or is not the correct length.
         """
-        shape = shape or self.auto_shape()
+        shape = shape if shape is not None else self.auto_shape()
         num_vars = (
             self.ansatz.num_CV_vars
             if isinstance(self.ansatz, PolyExpAnsatz)
             else self.ansatz.num_vars
         )
-        if isinstance(shape, int):
+        if isinstance(shape, int | math.int64):
             shape = (shape,) * num_vars
         shape = tuple(shape)
+        if 0 in shape:
+            raise ValueError(f"Expected a non-zero Fock shape, got {shape}.")
         if len(shape) != num_vars:
             raise ValueError(f"Expected Fock shape of length {num_vars}, got {len(shape)}")
         return shape

--- a/mrmustard/lab/circuit_components.py
+++ b/mrmustard/lab/circuit_components.py
@@ -759,7 +759,7 @@ class CircuitComponent:
         If the shape is not given, it defaults to the ``auto_shape`` of the component.
 
         Args:
-            shape: The FOck shape of the returned representation. If ``shape`` is given as an ``int``,
+            shape: The Fock shape of the returned representation. If ``shape`` is given as an ``int``,
                 it is broadcasted to all the dimensions. If not given, it is generated via ``auto_shape``.
         Returns:
             The shape of the Fock representation of this component.

--- a/mrmustard/lab/states/dm.py
+++ b/mrmustard/lab/states/dm.py
@@ -378,6 +378,9 @@ class DM(State):
         Returns:
             array: The Fock representation of this component.
 
+        Raises:
+            ValueError: If the shape is not valid for the component.
+
         Note:
             The ``standard_order`` boolean argument lets one choose the standard convention for the
             index ordering of the density matrix. For a single mode, if ``standard_order=True`` the

--- a/mrmustard/lab/states/squeezed_vacuum.py
+++ b/mrmustard/lab/states/squeezed_vacuum.py
@@ -94,17 +94,7 @@ class SqueezedVacuum(Ket):
         self,
         shape: int | Sequence[int] | None = None,
     ) -> ComplexTensor:
-        shape = shape or self.auto_shape()
-        if isinstance(shape, int):
-            shape = (shape,) * self.ansatz.core_dims
-        shape = tuple(shape)
-        num_vars = (
-            self.ansatz.num_CV_vars
-            if isinstance(self.ansatz, PolyExpAnsatz)
-            else self.ansatz.num_vars
-        )
-        if len(shape) != num_vars:
-            raise ValueError(f"Expected Fock shape of length {num_vars}, got {len(shape)}")
+        shape = self._check_fock_shape(shape)
         if self.ansatz.batch_shape:
             rs, phi = math.broadcast_arrays(
                 self.parameters.r.value,

--- a/mrmustard/lab/states/squeezed_vacuum.py
+++ b/mrmustard/lab/states/squeezed_vacuum.py
@@ -103,15 +103,14 @@ class SqueezedVacuum(Ket):
             rs = math.reshape(rs, (-1,))
             phi = math.reshape(phi, (-1,))
             ret = math.astensor(
-                [math.squeezed(-r, p, shape=shape) for r, p in zip(rs, phi)],
+                [math.squeezed(r, p, shape=shape) for r, p in zip(rs, phi)],
             )
             ret = math.reshape(ret, self.ansatz.batch_shape + shape)
             if self.ansatz._lin_sup:
                 ret = math.sum(ret, axis=self.ansatz.batch_dims - 1)
         else:
-            # TODO: difference of r in strategies.squeezed
             ret = math.squeezed(
-                -self.parameters.r.value,
+                self.parameters.r.value,
                 self.parameters.phi.value,
                 shape=shape,
             )

--- a/mrmustard/lab/states/squeezed_vacuum.py
+++ b/mrmustard/lab/states/squeezed_vacuum.py
@@ -94,11 +94,17 @@ class SqueezedVacuum(Ket):
         self,
         shape: int | Sequence[int] | None = None,
     ) -> ComplexTensor:
+        shape = shape or self.auto_shape()
         if isinstance(shape, int):
             shape = (shape,) * self.ansatz.core_dims
-        if shape is None:
-            shape = tuple(self.auto_shape())
         shape = tuple(shape)
+        num_vars = (
+            self.ansatz.num_CV_vars
+            if isinstance(self.ansatz, PolyExpAnsatz)
+            else self.ansatz.num_vars
+        )
+        if len(shape) != num_vars:
+            raise ValueError(f"Expected Fock shape of length {num_vars}, got {len(shape)}")
         if self.ansatz.batch_shape:
             rs, phi = math.broadcast_arrays(
                 self.parameters.r.value,

--- a/mrmustard/lab/states/squeezed_vacuum.py
+++ b/mrmustard/lab/states/squeezed_vacuum.py
@@ -24,6 +24,7 @@ from mrmustard import math
 from mrmustard.physics import triples
 from mrmustard.physics.ansatz import PolyExpAnsatz
 from mrmustard.physics.wires import Wires
+from mrmustard.utils.typing import ComplexTensor
 
 from ..utils import make_parameter
 from .ket import Ket
@@ -88,3 +89,34 @@ class SqueezedVacuum(Ket):
             phi=self.parameters.phi,
         )
         self._wires = Wires(modes_out_ket=set(mode))
+
+    def fock_array(
+        self,
+        shape: int | Sequence[int] | None = None,
+    ) -> ComplexTensor:
+        if isinstance(shape, int):
+            shape = (shape,) * self.ansatz.core_dims
+        if shape is None:
+            shape = tuple(self.auto_shape())
+
+        if self.ansatz.batch_shape:
+            rs, phi = math.broadcast_arrays(
+                self.parameters.r.value,
+                self.parameters.phi.value,
+            )
+            rs = math.reshape(rs, (-1,))
+            phi = math.reshape(phi, (-1,))
+            ret = math.astensor(
+                [math.squeezed(-r, p, shape=shape) for r, p in zip(rs, phi)],
+            )
+            ret = math.reshape(ret, self.ansatz.batch_shape + shape)
+            if self.ansatz._lin_sup:
+                ret = math.sum(ret, axis=self.ansatz.batch_dims - 1)
+        else:
+            # TODO: difference of r in strategies.squeezed
+            ret = math.squeezed(
+                -self.parameters.r.value,
+                self.parameters.phi.value,
+                shape=shape,
+            )
+        return ret

--- a/mrmustard/lab/states/squeezed_vacuum.py
+++ b/mrmustard/lab/states/squeezed_vacuum.py
@@ -98,7 +98,7 @@ class SqueezedVacuum(Ket):
             shape = (shape,) * self.ansatz.core_dims
         if shape is None:
             shape = tuple(self.auto_shape())
-
+        shape = tuple(shape)
         if self.ansatz.batch_shape:
             rs, phi = math.broadcast_arrays(
                 self.parameters.r.value,

--- a/mrmustard/lab/transformations/bsgate.py
+++ b/mrmustard/lab/transformations/bsgate.py
@@ -129,14 +129,17 @@ class BSgate(Unitary):
         Returns:
             array: The Fock representation of this component.
         """
+        shape = shape or self.auto_shape()
         if isinstance(shape, int):
             shape = (shape,) * self.ansatz.core_dims
-        if shape is None:
-            shape = tuple(self.auto_shape())
         shape = tuple(shape)
-        if len(shape) != 4:
-            raise ValueError(f"Expected Fock shape of length {4}, got length {len(shape)}")
-
+        num_vars = (
+            self.ansatz.num_CV_vars
+            if isinstance(self.ansatz, PolyExpAnsatz)
+            else self.ansatz.num_vars
+        )
+        if len(shape) != num_vars:
+            raise ValueError(f"Expected Fock shape of length {num_vars}, got {len(shape)}")
         if self.ansatz.batch_shape:
             theta, phi = math.broadcast_arrays(
                 self.parameters.theta.value,

--- a/mrmustard/lab/transformations/bsgate.py
+++ b/mrmustard/lab/transformations/bsgate.py
@@ -133,6 +133,7 @@ class BSgate(Unitary):
             shape = (shape,) * self.ansatz.core_dims
         if shape is None:
             shape = tuple(self.auto_shape())
+        shape = tuple(shape)
         if len(shape) != 4:
             raise ValueError(f"Expected Fock shape of length {4}, got length {len(shape)}")
 

--- a/mrmustard/lab/transformations/bsgate.py
+++ b/mrmustard/lab/transformations/bsgate.py
@@ -126,20 +126,14 @@ class BSgate(Unitary):
                 - ``"vanilla"``: standard recurrence relation (not numerically stable, but slightly faster than the stable one).
                 - ``"schwinger"``: Use the Schwinger representation to compute the Fock array.
                 - ``"stable"``: Use the stable implementation of the beamsplitter. (default)
+
         Returns:
             array: The Fock representation of this component.
+
+        Raises:
+            ValueError: If the shape is not valid for the component.
         """
-        shape = shape or self.auto_shape()
-        if isinstance(shape, int):
-            shape = (shape,) * self.ansatz.core_dims
-        shape = tuple(shape)
-        num_vars = (
-            self.ansatz.num_CV_vars
-            if isinstance(self.ansatz, PolyExpAnsatz)
-            else self.ansatz.num_vars
-        )
-        if len(shape) != num_vars:
-            raise ValueError(f"Expected Fock shape of length {num_vars}, got {len(shape)}")
+        shape = self._check_fock_shape(shape)
         if self.ansatz.batch_shape:
             theta, phi = math.broadcast_arrays(
                 self.parameters.theta.value,

--- a/mrmustard/lab/transformations/dgate.py
+++ b/mrmustard/lab/transformations/dgate.py
@@ -111,20 +111,14 @@ class Dgate(Unitary):
             shape: The shape of the returned representation. If ``shape`` is given as an ``int``,
                 it is broadcasted to all the dimensions. If not given, it defaults to
                 ``settings.DEFAULT_FOCK_SIZE``.
+
         Returns:
             array: The Fock representation of this component.
+
+        Raises:
+            ValueError: If the shape is not valid for the component.
         """
-        shape = shape or self.auto_shape()
-        if isinstance(shape, int):
-            shape = (shape,) * self.ansatz.core_dims
-        shape = tuple(shape)
-        num_vars = (
-            self.ansatz.num_CV_vars
-            if isinstance(self.ansatz, PolyExpAnsatz)
-            else self.ansatz.num_vars
-        )
-        if len(shape) != num_vars:
-            raise ValueError(f"Expected Fock shape of length {num_vars}, got {len(shape)}")
+        shape = self._check_fock_shape(shape)
         if self.ansatz.batch_shape:
             x, y = math.broadcast_arrays(self.parameters.x.value, self.parameters.y.value)
             x = math.reshape(x, (-1,))

--- a/mrmustard/lab/transformations/dgate.py
+++ b/mrmustard/lab/transformations/dgate.py
@@ -114,15 +114,17 @@ class Dgate(Unitary):
         Returns:
             array: The Fock representation of this component.
         """
+        shape = shape or self.auto_shape()
         if isinstance(shape, int):
-            shape = (shape,) * self.ansatz.num_vars
-        auto_shape = self.auto_shape()
-        shape = shape or auto_shape
+            shape = (shape,) * self.ansatz.core_dims
         shape = tuple(shape)
-        if len(shape) != len(auto_shape):
-            raise ValueError(
-                f"Expected Fock shape of length {len(auto_shape)}, got length {len(shape)}",
-            )
+        num_vars = (
+            self.ansatz.num_CV_vars
+            if isinstance(self.ansatz, PolyExpAnsatz)
+            else self.ansatz.num_vars
+        )
+        if len(shape) != num_vars:
+            raise ValueError(f"Expected Fock shape of length {num_vars}, got {len(shape)}")
         if self.ansatz.batch_shape:
             x, y = math.broadcast_arrays(self.parameters.x.value, self.parameters.y.value)
             x = math.reshape(x, (-1,))

--- a/mrmustard/lab/transformations/sgate.py
+++ b/mrmustard/lab/transformations/sgate.py
@@ -123,17 +123,7 @@ class Sgate(Unitary):
         self,
         shape: int | Sequence[int] | None = None,
     ) -> ComplexTensor:
-        shape = shape or self.auto_shape()
-        if isinstance(shape, int):
-            shape = (shape,) * self.ansatz.core_dims
-        shape = tuple(shape)
-        num_vars = (
-            self.ansatz.num_CV_vars
-            if isinstance(self.ansatz, PolyExpAnsatz)
-            else self.ansatz.num_vars
-        )
-        if len(shape) != num_vars:
-            raise ValueError(f"Expected Fock shape of length {num_vars}, got {len(shape)}")
+        shape = self._check_fock_shape(shape)
         if self.ansatz.batch_shape:
             rs, phi = math.broadcast_arrays(
                 self.parameters.r.value,

--- a/mrmustard/lab/transformations/sgate.py
+++ b/mrmustard/lab/transformations/sgate.py
@@ -127,7 +127,7 @@ class Sgate(Unitary):
             shape = (shape,) * self.ansatz.core_dims
         if shape is None:
             shape = tuple(self.auto_shape())
-
+        shape = tuple(shape)
         if self.ansatz.batch_shape:
             rs, phi = math.broadcast_arrays(
                 self.parameters.r.value,

--- a/mrmustard/lab/transformations/sgate.py
+++ b/mrmustard/lab/transformations/sgate.py
@@ -123,11 +123,17 @@ class Sgate(Unitary):
         self,
         shape: int | Sequence[int] | None = None,
     ) -> ComplexTensor:
+        shape = shape or self.auto_shape()
         if isinstance(shape, int):
             shape = (shape,) * self.ansatz.core_dims
-        if shape is None:
-            shape = tuple(self.auto_shape())
         shape = tuple(shape)
+        num_vars = (
+            self.ansatz.num_CV_vars
+            if isinstance(self.ansatz, PolyExpAnsatz)
+            else self.ansatz.num_vars
+        )
+        if len(shape) != num_vars:
+            raise ValueError(f"Expected Fock shape of length {num_vars}, got {len(shape)}")
         if self.ansatz.batch_shape:
             rs, phi = math.broadcast_arrays(
                 self.parameters.r.value,

--- a/mrmustard/lab/transformations/sgate.py
+++ b/mrmustard/lab/transformations/sgate.py
@@ -22,6 +22,7 @@ from collections.abc import Sequence
 
 from mrmustard import math
 from mrmustard.physics.wires import Wires
+from mrmustard.utils.typing import ComplexTensor
 
 from ...physics import triples
 from ...physics.ansatz import PolyExpAnsatz
@@ -117,3 +118,33 @@ class Sgate(Unitary):
             modes_in_ket=set(mode),
             modes_out_ket=set(mode),
         )
+
+    def fock_array(
+        self,
+        shape: int | Sequence[int] | None = None,
+    ) -> ComplexTensor:
+        if isinstance(shape, int):
+            shape = (shape,) * self.ansatz.core_dims
+        if shape is None:
+            shape = tuple(self.auto_shape())
+
+        if self.ansatz.batch_shape:
+            rs, phi = math.broadcast_arrays(
+                self.parameters.r.value,
+                self.parameters.phi.value,
+            )
+            rs = math.reshape(rs, (-1,))
+            phi = math.reshape(phi, (-1,))
+            ret = math.astensor(
+                [math.squeezer(r, p, shape=shape) for r, p in zip(rs, phi)],
+            )
+            ret = math.reshape(ret, self.ansatz.batch_shape + shape)
+            if self.ansatz._lin_sup:
+                ret = math.sum(ret, axis=self.ansatz.batch_dims - 1)
+        else:
+            ret = math.squeezer(
+                self.parameters.r.value,
+                self.parameters.phi.value,
+                shape=shape,
+            )
+        return ret

--- a/mrmustard/math/backend_jax.py
+++ b/mrmustard/math/backend_jax.py
@@ -504,7 +504,6 @@ class BackendJax(BackendBase):
     ) -> jnp.ndarray:
         return hermite_renormalized_binomial_jax(A, B, C, shape, max_l2, global_cutoff)
 
-    @partial(jax.jit, static_argnames=["cutoffs"])
     def hermite_renormalized_diagonal(
         self,
         A: jnp.ndarray,

--- a/mrmustard/math/backend_jax.py
+++ b/mrmustard/math/backend_jax.py
@@ -556,7 +556,7 @@ class BackendJax(BackendBase):
         C: jnp.ndarray,
         cutoffs: tuple[int],
     ) -> jnp.ndarray:
-        return hermite_renormalized_1leftoverMode_reorderedAB_jax(A, B, C, cutoffs)
+        return hermite_renormalized_1leftoverMode_reorderedAB_jax(A, B, C, cutoffs)[0]
 
     # ~~~~~~~~~~~~~~~~~~~~~~~
     # Fock lattice strategies

--- a/mrmustard/math/backend_jax.py
+++ b/mrmustard/math/backend_jax.py
@@ -39,8 +39,9 @@ from .jax_vjps import (
     hermite_renormalized_binomial_jax,
     hermite_renormalized_diagonal_jax,
     hermite_renormalized_jax,
+    squeezed_jax,
+    squeezer_jax,
 )
-from .lattice import strategies
 from .parameter_set import ParameterSet
 from .parameters import Constant, Variable
 
@@ -526,8 +527,7 @@ class BackendJax(BackendBase):
         reorderedAB: bool,
     ) -> jnp.ndarray:
         A, B = self.reorder_AB_bargmann(A, B) if reorderedAB else (A, B)
-        cutoffs = (output_cutoff + 1, *tuple(p + 1 for p in pnr_cutoffs))
-        return hermite_renormalized_1leftoverMode_jax(A, B, C, cutoffs)[0]
+        return hermite_renormalized_1leftoverMode_jax(A, B, C, output_cutoff, pnr_cutoffs)[0]
 
     # ~~~~~~~~~~~~~~~~~~~~~~~
     # Fock lattice strategies
@@ -540,14 +540,10 @@ class BackendJax(BackendBase):
         return beamsplitter_jax(theta, phi, shape, method)
 
     def squeezed(self, r: float, phi: float, shape: tuple[int, int]):
-        # TODO: implement vjps
-        sq_ket = strategies.squeezed(shape, self.asnumpy(r), self.asnumpy(phi))
-        return self.astensor(sq_ket, dtype=sq_ket.dtype.name)
+        return squeezed_jax(r, phi, shape)
 
     def squeezer(self, r: float, phi: float, shape: tuple[int, int]):
-        # TODO: implement vjps
-        sq_ket = strategies.squeezer(shape, self.asnumpy(r), self.asnumpy(phi))
-        return self.astensor(sq_ket, dtype=sq_ket.dtype.name)
+        return squeezer_jax(r, phi, shape)
 
 
 # defining custom pytree nodes

--- a/mrmustard/math/backend_jax.py
+++ b/mrmustard/math/backend_jax.py
@@ -516,7 +516,15 @@ class BackendJax(BackendBase):
         A, B = self.reorder_AB_bargmann(A, B) if reorderedAB else (A, B)
         return hermite_renormalized_diagonal_jax(A, B, C, cutoffs)[0]
 
-    def hermite_renormalized_1leftoverMode(self, A, B, C, output_cutoff, pnr_cutoffs, reorderedAB):
+    def hermite_renormalized_1leftoverMode(
+        self,
+        A: jnp.ndarray,
+        B: jnp.ndarray,
+        C: jnp.ndarray,
+        output_cutoff: int,
+        pnr_cutoffs: tuple[int, ...],
+        reorderedAB: bool,
+    ) -> jnp.ndarray:
         A, B = self.reorder_AB_bargmann(A, B) if reorderedAB else (A, B)
         cutoffs = (output_cutoff + 1, *tuple(p + 1 for p in pnr_cutoffs))
         return hermite_renormalized_1leftoverMode_jax(A, B, C, cutoffs)[0]

--- a/mrmustard/math/backend_jax.py
+++ b/mrmustard/math/backend_jax.py
@@ -35,6 +35,7 @@ from .jax_vjps import (
     beamsplitter_jax,
     displacement_jax,
     hermite_renormalized_batched_jax,
+    hermite_renormalized_binomial_jax,
     hermite_renormalized_unbatched_jax,
 )
 from .lattice import strategies
@@ -479,7 +480,6 @@ class BackendJax(BackendBase):
             raise ValueError("The 'out' keyword is not supported in the JAX backend.")
         return hermite_renormalized_unbatched_jax(A, b, c, shape, stable)
 
-    @partial(jax.jit, static_argnames=["shape", "stable"])
     def hermite_renormalized_batched(
         self,
         A: jnp.ndarray,
@@ -580,7 +580,6 @@ class BackendJax(BackendBase):
             C,
         )
 
-    @partial(jax.jit, static_argnames=["shape", "max_l2", "global_cutoff"])
     def hermite_renormalized_binomial(
         self,
         A: jnp.ndarray,
@@ -607,22 +606,7 @@ class BackendJax(BackendBase):
         Returns:
             The renormalized Hermite polynomial of given shape.
         """
-        function = partial(strategies.binomial, tuple(shape))
-        return jax.pure_callback(
-            lambda A, B, C, max_l2, global_cutoff: function(
-                np.asarray(A),
-                np.asarray(B),
-                np.asarray(C),
-                max_l2,
-                global_cutoff,
-            )[0],
-            jax.ShapeDtypeStruct(shape, jnp.complex128),
-            A,
-            B,
-            C,
-            max_l2,
-            global_cutoff,
-        )
+        return hermite_renormalized_binomial_jax(A, B, C, shape, max_l2, global_cutoff)
 
     @partial(jax.jit, static_argnames=["output_cutoff", "pnr_cutoffs"])
     def hermite_renormalized_1leftoverMode(self, A, B, C, output_cutoff, pnr_cutoffs):

--- a/mrmustard/math/backend_jax.py
+++ b/mrmustard/math/backend_jax.py
@@ -37,7 +37,6 @@ from .jax_vjps import (
     hermite_renormalized_1leftoverMode_reorderedAB_jax,
     hermite_renormalized_batched_jax,
     hermite_renormalized_binomial_jax,
-    hermite_renormalized_diagonal_reorderedAB_batch_jax,
     hermite_renormalized_diagonal_reorderedAB_jax,
     hermite_renormalized_jax,
 )
@@ -524,25 +523,6 @@ class BackendJax(BackendBase):
         cutoffs: tuple[int],
     ) -> jnp.ndarray:
         return hermite_renormalized_diagonal_reorderedAB_jax(A, B, C, cutoffs)[0]
-
-    def hermite_renormalized_diagonal_batch(
-        self,
-        A: jnp.ndarray,
-        B: jnp.ndarray,
-        C: jnp.ndarray,
-        cutoffs: tuple[int],
-    ) -> jnp.ndarray:
-        A, B = self.reorder_AB_bargmann(A, B)
-        return self.hermite_renormalized_diagonal_reorderedAB_batch(A, B, C, cutoffs=cutoffs)
-
-    def hermite_renormalized_diagonal_reorderedAB_batch(
-        self,
-        A: jnp.ndarray,
-        B: jnp.ndarray,
-        C: jnp.ndarray,
-        cutoffs: tuple[int],
-    ) -> jnp.ndarray:
-        return hermite_renormalized_diagonal_reorderedAB_batch_jax(A, B, C, cutoffs)
 
     def hermite_renormalized_1leftoverMode(self, A, B, C, output_cutoff, pnr_cutoffs):
         A, B = self.reorder_AB_bargmann(A, B)

--- a/mrmustard/math/backend_jax.py
+++ b/mrmustard/math/backend_jax.py
@@ -539,7 +539,7 @@ class BackendJax(BackendBase):
     def beamsplitter(self, theta: float, phi: float, shape: tuple[int, int, int, int], method: str):
         return beamsplitter_jax(theta, phi, shape, method)
 
-    def squeezed(self, r: float, phi: float, shape: tuple[int, int]):
+    def squeezed(self, r: float, phi: float, shape: tuple[int]):
         return squeezed_jax(r, phi, shape)
 
     def squeezer(self, r: float, phi: float, shape: tuple[int, int]):

--- a/mrmustard/math/backend_jax.py
+++ b/mrmustard/math/backend_jax.py
@@ -468,7 +468,7 @@ class BackendJax(BackendBase):
     # hermite_renormalized
     # ~~~~~~~~~~~~~~~~~~~~
 
-    def hermite_renormalized_unbatched(
+    def hermite_renormalized(
         self,
         A: jnp.ndarray,
         b: jnp.ndarray,

--- a/mrmustard/math/backend_jax.py
+++ b/mrmustard/math/backend_jax.py
@@ -34,7 +34,7 @@ from .backend_base import BackendBase
 from .jax_vjps import (
     beamsplitter_jax,
     displacement_jax,
-    hermite_renormalized_1leftoverMode_reorderedAB_jax,
+    hermite_renormalized_1leftoverMode_jax,
     hermite_renormalized_batched_jax,
     hermite_renormalized_binomial_jax,
     hermite_renormalized_diagonal_jax,
@@ -516,19 +516,10 @@ class BackendJax(BackendBase):
         A, B = self.reorder_AB_bargmann(A, B) if reorderedAB else (A, B)
         return hermite_renormalized_diagonal_jax(A, B, C, cutoffs)[0]
 
-    def hermite_renormalized_1leftoverMode(self, A, B, C, output_cutoff, pnr_cutoffs):
-        A, B = self.reorder_AB_bargmann(A, B)
+    def hermite_renormalized_1leftoverMode(self, A, B, C, output_cutoff, pnr_cutoffs, reorderedAB):
+        A, B = self.reorder_AB_bargmann(A, B) if reorderedAB else (A, B)
         cutoffs = (output_cutoff + 1, *tuple(p + 1 for p in pnr_cutoffs))
-        return self.hermite_renormalized_1leftoverMode_reorderedAB(A, B, C, cutoffs=cutoffs)
-
-    def hermite_renormalized_1leftoverMode_reorderedAB(
-        self,
-        A: jnp.ndarray,
-        B: jnp.ndarray,
-        C: jnp.ndarray,
-        cutoffs: tuple[int],
-    ) -> jnp.ndarray:
-        return hermite_renormalized_1leftoverMode_reorderedAB_jax(A, B, C, cutoffs)[0]
+        return hermite_renormalized_1leftoverMode_jax(A, B, C, cutoffs)[0]
 
     # ~~~~~~~~~~~~~~~~~~~~~~~
     # Fock lattice strategies

--- a/mrmustard/math/backend_jax.py
+++ b/mrmustard/math/backend_jax.py
@@ -37,7 +37,7 @@ from .jax_vjps import (
     hermite_renormalized_1leftoverMode_reorderedAB_jax,
     hermite_renormalized_batched_jax,
     hermite_renormalized_binomial_jax,
-    hermite_renormalized_diagonal_reorderedAB_jax,
+    hermite_renormalized_diagonal_jax,
     hermite_renormalized_jax,
 )
 from .lattice import strategies
@@ -511,18 +511,10 @@ class BackendJax(BackendBase):
         B: jnp.ndarray,
         C: jnp.ndarray,
         cutoffs: tuple[int],
+        reorderedAB: bool,
     ) -> jnp.ndarray:
-        A, B = self.reorder_AB_bargmann(A, B)
-        return self.hermite_renormalized_diagonal_reorderedAB(A, B, C, cutoffs=cutoffs)
-
-    def hermite_renormalized_diagonal_reorderedAB(
-        self,
-        A: jnp.ndarray,
-        B: jnp.ndarray,
-        C: jnp.ndarray,
-        cutoffs: tuple[int],
-    ) -> jnp.ndarray:
-        return hermite_renormalized_diagonal_reorderedAB_jax(A, B, C, cutoffs)[0]
+        A, B = self.reorder_AB_bargmann(A, B) if reorderedAB else (A, B)
+        return hermite_renormalized_diagonal_jax(A, B, C, cutoffs)[0]
 
     def hermite_renormalized_1leftoverMode(self, A, B, C, output_cutoff, pnr_cutoffs):
         A, B = self.reorder_AB_bargmann(A, B)

--- a/mrmustard/math/backend_jax.py
+++ b/mrmustard/math/backend_jax.py
@@ -522,7 +522,7 @@ class BackendJax(BackendBase):
         C: jnp.ndarray,
         cutoffs: tuple[int],
     ) -> jnp.ndarray:
-        return hermite_renormalized_diagonal_reorderedAB_jax(A, B, C, cutoffs)
+        return hermite_renormalized_diagonal_reorderedAB_jax(A, B, C, cutoffs)[0]
 
     @partial(jax.jit, static_argnames=["cutoffs"])
     def hermite_renormalized_diagonal_batch(

--- a/mrmustard/math/backend_jax.py
+++ b/mrmustard/math/backend_jax.py
@@ -39,7 +39,7 @@ from .jax_vjps import (
     hermite_renormalized_binomial_jax,
     hermite_renormalized_diagonal_reorderedAB_batch_jax,
     hermite_renormalized_diagonal_reorderedAB_jax,
-    hermite_renormalized_unbatched_jax,
+    hermite_renormalized_jax,
 )
 from .lattice import strategies
 from .parameter_set import ParameterSet
@@ -480,7 +480,7 @@ class BackendJax(BackendBase):
     ) -> jnp.ndarray:
         if out is not None:
             raise ValueError("The 'out' keyword is not supported in the JAX backend.")
-        return hermite_renormalized_unbatched_jax(A, b, c, shape, stable)
+        return hermite_renormalized_jax(A, b, c, shape, stable)
 
     def hermite_renormalized_batched(
         self,

--- a/mrmustard/math/backend_manager.py
+++ b/mrmustard/math/backend_manager.py
@@ -748,6 +748,7 @@ class BackendManager:
         c: Tensor,
         output_cutoff: int,
         pnr_cutoffs: tuple[int, ...],
+        reorderedAB: bool = True,
     ) -> Tensor:
         r"""Compute the conditional density matrix of mode 0, with all the other modes
         detected with PNR detectors up to the given photon numbers.
@@ -758,6 +759,7 @@ class BackendManager:
             c: The c scalar.
             output_cutoff: upper boundary of photon numbers in mode 0
             pnr_cutoffs: upper boundary of photon numbers in the other modes
+            reorderedAB: Whether to reorder A and B parameters match conventions in mrmustard.math.numba.compactFock~.
 
         Returns:
             The conditional density matrix of mode 0. The final shape is
@@ -765,7 +767,7 @@ class BackendManager:
         """
         return self._apply(
             "hermite_renormalized_1leftoverMode",
-            (A, b, c, output_cutoff, pnr_cutoffs),
+            (A, b, c, output_cutoff, pnr_cutoffs, reorderedAB),
         )
 
     def hermite_renormalized_binomial(

--- a/mrmustard/math/backend_manager.py
+++ b/mrmustard/math/backend_manager.py
@@ -717,22 +717,29 @@ class BackendManager:
         b: Tensor,
         c: Tensor,
         cutoffs: tuple[int],
+        reorderedAB: bool = True,
     ) -> Tensor:
         r"""
-        Renormalized multidimensional Hermite polynomial for calculating the diagonal of the Fock representation.
+        Renormalized multidimensional Hermite polynomial given by the "exponential" Taylor
+        series of :math:`exp(C + Bx - Ax^2)` at zero, where the series has :math:`sqrt(n!)` at the
+        denominator rather than :math:`n!`. Note the minus sign in front of ``A``.
+
+        Calculates the diagonal of the Fock representation (i.e. the PNR detection probabilities of all modes)
+        by applying the recursion relation in a selective manner.
 
         Note: This function supports batching of different B's.
 
         Args:
             A: The A matrix.
-            b: The b vector.
-            c: The c scalar.
-            cutoffs: Upper boundary of photon numbers in each mode.
+            B: The B vector.
+            C: The C scalar.
+            cutoffs: upper boundary of photon numbers in each mode
+            reorderedAB: Whether to reorder A and B parameters match conventions in mrmustard.math.numba.compactFock~.
 
         Returns:
-            The diagonal elements of the Fock representation (i.e., PNR detection probabilities).
+            The renormalized Hermite polynomial.
         """
-        return self._apply("hermite_renormalized_diagonal", (A, b, c, cutoffs))
+        return self._apply("hermite_renormalized_diagonal", (A, b, c, cutoffs, reorderedAB))
 
     def hermite_renormalized_1leftoverMode(
         self,

--- a/mrmustard/math/backend_manager.py
+++ b/mrmustard/math/backend_manager.py
@@ -718,7 +718,10 @@ class BackendManager:
         c: Tensor,
         cutoffs: tuple[int],
     ) -> Tensor:
-        r"""Renormalized multidimensional Hermite polynomial for calculating the diagonal of the Fock representation.
+        r"""
+        Renormalized multidimensional Hermite polynomial for calculating the diagonal of the Fock representation.
+
+        Note: This function supports batching of different B's.
 
         Args:
             A: The A matrix.
@@ -730,18 +733,6 @@ class BackendManager:
             The diagonal elements of the Fock representation (i.e., PNR detection probabilities).
         """
         return self._apply("hermite_renormalized_diagonal", (A, b, c, cutoffs))
-
-    def hermite_renormalized_diagonal_batch(
-        self,
-        A: Tensor,
-        B: Tensor,
-        C: Tensor,
-        cutoffs: tuple[int],
-    ) -> Tensor:
-        r"""First, reorder A and B parameters of Bargmann representation to match conventions in mrmustard.math.compactFock~
-        Then, calculates the required renormalized multidimensional Hermite polynomial.
-        Same as hermite_renormalized_diagonal but works for a batch of different B's."""
-        return self._apply("hermite_renormalized_diagonal_batch", (A, B, C, cutoffs))
 
     def hermite_renormalized_1leftoverMode(
         self,

--- a/mrmustard/math/backend_manager.py
+++ b/mrmustard/math/backend_manager.py
@@ -706,7 +706,7 @@ class BackendManager:
         # Unbatched case
         check_out_shape(())
         return self._apply(
-            "hermite_renormalized_unbatched",
+            "hermite_renormalized",
             (A, b, c),
             {"shape": tuple(shape), "stable": stable, "out": out},
         )

--- a/mrmustard/math/backend_manager.py
+++ b/mrmustard/math/backend_manager.py
@@ -731,8 +731,8 @@ class BackendManager:
 
         Args:
             A: The A matrix.
-            B: The B vector.
-            C: The C scalar.
+            b: The b vector.
+            c: The c scalar.
             cutoffs: upper boundary of photon numbers in each mode
             reorderedAB: Whether to reorder A and B parameters match conventions in mrmustard.math.numba.compactFock~.
 

--- a/mrmustard/math/backend_manager.py
+++ b/mrmustard/math/backend_manager.py
@@ -1468,14 +1468,14 @@ class BackendManager:
         """
         return self._apply("beamsplitter", (theta, phi), {"shape": shape, "method": method})
 
-    def squeezed(self, r: float, phi: float, shape: tuple[int, int]):
+    def squeezed(self, r: float, phi: float, shape: tuple[int]):
         r"""
         Creates a single mode squeezed state matrix using a numba-based fock lattice strategy.
 
         Args:
             r: Squeezing magnitude.
             phi: Squeezing angle.
-            shape: Output shape of the two modes.
+            shape: Output shape of the mode.
 
         Returns:
             The matrix representing the squeezed state.

--- a/mrmustard/math/backend_numpy.py
+++ b/mrmustard/math/backend_numpy.py
@@ -450,7 +450,6 @@ class BackendNumpy(BackendBase):
         stable: bool = False,
         reorderedAB: bool = True,
     ) -> np.ndarray:
-        # why is this different from the jax version?
         return strategies.fast_diagonal(A, b, c, output_cutoff, pnr_cutoffs, stable).transpose(
             (-2, -1, *tuple(range(len(pnr_cutoffs)))),
         )

--- a/mrmustard/math/backend_numpy.py
+++ b/mrmustard/math/backend_numpy.py
@@ -30,7 +30,6 @@ from .backend_base import BackendBase
 from .lattice import strategies
 from .lattice.strategies.compactFock.inputValidation import (
     hermite_multidimensional_diagonal,
-    hermite_multidimensional_diagonal_batch,
 )
 
 np.set_printoptions(legacy="1.25")
@@ -510,9 +509,7 @@ class BackendNumpy(BackendBase):
         Returns:
             The renormalized Hermite polynomial from different B values.
         """
-        poly0, _, _, _, _ = hermite_multidimensional_diagonal_batch(A, B, C, cutoffs)
-
-        return poly0
+        return hermite_multidimensional_diagonal(A, B, C, cutoffs)[0]
 
     def hermite_renormalized_1leftoverMode(
         self,

--- a/mrmustard/math/backend_numpy.py
+++ b/mrmustard/math/backend_numpy.py
@@ -446,36 +446,9 @@ class BackendNumpy(BackendBase):
         B: np.ndarray,
         C: np.ndarray,
         cutoffs: tuple[int],
+        reorderedAB: bool,
     ) -> np.ndarray:
-        r"""First, reorder A and B parameters of Bargmann representation to match conventions in mrmustard.math.numba.compactFock~
-        Then, calculate the required renormalized multidimensional Hermite polynomial.
-        """
-        A, B = self.reorder_AB_bargmann(A, B)
-        return self.hermite_renormalized_diagonal_reorderedAB(A, B, C, cutoffs=cutoffs)
-
-    def hermite_renormalized_diagonal_reorderedAB(
-        self,
-        A: np.ndarray,
-        B: np.ndarray,
-        C: np.ndarray,
-        cutoffs: tuple[int],
-    ) -> np.ndarray:
-        r"""Renormalized multidimensional Hermite polynomial given by the "exponential" Taylor
-        series of :math:`exp(C + Bx - Ax^2)` at zero, where the series has :math:`sqrt(n!)` at the
-        denominator rather than :math:`n!`. Note the minus sign in front of ``A``.
-
-        Calculates the diagonal of the Fock representation (i.e. the PNR detection probabilities of all modes)
-        by applying the recursion relation in a selective manner.
-
-        Args:
-            A: The A matrix.
-            B: The B vector.
-            C: The C scalar.
-            cutoffs: upper boundary of photon numbers in each mode
-
-        Returns:
-            The renormalized Hermite polynomial.
-        """
+        A, B = self.reorder_AB_bargmann(A, B) if reorderedAB else (A, B)
         return hermite_multidimensional_diagonal(A, B, C, cutoffs)[0]
 
     def hermite_renormalized_1leftoverMode(

--- a/mrmustard/math/backend_numpy.py
+++ b/mrmustard/math/backend_numpy.py
@@ -473,8 +473,8 @@ class BackendNumpy(BackendBase):
             bs_unitary = strategies.stable_beamsplitter(shape, t, s)
         return self.astensor(bs_unitary, dtype=bs_unitary.dtype.name)
 
-    def squeezed(self, r: float, phi: float, shape: tuple[int, int]):
-        sq_ket = strategies.squeezed(shape, self.asnumpy(r), self.asnumpy(phi))
+    def squeezed(self, r: float, phi: float, shape: tuple[int]):
+        sq_ket = strategies.squeezed(shape[0], self.asnumpy(r), self.asnumpy(phi))
         return self.astensor(sq_ket, dtype=sq_ket.dtype.name)
 
     def squeezer(self, r: float, phi: float, shape: tuple[int, int]):

--- a/mrmustard/math/backend_numpy.py
+++ b/mrmustard/math/backend_numpy.py
@@ -416,23 +416,6 @@ class BackendNumpy(BackendBase):
         max_l2: float | None,
         global_cutoff: int | None,
     ) -> np.ndarray:
-        r"""Renormalized multidimensional Hermite polynomial given by the "exponential" Taylor
-        series of :math:`exp(C + Bx + 1/2*Ax^2)` at zero, where the series has :math:`sqrt(n!)`
-        at the denominator rather than :math:`n!`. The computation fills a tensor of given shape
-        up to a given L2 norm or global cutoff, whichever applies first. The max_l2 value, if
-        not provided, is set to the default value of the AUTOSHAPE_PROBABILITY setting.
-
-        Args:
-            A: The A matrix.
-            B: The B vector.
-            C: The C scalar.
-            shape: The shape of the final tensor (local cutoffs).
-            max_l2 (float): The maximum squared L2 norm of the tensor.
-            global_cutoff (optional int): The global cutoff.
-
-        Returns:
-            The renormalized Hermite polynomial of given shape.
-        """
         return strategies.binomial(
             tuple(shape),
             A,

--- a/mrmustard/math/backend_numpy.py
+++ b/mrmustard/math/backend_numpy.py
@@ -419,16 +419,14 @@ class BackendNumpy(BackendBase):
         Returns:
             The renormalized Hermite polynomial of given shape.
         """
-        G, _ = strategies.binomial(
+        return strategies.binomial(
             tuple(shape),
             A,
             B,
             C,
             max_l2=max_l2 or settings.AUTOSHAPE_PROBABILITY,
             global_cutoff=global_cutoff or sum(shape) - len(shape) + 1,
-        )
-
-        return G
+        )[0]
 
     def reorder_AB_bargmann(self, A: np.ndarray, B: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         r"""In mrmustard.math.numba.compactFock~ dimensions of the Fock representation are ordered like [mode0,mode0,mode1,mode1,...]
@@ -459,7 +457,9 @@ class BackendNumpy(BackendBase):
         output_cutoff: int,
         pnr_cutoffs: tuple[int, ...],
         stable: bool = False,
+        reorderedAB: bool = True,
     ) -> np.ndarray:
+        # why is this different from the jax version?
         return strategies.fast_diagonal(A, b, c, output_cutoff, pnr_cutoffs, stable).transpose(
             (-2, -1, *tuple(range(len(pnr_cutoffs)))),
         )

--- a/mrmustard/math/backend_numpy.py
+++ b/mrmustard/math/backend_numpy.py
@@ -476,39 +476,6 @@ class BackendNumpy(BackendBase):
         Returns:
             The renormalized Hermite polynomial.
         """
-        poly0, _, _, _, _ = hermite_multidimensional_diagonal(A, B, C, cutoffs)
-
-        return poly0
-
-    def hermite_renormalized_diagonal_batch(
-        self,
-        A: np.ndarray,
-        B: np.ndarray,
-        C: np.ndarray,
-        cutoffs: tuple[int],
-    ) -> np.ndarray:
-        r"""Same as hermite_renormalized_diagonal but works for a batch of different B's."""
-        A, B = self.reorder_AB_bargmann(A, B)
-        return self.hermite_renormalized_diagonal_reorderedAB_batch(A, B, C, cutoffs=cutoffs)
-
-    def hermite_renormalized_diagonal_reorderedAB_batch(
-        self,
-        A: np.ndarray,
-        B: np.ndarray,
-        C: np.ndarray,
-        cutoffs: tuple[int],
-    ) -> np.ndarray:
-        r"""Same as hermite_renormalized_diagonal_reorderedAB but works for a batch of different B's.
-
-        Args:
-            A: The A matrix.
-            B: The B vectors.
-            C: The C scalar.
-            cutoffs: upper boundary of photon numbers in each mode
-
-        Returns:
-            The renormalized Hermite polynomial from different B values.
-        """
         return hermite_multidimensional_diagonal(A, B, C, cutoffs)[0]
 
     def hermite_renormalized_1leftoverMode(

--- a/mrmustard/math/backend_numpy.py
+++ b/mrmustard/math/backend_numpy.py
@@ -369,7 +369,7 @@ class BackendNumpy(BackendBase):
             return self.cast(ret, self.complex128)
         return self.cast(ret, dtype)
 
-    def hermite_renormalized_unbatched(
+    def hermite_renormalized(
         self,
         A: np.ndarray,
         b: np.ndarray,

--- a/mrmustard/math/jax_vjps/fock_utils.py
+++ b/mrmustard/math/jax_vjps/fock_utils.py
@@ -195,7 +195,7 @@ def squeezed_jax(r: float, phi: float, shape: tuple[int]) -> jnp.ndarray:
     The jax custom gradient for the squeezed state.
     """
     return jax.pure_callback(
-        lambda shape, r, phi: strategies.squeezed(shape[0], np.asarray(r), np.asarray(phi)),
+        lambda shape, r, phi: strategies.squeezed(int(shape[0]), np.asarray(r), np.asarray(phi)),
         jax.ShapeDtypeStruct(shape, jnp.complex128),
         shape,
         r,
@@ -208,23 +208,23 @@ def squeezed_jax_fwd(r, phi, shape):
     The jax forward pass for the squeezed state.
     """
     primal_output = squeezed_jax(r, phi, shape)
-    return (primal_output, (*primal_output, r, phi))
+    return (primal_output, (primal_output, r, phi))
 
 
 def squeezed_jax_bwd(shape, res, g):
     r"""
     The jax backward pass for the squeezed state.
     """
-    sq_ket, r, phi = res
+    sq_state, r, phi = res
     return jax.pure_callback(
-        lambda sq_ket, g, r, phi: strategies.squeezed_vjp(
-            np.asarray(sq_ket),
+        lambda sq_state, g, r, phi: strategies.squeezed_vjp(
+            np.asarray(sq_state),
             np.asarray(g),
             np.asarray(r),
             np.asarray(phi),
         ),
         (jax.ShapeDtypeStruct((), jnp.float64), jax.ShapeDtypeStruct((), jnp.float64)),
-        sq_ket,
+        sq_state,
         g,
         r,
         phi,
@@ -246,7 +246,9 @@ def squeezer_jax(r: float, phi: float, shape: tuple[int, int]) -> jnp.ndarray:
     The jax custom gradient for the squeezer gate.
     """
     return jax.pure_callback(
-        lambda shape, r, phi: strategies.squeezer(shape, np.asarray(r), np.asarray(phi)),
+        lambda shape, r, phi: strategies.squeezer(
+            tuple(int(s) for s in shape), np.asarray(r), np.asarray(phi)
+        ),
         jax.ShapeDtypeStruct(shape, jnp.complex128),
         shape,
         r,
@@ -259,23 +261,23 @@ def squeezer_jax_fwd(r, phi, shape):
     The jax forward pass for the squeezer gate.
     """
     primal_output = squeezer_jax(r, phi, shape)
-    return (primal_output, (*primal_output, r, phi))
+    return (primal_output, (primal_output, r, phi))
 
 
 def squeezer_jax_bwd(shape, res, g):
     r"""
     The jax backward pass for the squeezer gate.
     """
-    sq_ket, r, phi = res
+    squeezer, r, phi = res
     return jax.pure_callback(
-        lambda sq_ket, g, r, phi: strategies.squeezer_vjp(
-            np.asarray(sq_ket),
+        lambda squeezer, g, r, phi: strategies.squeezer_vjp(
+            np.asarray(squeezer),
             np.asarray(g),
             np.asarray(r),
             np.asarray(phi),
         ),
         (jax.ShapeDtypeStruct((), jnp.float64), jax.ShapeDtypeStruct((), jnp.float64)),
-        sq_ket,
+        squeezer,
         g,
         r,
         phi,

--- a/mrmustard/math/jax_vjps/fock_utils.py
+++ b/mrmustard/math/jax_vjps/fock_utils.py
@@ -190,12 +190,12 @@ displacement_jax.defvjp(displacement_jax_fwd, displacement_jax_bwd)
 
 @partial(jax.custom_vjp, nondiff_argnums=(2,))
 @partial(jax.jit, static_argnums=(2,))
-def squeezed_jax(r: float, phi: float, shape: tuple[int, int]) -> jnp.ndarray:
+def squeezed_jax(r: float, phi: float, shape: tuple[int]) -> jnp.ndarray:
     r"""
     The jax custom gradient for the squeezed state.
     """
     return jax.pure_callback(
-        lambda shape, r, phi: strategies.squeezed(shape, np.asarray(r), np.asarray(phi)),
+        lambda shape, r, phi: strategies.squeezed(shape[0], np.asarray(r), np.asarray(phi)),
         jax.ShapeDtypeStruct(shape, jnp.complex128),
         shape,
         r,

--- a/mrmustard/math/jax_vjps/fock_utils.py
+++ b/mrmustard/math/jax_vjps/fock_utils.py
@@ -26,7 +26,7 @@ import numpy as np
 
 from mrmustard.math.lattice import strategies
 
-__all__ = ["beamsplitter_jax", "displacement_jax"]
+__all__ = ["beamsplitter_jax", "displacement_jax", "squeezed_jax", "squeezer_jax"]
 
 # ~~~~~~~~~~~~~~~~~
 # beamsplitter
@@ -181,3 +181,105 @@ def displacement_jax_bwd(
 
 
 displacement_jax.defvjp(displacement_jax_fwd, displacement_jax_bwd)
+
+
+# ~~~~~~~~
+# squeezed
+# ~~~~~~~~
+
+
+@partial(jax.custom_vjp, nondiff_argnums=(2,))
+@partial(jax.jit, static_argnums=(2,))
+def squeezed_jax(r: float, phi: float, shape: tuple[int, int]) -> jnp.ndarray:
+    r"""
+    The jax custom gradient for the squeezed state.
+    """
+    return jax.pure_callback(
+        lambda shape, r, phi: strategies.squeezed(shape, np.asarray(r), np.asarray(phi)),
+        jax.ShapeDtypeStruct(shape, jnp.complex128),
+        shape,
+        r,
+        phi,
+    )
+
+
+def squeezed_jax_fwd(r, phi, shape):
+    r"""
+    The jax forward pass for the squeezed state.
+    """
+    primal_output = squeezed_jax(r, phi, shape)
+    return (primal_output, (*primal_output, r, phi))
+
+
+def squeezed_jax_bwd(shape, res, g):
+    r"""
+    The jax backward pass for the squeezed state.
+    """
+    sq_ket, r, phi = res
+    return jax.pure_callback(
+        lambda sq_ket, g, r, phi: strategies.squeezed_vjp(
+            np.asarray(sq_ket),
+            np.asarray(g),
+            np.asarray(r),
+            np.asarray(phi),
+        ),
+        (jax.ShapeDtypeStruct((), jnp.float64), jax.ShapeDtypeStruct((), jnp.float64)),
+        sq_ket,
+        g,
+        r,
+        phi,
+    )
+
+
+squeezed_jax.defvjp(squeezed_jax_fwd, squeezed_jax_bwd)
+
+
+# ~~~~~~~~
+# squeezer
+# ~~~~~~~~
+
+
+@partial(jax.custom_vjp, nondiff_argnums=(2,))
+@partial(jax.jit, static_argnums=(2,))
+def squeezer_jax(r: float, phi: float, shape: tuple[int, int]) -> jnp.ndarray:
+    r"""
+    The jax custom gradient for the squeezer gate.
+    """
+    return jax.pure_callback(
+        lambda shape, r, phi: strategies.squeezer(shape, np.asarray(r), np.asarray(phi)),
+        jax.ShapeDtypeStruct(shape, jnp.complex128),
+        shape,
+        r,
+        phi,
+    )
+
+
+def squeezer_jax_fwd(r, phi, shape):
+    r"""
+    The jax forward pass for the squeezer gate.
+    """
+    primal_output = squeezer_jax(r, phi, shape)
+    return (primal_output, (*primal_output, r, phi))
+
+
+def squeezer_jax_bwd(shape, res, g):
+    r"""
+    The jax backward pass for the squeezer gate.
+    """
+    sq_ket, r, phi = res
+    return jax.pure_callback(
+        lambda sq_ket, g, r, phi: strategies.squeezer_vjp(
+            np.asarray(sq_ket),
+            np.asarray(g),
+            np.asarray(r),
+            np.asarray(phi),
+        ),
+        (jax.ShapeDtypeStruct((), jnp.float64), jax.ShapeDtypeStruct((), jnp.float64)),
+        sq_ket,
+        g,
+        r,
+        phi,
+    )
+
+
+squeezer_jax.defvjp(squeezer_jax_fwd, squeezer_jax_bwd)

--- a/mrmustard/math/jax_vjps/hermite.py
+++ b/mrmustard/math/jax_vjps/hermite.py
@@ -357,6 +357,7 @@ def hermite_renormalized_1leftoverMode_jax(
         shape = (1, 1, 1, 1, 1)
     else:
         shape = (cutoff_leftoverMode, cutoff_leftoverMode, M - 1, M - 2, *cutoffs_tail)
+    # TODO: add vjp for fast_diagonal and make use of it in 95226
     return jax.pure_callback(
         lambda A, B, C, cutoffs: hermite_multidimensional_1leftoverMode(
             np.array(A), np.array(B), np.array(C), np.array(cutoffs)

--- a/mrmustard/math/jax_vjps/hermite.py
+++ b/mrmustard/math/jax_vjps/hermite.py
@@ -31,7 +31,7 @@ from ..lattice.strategies.compactFock.inputValidation import (
 )
 
 __all__ = [
-    "hermite_renormalized_1leftoverMode_reorderedAB_jax",
+    "hermite_renormalized_1leftoverMode_jax",
     "hermite_renormalized_batched_jax",
     "hermite_renormalized_binomial_jax",
     "hermite_renormalized_diagonal_jax",
@@ -332,21 +332,21 @@ hermite_renormalized_diagonal_jax.defvjp(
 )
 
 
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# hermite_renormalized_1leftoverMode_reorderedAB
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# hermite_renormalized_1leftoverMode
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 
 @partial(jax.custom_vjp, nondiff_argnums=(3,))
 @partial(jax.jit, static_argnums=(3,))
-def hermite_renormalized_1leftoverMode_reorderedAB_jax(
+def hermite_renormalized_1leftoverMode_jax(
     A: jnp.ndarray,
     B: jnp.ndarray,
     C: jnp.ndarray,
     cutoffs: tuple[int],
 ) -> jnp.ndarray:
     r"""
-    The jax custom gradient for hermite_renormalized_1leftoverMode_reorderedAB.
+    The jax custom gradient for hermite_renormalized_1leftoverMode.
     """
     M = len(cutoffs)
     cutoff_leftoverMode = cutoffs[0]
@@ -380,17 +380,17 @@ def hermite_renormalized_1leftoverMode_reorderedAB_jax(
     )
 
 
-def hermite_renormalized_1leftoverMode_reorderedAB_jax_fwd(A, b, c, shape):
+def hermite_renormalized_1leftoverMode_jax_fwd(A, b, c, shape):
     r"""
-    The jax forward pass for hermite_renormalized_1leftoverMode_reorderedAB.
+    The jax forward pass for hermite_renormalized_reorderedAB.
     """
-    primal_output = hermite_renormalized_1leftoverMode_reorderedAB_jax(A, b, c, shape)
+    primal_output = hermite_renormalized_1leftoverMode_jax(A, b, c, shape)
     return (primal_output, (*primal_output, A, b, c))
 
 
-def hermite_renormalized_1leftoverMode_reorderedAB_jax_bwd(shape, res, g):
+def hermite_renormalized_1leftoverMode_jax_bwd(shape, res, g):
     r"""
-    The jax backward pass for hermite_renormalized_1leftoverMode_reorderedAB.
+    The jax backward pass for hermite_renormalized_1leftoverMode.
     """
     poly0, poly2, poly1010, poly1001, poly1, A, b, c = res
     dpoly_dC, dpoly_dA, dpoly_dB = jax.pure_callback(
@@ -433,7 +433,7 @@ def hermite_renormalized_1leftoverMode_reorderedAB_jax_bwd(shape, res, g):
     return dLdA, dLdB, dLdC
 
 
-hermite_renormalized_1leftoverMode_reorderedAB_jax.defvjp(
-    hermite_renormalized_1leftoverMode_reorderedAB_jax_fwd,
-    hermite_renormalized_1leftoverMode_reorderedAB_jax_bwd,
+hermite_renormalized_1leftoverMode_jax.defvjp(
+    hermite_renormalized_1leftoverMode_jax_fwd,
+    hermite_renormalized_1leftoverMode_jax_bwd,
 )

--- a/mrmustard/math/jax_vjps/hermite.py
+++ b/mrmustard/math/jax_vjps/hermite.py
@@ -34,7 +34,6 @@ __all__ = [
     "hermite_renormalized_1leftoverMode_reorderedAB_jax",
     "hermite_renormalized_batched_jax",
     "hermite_renormalized_binomial_jax",
-    "hermite_renormalized_diagonal_reorderedAB_batch_jax",
     "hermite_renormalized_diagonal_reorderedAB_jax",
     "hermite_renormalized_jax",
 ]
@@ -350,33 +349,6 @@ hermite_renormalized_diagonal_reorderedAB_jax.defvjp(
     hermite_renormalized_diagonal_reorderedAB_jax_fwd,
     hermite_renormalized_diagonal_reorderedAB_jax_bwd,
 )
-
-
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# hermite_renormalized_diagonal_reorderedAB_batch
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-
-# TODO: update grad_hermite_multidimensional_diagonal to handle batch dimensions and merge
-# with hermite_renormalized_diagonal_reorderedAB_jax
-@partial(jax.jit, static_argnums=(3,))
-def hermite_renormalized_diagonal_reorderedAB_batch_jax(
-    A: jnp.ndarray,
-    B: jnp.ndarray,
-    C: jnp.ndarray,
-    cutoffs: tuple[int],
-) -> jnp.ndarray:
-    r"""
-    The jax custom gradient for hermite_renormalized_diagonal_reorderedAB_batch.
-    """
-    function = partial(hermite_multidimensional_diagonal, cutoffs=tuple(cutoffs))
-    return jax.pure_callback(
-        lambda A, B, C: function(np.asarray(A), np.asarray(B), np.asarray(C))[0],
-        jax.ShapeDtypeStruct((*cutoffs, B.shape[1]), jnp.complex128),
-        A,
-        B,
-        C,
-    )
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/mrmustard/math/jax_vjps/hermite.py
+++ b/mrmustard/math/jax_vjps/hermite.py
@@ -278,15 +278,15 @@ def hermite_renormalized_diagonal_jax(
     )
 
 
-def hermite_renormalized_diagonal_jax_fwd(A, b, c, shape):
+def hermite_renormalized_diagonal_jax_fwd(A, b, c, cutoffs):
     r"""
     The jax forward pass for hermite_renormalized_diagonal.
     """
-    primal_output = hermite_renormalized_diagonal_jax(A, b, c, shape)
+    primal_output = hermite_renormalized_diagonal_jax(A, b, c, cutoffs)
     return (primal_output, (*primal_output, A, b, c))
 
 
-def hermite_renormalized_diagonal_jax_bwd(shape, res, g):
+def hermite_renormalized_diagonal_jax_bwd(cutoffs, res, g):
     r"""
     The jax backward pass for hermite_renormalized_diagonal.
     """
@@ -337,17 +337,19 @@ hermite_renormalized_diagonal_jax.defvjp(
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 
-@partial(jax.custom_vjp, nondiff_argnums=(3,))
-@partial(jax.jit, static_argnums=(3,))
+@partial(jax.custom_vjp, nondiff_argnums=(3, 4))
+@partial(jax.jit, static_argnums=(3, 4))
 def hermite_renormalized_1leftoverMode_jax(
     A: jnp.ndarray,
     B: jnp.ndarray,
     C: jnp.ndarray,
-    cutoffs: tuple[int],
+    output_cutoff: int,
+    pnr_cutoffs: tuple[int, ...],
 ) -> jnp.ndarray:
     r"""
     The jax custom gradient for hermite_renormalized_1leftoverMode.
     """
+    cutoffs = (output_cutoff + 1, *tuple(p + 1 for p in pnr_cutoffs))
     M = len(cutoffs)
     cutoff_leftoverMode = cutoffs[0]
     cutoffs_tail = tuple(cutoffs[1:])
@@ -380,15 +382,15 @@ def hermite_renormalized_1leftoverMode_jax(
     )
 
 
-def hermite_renormalized_1leftoverMode_jax_fwd(A, b, c, shape):
+def hermite_renormalized_1leftoverMode_jax_fwd(A, b, c, output_cutoff, pnr_cutoffs):
     r"""
     The jax forward pass for hermite_renormalized_reorderedAB.
     """
-    primal_output = hermite_renormalized_1leftoverMode_jax(A, b, c, shape)
+    primal_output = hermite_renormalized_1leftoverMode_jax(A, b, c, output_cutoff, pnr_cutoffs)
     return (primal_output, (*primal_output, A, b, c))
 
 
-def hermite_renormalized_1leftoverMode_jax_bwd(shape, res, g):
+def hermite_renormalized_1leftoverMode_jax_bwd(output_cutoff, pnr_cutoffs, res, g):
     r"""
     The jax backward pass for hermite_renormalized_1leftoverMode.
     """

--- a/mrmustard/math/jax_vjps/hermite.py
+++ b/mrmustard/math/jax_vjps/hermite.py
@@ -38,9 +38,9 @@ __all__ = [
     "hermite_renormalized_jax",
 ]
 
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# hermite_renormalized_unbatched
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# ~~~~~~~~~~~~~~~~~~~~
+# hermite_renormalized
+# ~~~~~~~~~~~~~~~~~~~~
 
 
 @partial(jax.custom_vjp, nondiff_argnums=(3, 4))
@@ -53,7 +53,7 @@ def hermite_renormalized_jax(
     stable: bool,
 ) -> jnp.ndarray:
     r"""
-    The jax custom gradient for hermite_renormalized_unbatched.
+    The jax custom gradient for hermite_renormalized.
     """
     if stable:
         G = jax.pure_callback(
@@ -76,7 +76,7 @@ def hermite_renormalized_jax(
 
 def hermite_renormalized_jax_fwd(A, b, c, shape, stable):
     r"""
-    The jax forward pass for hermite_renormalized_unbatched.
+    The jax forward pass for hermite_renormalized.
     """
     G = hermite_renormalized_jax(A, b, c, shape, stable)
     return (G, (G, A, b, c))
@@ -84,7 +84,7 @@ def hermite_renormalized_jax_fwd(A, b, c, shape, stable):
 
 def hermite_renormalized_jax_bwd(shape, stable, res, g):
     r"""
-    The jax backward pass for hermite_renormalized_unbatched.
+    The jax backward pass for hermite_renormalized.
     """
     G, A, b, c = res
     dLdA, dLdB, dLdC = jax.pure_callback(
@@ -141,7 +141,7 @@ def hermite_renormalized_batched_jax(
 
 def hermite_renormalized_batched_jax_fwd(A, b, c, shape, stable):
     r"""
-    The jax forward pass for hermite_renormalized_unbatched.
+    The jax forward pass for hermite_renormalized_batched.
     """
     G = hermite_renormalized_batched_jax(A, b, c, shape, stable)
     return (G, (G, A, b, c))
@@ -149,7 +149,7 @@ def hermite_renormalized_batched_jax_fwd(A, b, c, shape, stable):
 
 def hermite_renormalized_batched_jax_bwd(shape, stable, res, g):
     r"""
-    The jax backward pass for hermite_renormalized_unbatched.
+    The jax backward pass for hermite_renormalized_batched.
     """
     G, A, b, c = res
     dLdA, dLdB, dLdC = jax.pure_callback(

--- a/mrmustard/math/jax_vjps/hermite.py
+++ b/mrmustard/math/jax_vjps/hermite.py
@@ -25,12 +25,16 @@ import numpy as np
 from ..lattice import strategies
 from ..lattice.strategies.compactFock.inputValidation import (
     grad_hermite_multidimensional_diagonal,
+    hermite_multidimensional_1leftoverMode,
     hermite_multidimensional_diagonal,
+    hermite_multidimensional_diagonal_batch,
 )
 
 __all__ = [
+    "hermite_renormalized_1leftoverMode_reorderedAB_jax",
     "hermite_renormalized_batched_jax",
     "hermite_renormalized_binomial_jax",
+    "hermite_renormalized_diagonal_reorderedAB_batch_jax",
     "hermite_renormalized_diagonal_reorderedAB_jax",
     "hermite_renormalized_unbatched_jax",
 ]
@@ -331,3 +335,91 @@ hermite_renormalized_diagonal_reorderedAB_jax.defvjp(
     hermite_renormalized_diagonal_reorderedAB_jax_fwd,
     hermite_renormalized_diagonal_reorderedAB_jax_bwd,
 )
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# hermite_renormalized_diagonal_reorderedAB_batch
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+# @partial(jax.custom_vjp, nondiff_argnums=(3,))
+@partial(jax.jit, static_argnums=(3,))
+def hermite_renormalized_diagonal_reorderedAB_batch_jax(
+    A: jnp.ndarray,
+    B: jnp.ndarray,
+    C: jnp.ndarray,
+    cutoffs: tuple[int],
+) -> jnp.ndarray:
+    r"""
+    The jax custom gradient for hermite_renormalized_diagonal_reorderedAB_batch.
+    """
+    function = partial(hermite_multidimensional_diagonal_batch, cutoffs=tuple(cutoffs))
+    return jax.pure_callback(
+        lambda A, B, C: function(np.asarray(A), np.asarray(B), np.asarray(C))[0],
+        jax.ShapeDtypeStruct((*cutoffs, B.shape[1]), jnp.complex128),
+        A,
+        B,
+        C,
+    )
+
+
+def hermite_renormalized_diagonal_reorderedAB_batch_jax_fwd(A, b, c, shape):
+    r"""
+    The jax forward pass for hermite_renormalized_diagonal_reorderedAB_batch.
+    """
+
+
+def hermite_renormalized_diagonal_reorderedAB_batch_jax_bwd(shape, res, g):
+    r"""
+    The jax backward pass for hermite_renormalized_diagonal_reorderedAB_batch.
+    """
+
+
+# hermite_renormalized_diagonal_reorderedAB_batch_jax.defvjp(
+#     hermite_renormalized_diagonal_reorderedAB_batch_jax_fwd,
+#     hermite_renormalized_diagonal_reorderedAB_batch_jax_bwd,
+# )
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# hermite_renormalized_1leftoverMode_reorderedAB
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+# @partial(jax.custom_vjp, nondiff_argnums=(3,))
+@partial(jax.jit, static_argnums=(3,))
+def hermite_renormalized_1leftoverMode_reorderedAB_jax(
+    A: jnp.ndarray,
+    B: jnp.ndarray,
+    C: jnp.ndarray,
+    cutoffs: tuple[int],
+) -> jnp.ndarray:
+    r"""
+    The jax custom gradient for hermite_renormalized_1leftoverMode_reorderedAB.
+    """
+    function = partial(hermite_multidimensional_1leftoverMode, cutoffs=cutoffs)
+    return jax.pure_callback(
+        lambda A, B, C: function(np.asarray(A), np.asarray(B), np.asarray(C))[0],
+        jax.ShapeDtypeStruct((cutoffs[0], *cutoffs), jnp.complex128),
+        A,
+        B,
+        C,
+    )
+
+
+def hermite_renormalized_1leftoverMode_reorderedAB_jax_fwd(A, b, c, shape):
+    r"""
+    The jax forward pass for hermite_renormalized_1leftoverMode_reorderedAB.
+    """
+
+
+def hermite_renormalized_1leftoverMode_reorderedAB_jaxbwd(shape, res, g):
+    r"""
+    The jax backward pass for hermite_renormalized_1leftoverMode_reorderedAB.
+    """
+
+
+# hermite_renormalized_1leftoverMode_reorderedAB_jax.defvjp(
+#     hermite_renormalized_1leftoverMode_reorderedAB_jax_fwd,
+#     hermite_renormalized_1leftoverMode_reorderedAB_jaxbwd,
+# )

--- a/mrmustard/math/jax_vjps/hermite.py
+++ b/mrmustard/math/jax_vjps/hermite.py
@@ -28,7 +28,6 @@ from ..lattice.strategies.compactFock.inputValidation import (
     grad_hermite_multidimensional_diagonal,
     hermite_multidimensional_1leftoverMode,
     hermite_multidimensional_diagonal,
-    hermite_multidimensional_diagonal_batch,
 )
 
 __all__ = [
@@ -37,7 +36,7 @@ __all__ = [
     "hermite_renormalized_binomial_jax",
     "hermite_renormalized_diagonal_reorderedAB_batch_jax",
     "hermite_renormalized_diagonal_reorderedAB_jax",
-    "hermite_renormalized_unbatched_jax",
+    "hermite_renormalized_jax",
 ]
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -47,7 +46,7 @@ __all__ = [
 
 @partial(jax.custom_vjp, nondiff_argnums=(3, 4))
 @partial(jax.jit, static_argnums=(3, 4))
-def hermite_renormalized_unbatched_jax(
+def hermite_renormalized_jax(
     A: jnp.ndarray,
     b: jnp.ndarray,
     c: jnp.ndarray,
@@ -76,15 +75,15 @@ def hermite_renormalized_unbatched_jax(
     return G
 
 
-def hermite_renormalized_unbatched_jax_fwd(A, b, c, shape, stable):
+def hermite_renormalized_jax_fwd(A, b, c, shape, stable):
     r"""
     The jax forward pass for hermite_renormalized_unbatched.
     """
-    G = hermite_renormalized_unbatched_jax(A, b, c, shape, stable)
+    G = hermite_renormalized_jax(A, b, c, shape, stable)
     return (G, (G, A, b, c))
 
 
-def hermite_renormalized_unbatched_jax_bwd(shape, stable, res, g):
+def hermite_renormalized_jax_bwd(shape, stable, res, g):
     r"""
     The jax backward pass for hermite_renormalized_unbatched.
     """
@@ -103,10 +102,7 @@ def hermite_renormalized_unbatched_jax_bwd(shape, stable, res, g):
     return dLdA, dLdB, dLdC
 
 
-hermite_renormalized_unbatched_jax.defvjp(
-    hermite_renormalized_unbatched_jax_fwd,
-    hermite_renormalized_unbatched_jax_bwd,
-)
+hermite_renormalized_jax.defvjp(hermite_renormalized_jax_fwd, hermite_renormalized_jax_bwd)
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -343,7 +339,8 @@ hermite_renormalized_diagonal_reorderedAB_jax.defvjp(
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 
-# @partial(jax.custom_vjp, nondiff_argnums=(3,))
+# TODO: update grad_hermite_multidimensional_diagonal to handle batch dimensions and merge
+# with hermite_renormalized_diagonal_reorderedAB_jax
 @partial(jax.jit, static_argnums=(3,))
 def hermite_renormalized_diagonal_reorderedAB_batch_jax(
     A: jnp.ndarray,
@@ -354,7 +351,7 @@ def hermite_renormalized_diagonal_reorderedAB_batch_jax(
     r"""
     The jax custom gradient for hermite_renormalized_diagonal_reorderedAB_batch.
     """
-    function = partial(hermite_multidimensional_diagonal_batch, cutoffs=tuple(cutoffs))
+    function = partial(hermite_multidimensional_diagonal, cutoffs=tuple(cutoffs))
     return jax.pure_callback(
         lambda A, B, C: function(np.asarray(A), np.asarray(B), np.asarray(C))[0],
         jax.ShapeDtypeStruct((*cutoffs, B.shape[1]), jnp.complex128),
@@ -362,24 +359,6 @@ def hermite_renormalized_diagonal_reorderedAB_batch_jax(
         B,
         C,
     )
-
-
-def hermite_renormalized_diagonal_reorderedAB_batch_jax_fwd(A, b, c, shape):
-    r"""
-    The jax forward pass for hermite_renormalized_diagonal_reorderedAB_batch.
-    """
-
-
-def hermite_renormalized_diagonal_reorderedAB_batch_jax_bwd(shape, res, g):
-    r"""
-    The jax backward pass for hermite_renormalized_diagonal_reorderedAB_batch.
-    """
-
-
-# hermite_renormalized_diagonal_reorderedAB_batch_jax.defvjp(
-#     hermite_renormalized_diagonal_reorderedAB_batch_jax_fwd,
-#     hermite_renormalized_diagonal_reorderedAB_batch_jax_bwd,
-# )
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/mrmustard/math/lattice/strategies/compactFock/inputValidation.py
+++ b/mrmustard/math/lattice/strategies/compactFock/inputValidation.py
@@ -63,6 +63,10 @@ def hermite_multidimensional_diagonal(A, B, G0, cutoffs, rtol=1e-05, atol=1e-08)
     Validation of user input for mrmustard.math.hermite_renormalized_diagonal
     """
     input_validation(A, atol=atol, rtol=rtol)
+    if B.ndim > 2:
+        raise ValueError(
+            "B should be either unbactched or two dimensional (vector and batch dimension)"
+        )
     if A.shape[0] != B.shape[0]:
         raise ValueError("The matrix A and vector B have incompatible dimensions")
     if isinstance(cutoffs, Iterable):
@@ -136,22 +140,3 @@ def grad_hermite_multidimensional_1leftoverMode(A, B, G0, arr0, arr2, arr1010, a
     )
     arr0_dG0 = np.array(arr0 / G0).astype(np.complex128)
     return arr0_dG0, arr0_dA, arr0_dB
-
-
-def hermite_multidimensional_diagonal_batch(A, B, G0, cutoffs, rtol=1e-05, atol=1e-08):
-    """
-    Validation of user input for mrmustard.math.hermite_renormalized_diagonal_batch
-    """
-    input_validation(A, atol=atol, rtol=rtol)
-    if len(B.shape) != 2:
-        raise ValueError("B should be two dimensional (vector and batch dimension)")
-    if A.shape[0] != B.shape[0]:
-        raise ValueError("The matrix A and vector B have incompatible dimensions")
-    if isinstance(cutoffs, Iterable):
-        cutoffs = tuple(cutoffs)
-    else:
-        raise ValueError("cutoffs should be array like of length M")
-    M = len(cutoffs)
-    if A.shape[0] // 2 != M:
-        raise ValueError("The matrix A and cutoffs have incompatible dimensions")
-    return fock_representation_diagonal_amps(A, B, G0, M, cutoffs)

--- a/mrmustard/math/lattice/strategies/squeezer.py
+++ b/mrmustard/math/lattice/strategies/squeezer.py
@@ -137,7 +137,7 @@ def squeezed(cutoff: int, r: float, theta: float, dtype=np.complex128):  # pragm
         array (ComplexMatrix): matrix representing the squeezing gate.
     """
     S = np.zeros(cutoff, dtype=dtype)
-    eitheta_tanhr = np.exp(1j * theta) * np.tanh(r)
+    eitheta_tanhr = np.exp(1j * theta) * -np.tanh(r)
     S[0] = np.sqrt(1.0 / np.cosh(r))
 
     for m in range(2, cutoff, 2):

--- a/tests/test_lab/test_circuit_components.py
+++ b/tests/test_lab/test_circuit_components.py
@@ -357,6 +357,13 @@ class TestCircuitComponent:
             result2 = coh0.contract(coh1)
             assert isinstance(result2.ansatz, ArrayAnsatz)
 
+    def test_to_fock_shape_error(self):
+        state = Coherent(0, alpha=0.1 + 0.1j)
+        with pytest.raises(ValueError, match="non-zero"):
+            state.to_fock(shape=(0, 1))
+        with pytest.raises(ValueError, match="Fock shape of"):
+            state.to_fock(shape=(1, 1, 1, 1))
+
     def test_rshift_all_bargmann(self):
         vac012 = Vacuum((0, 1, 2))
         d0 = Dgate(0, alpha=0.1 + 0.1j)

--- a/tests/test_lab/test_states/test_squeezed_vacuum.py
+++ b/tests/test_lab/test_states/test_squeezed_vacuum.py
@@ -37,6 +37,34 @@ class TestSqueezedVacuum:
         assert state.name == "SqueezedVacuum"
         assert state.modes == (modes,)
 
+    def test_fock_representation(self):
+        shape = (5,)
+        sq_vac = SqueezedVacuum(0, r=1, phi=2)
+        sq_vac_fock = sq_vac.fock_array(shape)
+
+        herm_renom = math.hermite_renormalized(*sq_vac.ansatz.triple, shape=shape)
+        assert math.allclose(sq_vac_fock, herm_renom)
+
+        sq_vac_batch = SqueezedVacuum(0, r=[1, 1, 1], phi=[2, 2, 2])
+        sq_vac_batch_fock = sq_vac_batch.fock_array(shape)
+        herm_renom_batch = math.hermite_renormalized(*sq_vac_batch.ansatz.triple, shape=shape)
+        assert math.allclose(sq_vac_batch_fock, herm_renom_batch)
+
+    def test_to_fock_lin_sup(self):
+        bsgate = (SqueezedVacuum(0, 2, 3) + SqueezedVacuum(0, -2, -3)).to_fock(5)
+        assert bsgate.ansatz.batch_dims == 0
+        assert bsgate.ansatz.batch_shape == ()
+        assert bsgate.ansatz.array.shape == (5,)
+
+    @pytest.mark.parametrize("modes,r,phi", zip(modes, r, phi))
+    @pytest.mark.parametrize("batch_shape", [(), (2,), (2, 3)])
+    def test_representation(self, modes, r, phi, batch_shape):
+        r = math.broadcast_to(r, batch_shape)
+        phi = math.broadcast_to(phi, batch_shape)
+        rep = SqueezedVacuum(modes, r, phi).ansatz
+        exp = (Vacuum(modes) >> Sgate(modes, r, phi)).ansatz
+        assert rep == exp
+
     def test_trainable_parameters(self):
         state1 = SqueezedVacuum(0, 1, 1)
         state2 = SqueezedVacuum(0, 1, 1, r_trainable=True, r_bounds=(-2, 2))
@@ -50,12 +78,3 @@ class TestSqueezedVacuum:
 
         state3.parameters.phi.value = 2
         assert state3.parameters.phi.value == 2
-
-    @pytest.mark.parametrize("modes,r,phi", zip(modes, r, phi))
-    @pytest.mark.parametrize("batch_shape", [(), (2,), (2, 3)])
-    def test_representation(self, modes, r, phi, batch_shape):
-        r = math.broadcast_to(r, batch_shape)
-        phi = math.broadcast_to(phi, batch_shape)
-        rep = SqueezedVacuum(modes, r, phi).ansatz
-        exp = (Vacuum(modes) >> Sgate(modes, r, phi)).ansatz
-        assert rep == exp

--- a/tests/test_lab/test_states/test_squeezed_vacuum.py
+++ b/tests/test_lab/test_states/test_squeezed_vacuum.py
@@ -45,7 +45,7 @@ class TestSqueezedVacuum:
         herm_renom = math.hermite_renormalized(*sq_vac.ansatz.triple, shape=shape)
         assert math.allclose(sq_vac_fock, herm_renom)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Expected Fock shape"):
             sq_vac.fock_array((5, 5, 5))
 
         sq_vac_batch = SqueezedVacuum(0, r=[1, 1, 1], phi=[2, 2, 2])

--- a/tests/test_lab/test_states/test_squeezed_vacuum.py
+++ b/tests/test_lab/test_states/test_squeezed_vacuum.py
@@ -45,6 +45,9 @@ class TestSqueezedVacuum:
         herm_renom = math.hermite_renormalized(*sq_vac.ansatz.triple, shape=shape)
         assert math.allclose(sq_vac_fock, herm_renom)
 
+        with pytest.raises(ValueError):
+            sq_vac.fock_array((5, 5, 5))
+
         sq_vac_batch = SqueezedVacuum(0, r=[1, 1, 1], phi=[2, 2, 2])
         sq_vac_batch_fock = sq_vac_batch.fock_array(shape)
         herm_renom_batch = math.hermite_renormalized(*sq_vac_batch.ansatz.triple, shape=shape)

--- a/tests/test_lab/test_transformations/test_bsgate.py
+++ b/tests/test_lab/test_transformations/test_bsgate.py
@@ -84,7 +84,7 @@ class TestBSgate:
         gate_fock2 = gate.fock_array((5, 5, 5, 5), method="schwinger")  # tuple shape
         assert math.allclose(gate_fock, gate_fock2)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Expected Fock shape"):
             gate.fock_array((5, 5, 5))  # wrong shape
 
         bs_with_batch = BSgate((0, 1), math.astensor([[1, 2]]), math.astensor([[3], [4], [5]]))

--- a/tests/test_lab/test_transformations/test_dgate.py
+++ b/tests/test_lab/test_transformations/test_dgate.py
@@ -47,6 +47,9 @@ class TestDgate:
         assert math.all((state.to_fock() >> dgate).probability < 1)
         assert math.all(math.abs(dgate.fock_array(150)) < 1)
 
+        with pytest.raises(ValueError, match="Expected Fock shape"):
+            dgate.fock_array((5, 5, 5))
+
     def test_to_fock_lin_sup(self):
         dgate = (Dgate(0, 0.1) + Dgate(0, -0.1)).to_fock(150)
         assert dgate.ansatz.batch_dims == 0

--- a/tests/test_lab/test_transformations/test_sgate.py
+++ b/tests/test_lab/test_transformations/test_sgate.py
@@ -36,6 +36,25 @@ class TestSgate:
         assert gate.name == "Sgate"
         assert gate.modes == (modes,)
 
+    def test_fock_representation(self):
+        shape = (5, 5)
+        sgate = Sgate(0, r=1, phi=2)
+        sgate_fock = sgate.fock_array(shape)
+
+        herm_renom = math.hermite_renormalized(*sgate.ansatz.triple, shape=shape)
+        assert math.allclose(sgate_fock, herm_renom)
+
+        sgate_batch = Sgate(0, r=[1, 1, 1], phi=[2, 2, 2])
+        sgate_batch_fock = sgate_batch.fock_array(shape)
+        herm_renom_batch = math.hermite_renormalized(*sgate_batch.ansatz.triple, shape=shape)
+        assert math.allclose(sgate_batch_fock, herm_renom_batch)
+
+    def test_to_fock_lin_sup(self):
+        bsgate = (Sgate(0, 2, 3) + Sgate(0, -2, -3)).to_fock(5)
+        assert bsgate.ansatz.batch_dims == 0
+        assert bsgate.ansatz.batch_shape == ()
+        assert bsgate.ansatz.array.shape == (5, 5)
+
     @pytest.mark.parametrize("batch_shape", [(), (2,), (2, 3)])
     def test_representation(self, batch_shape):
         r = math.broadcast_to(0.1, batch_shape)

--- a/tests/test_lab/test_transformations/test_sgate.py
+++ b/tests/test_lab/test_transformations/test_sgate.py
@@ -44,6 +44,9 @@ class TestSgate:
         herm_renom = math.hermite_renormalized(*sgate.ansatz.triple, shape=shape)
         assert math.allclose(sgate_fock, herm_renom)
 
+        with pytest.raises(ValueError):
+            sgate.fock_array((5, 5, 5))
+
         sgate_batch = Sgate(0, r=[1, 1, 1], phi=[2, 2, 2])
         sgate_batch_fock = sgate_batch.fock_array(shape)
         herm_renom_batch = math.hermite_renormalized(*sgate_batch.ansatz.triple, shape=shape)

--- a/tests/test_lab/test_transformations/test_sgate.py
+++ b/tests/test_lab/test_transformations/test_sgate.py
@@ -44,7 +44,7 @@ class TestSgate:
         herm_renom = math.hermite_renormalized(*sgate.ansatz.triple, shape=shape)
         assert math.allclose(sgate_fock, herm_renom)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Expected Fock shape"):
             sgate.fock_array((5, 5, 5))
 
         sgate_batch = Sgate(0, r=[1, 1, 1], phi=[2, 2, 2])

--- a/tests/test_math/test_compactFock.py
+++ b/tests/test_math/test_compactFock.py
@@ -93,7 +93,7 @@ def test_compactFock_diagonal_gradients():
         assert opt.opt_history[i - 1] >= opt.opt_history[i]
 
 
-@pytest.mark.requires_backend()  # TODO: investigate the JAX tracer error here with normalize
+@pytest.mark.requires_backend()  # TODO: [sc-96431]
 def test_compactFock_1leftover_gradients():
     r"""
     Test getting Fock amplitudes and if all but the first

--- a/tests/test_math/test_compactFock.py
+++ b/tests/test_math/test_compactFock.py
@@ -97,7 +97,7 @@ def test_compactFock_diagonal_gradients():
         assert opt.opt_history[i - 1] >= opt.opt_history[i]
 
 
-@pytest.mark.requires_backend()  # TODO: [sc-96431]
+@pytest.mark.requires_backend()  # TODO: investigate and solve in 96431
 def test_compactFock_1leftover_gradients():
     r"""
     Test getting Fock amplitudes and if all but the first

--- a/tests/test_math/test_compactFock.py
+++ b/tests/test_math/test_compactFock.py
@@ -93,7 +93,7 @@ def test_compactFock_diagonal_gradients():
         assert opt.opt_history[i - 1] >= opt.opt_history[i]
 
 
-@pytest.mark.requires_backend()
+@pytest.mark.requires_backend()  # TODO: fix
 def test_compactFock_1leftover_gradients():
     r"""
     Test getting Fock amplitudes and if all but the first
@@ -104,16 +104,16 @@ def test_compactFock_1leftover_gradients():
 
     def cost_fn(G):
         n2 = 2  # number of detected photons
-        state_opt = Vacuum([0, 1]) >> G >> Att
+        state_opt = Vacuum((0, 1)) >> G >> Att
         A, B, G0 = state_opt.bargmann_triple()
         marginal = math.hermite_renormalized_1leftoverMode(
             math.conj(-A),
             math.conj(B),
             math.conj(G0),
             output_cutoff=2,
-            pnr_cutoffs=[n2 + 1],
+            pnr_cutoffs=(n2 + 1,),
         )
-        conditional_state = DM.from_fock([0], marginal[..., n2]).normalize()
+        conditional_state = DM.from_fock((0,), marginal[..., n2]).to_bargmann().normalize()
         return -gaussian.fidelity(
             *conditional_state.phase_space(0)[:2],
             *SqueezedVacuum(0, r=1).phase_space(0)[:2],

--- a/tests/test_math/test_compactFock.py
+++ b/tests/test_math/test_compactFock.py
@@ -65,7 +65,7 @@ def test_compactFock_1leftover():
     assert np.allclose(expected, G_leftover)
 
 
-@pytest.mark.requires_backend("jax")  # TODO: implement gradient of hermite_renormalized_diagonal
+@pytest.mark.requires_backend("jax")
 def test_compactFock_diagonal_gradients():
     r"""
     Test getting Fock amplitudes and gradients if all modes
@@ -93,7 +93,7 @@ def test_compactFock_diagonal_gradients():
         assert opt.opt_history[i - 1] >= opt.opt_history[i]
 
 
-@pytest.mark.requires_backend()  # TODO: implement gradient of hermite_renormalized_1leftoverMode
+@pytest.mark.requires_backend()
 def test_compactFock_1leftover_gradients():
     r"""
     Test getting Fock amplitudes and if all but the first

--- a/tests/test_math/test_compactFock.py
+++ b/tests/test_math/test_compactFock.py
@@ -65,7 +65,7 @@ def test_compactFock_1leftover():
     assert np.allclose(expected, G_leftover)
 
 
-@pytest.mark.requires_backend()  # TODO: implement gradient of hermite_renormalized_diagonal
+@pytest.mark.requires_backend("jax")  # TODO: implement gradient of hermite_renormalized_diagonal
 def test_compactFock_diagonal_gradients():
     r"""
     Test getting Fock amplitudes and gradients if all modes
@@ -82,7 +82,7 @@ def test_compactFock_diagonal_gradients():
             math.conj(-A),
             math.conj(B),
             math.conj(G0),
-            cutoffs=[n1 + 1],
+            cutoffs=(n1 + 1,),
         )
         p = probs[n1]
         return -math.real(p)

--- a/tests/test_math/test_compactFock.py
+++ b/tests/test_math/test_compactFock.py
@@ -93,7 +93,7 @@ def test_compactFock_diagonal_gradients():
         assert opt.opt_history[i - 1] >= opt.opt_history[i]
 
 
-@pytest.mark.requires_backend()  # TODO: fix
+@pytest.mark.requires_backend()  # TODO: investigate the JAX tracer error here with normalize
 def test_compactFock_1leftover_gradients():
     r"""
     Test getting Fock amplitudes and if all but the first
@@ -113,7 +113,7 @@ def test_compactFock_1leftover_gradients():
             output_cutoff=2,
             pnr_cutoffs=(n2 + 1,),
         )
-        conditional_state = DM.from_fock((0,), marginal[..., n2]).to_bargmann().normalize()
+        conditional_state = DM.from_fock((0,), marginal[..., n2]).normalize()
         return -gaussian.fidelity(
             *conditional_state.phase_space(0)[:2],
             *SqueezedVacuum(0, r=1).phase_space(0)[:2],

--- a/tests/test_math/test_lattice/test_lattice_functions.py
+++ b/tests/test_math/test_lattice/test_lattice_functions.py
@@ -77,7 +77,7 @@ def test_diagonalbatchNumba_vs_diagonalNumba(batch_size):
     # replicate the B
     b_batched = math.astensor(np.stack((b,) * batch_size, axis=1))
 
-    G_batched = math.hermite_renormalized_diagonal_batch(A, b_batched, c, cutoffs=cutoffs[:-1])
+    G_batched = math.hermite_renormalized_diagonal(A, b_batched, c, cutoffs=cutoffs[:-1])
 
     for nb in range(batch_size):
         assert np.allclose(G_ref, G_batched[:, :, :, nb])


### PR DESCRIPTION
**Context:** Follow up to the remove tensorflow PR. In this PR we port the remaining custom gradients to the JAX backend.

TODOs added: 
- sc-95226: add vjp for fast_diagonal and make use of it in `hermite_renormalized_1leftoverMode_jax`

- sc-96431: figure out tracer type error in `test_compactFock_1leftover_gradients`

**Description of the Change:** Ported all hermite renormalized and fock utils vjps from the tensorflow backend. Brought back `test_compactFock_diagonal_gradients` for the JAX backend tests. Significantly cleaned up the hermite renormalized methods in the backend. Updated `SqueezedVacuum` and `Sgate` to make use of their respective fock lattice strategies.

**Benefits:** Can do optimizations with the other hermite renorm and fock utils methods. Lots of cleanup 
