### PR TITLE
[sc-94954] Make JAX an optional dependency

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,7 +10,7 @@
 * Added a ``rich`` based repr to ``ParameterSet``.
 [(#616)](https://github.com/XanaduAI/MrMustard/pull/616)
 
-* Made `JAX` and optional dependency.
+* Made `JAX` an optional dependency.
 [(#637)](https://github.com/XanaduAI/MrMustard/pull/637)
 
 ### Bug fixes

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,6 +10,9 @@
 * Added a ``rich`` based repr to ``ParameterSet``.
 [(#616)](https://github.com/XanaduAI/MrMustard/pull/616)
 
+* Made `JAX` and optional dependency.
+[(#637)](https://github.com/XanaduAI/MrMustard/pull/637)
+
 ### Bug fixes
 
 * Fixed a bug in `OptimizerJax` that would make the optimizer think it reached a stable optimum upon repeat calls to `minimize`.

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,7 +10,7 @@
 * Added a ``rich`` based repr to ``ParameterSet``.
 [(#616)](https://github.com/XanaduAI/MrMustard/pull/616)
 
-* Made `JAX` an optional dependency.
+* Made `JAX` an optional `jax_backend` dependency.
 [(#637)](https://github.com/XanaduAI/MrMustard/pull/637)
 
 ### Bug fixes

--- a/.github/workflows/tests_numpy.yml
+++ b/.github/workflows/tests_numpy.yml
@@ -56,7 +56,7 @@ jobs:
           NUMBA_CPU_FEATURES: ""
         run: |
           set -o pipefail
-          uv run --all-extras pytest tests --backend=numpy -p no:warnings --tb=native ${{ env.UPLOAD_TIMINGS == 'true' && '--durations=0 -vv ' || '' }}| tee durations.txt
+          uv run --no-group jax_backend pytest tests --backend=numpy -p no:warnings --tb=native ${{ env.UPLOAD_TIMINGS == 'true' && '--durations=0 -vv ' || '' }}| tee durations.txt
           set +o pipefail
 
       - name: configure aws credentials

--- a/mrmustard/math/__init__.py
+++ b/mrmustard/math/__init__.py
@@ -22,7 +22,6 @@ from .backend_base import *
 from .backend_manager import BackendManager
 from .backend_numpy import *
 from .caching import *
-from .jax_vjps import *
 from .lattice import *
 from .parameter_set import *
 from .parameters import *

--- a/mrmustard/math/__init__.py
+++ b/mrmustard/math/__init__.py
@@ -16,7 +16,6 @@ r"""
 The point of entry for the backend.
 """
 
-import contextlib
 import sys
 
 from .backend_base import *
@@ -27,7 +26,9 @@ from .lattice import *
 from .parameter_set import *
 from .parameters import *
 
-with contextlib.suppress(ImportError):
+try:  # noqa: SIM105
     from .jax_vjps import *
+except ImportError:
+    pass
 
 sys.modules[__name__] = BackendManager()

--- a/mrmustard/math/__init__.py
+++ b/mrmustard/math/__init__.py
@@ -28,7 +28,7 @@ from .parameters import *
 
 try:  # noqa: SIM105
     from .jax_vjps import *
-except ImportError:
+except ImportError:  # pragma: no cover
     pass
 
 sys.modules[__name__] = BackendManager()

--- a/mrmustard/math/__init__.py
+++ b/mrmustard/math/__init__.py
@@ -16,6 +16,7 @@ r"""
 The point of entry for the backend.
 """
 
+import contextlib
 import sys
 
 from .backend_base import *
@@ -25,5 +26,8 @@ from .caching import *
 from .lattice import *
 from .parameter_set import *
 from .parameters import *
+
+with contextlib.suppress(ImportError):
+    from .jax_vjps import *
 
 sys.modules[__name__] = BackendManager()

--- a/mrmustard/math/backend_jax.py
+++ b/mrmustard/math/backend_jax.py
@@ -20,10 +20,6 @@ from collections.abc import Callable, Sequence
 from functools import partial
 from typing import Any
 
-import equinox as eqx
-import jax
-import jax.numpy as jnp
-import jax.scipy as jsp
 import numpy as np
 from platformdirs import user_cache_dir
 
@@ -31,12 +27,6 @@ from mrmustard.lab import Circuit, CircuitComponent
 from mrmustard.physics.ansatz import Ansatz
 
 from .backend_base import BackendBase
-from .jax_vjps import (
-    beamsplitter_jax,
-    displacement_jax,
-    hermite_renormalized_batched_jax,
-    hermite_renormalized_unbatched_jax,
-)
 from .lattice import strategies
 from .lattice.strategies.compactFock.inputValidation import (
     hermite_multidimensional_1leftoverMode,
@@ -45,6 +35,23 @@ from .lattice.strategies.compactFock.inputValidation import (
 )
 from .parameter_set import ParameterSet
 from .parameters import Constant, Variable
+
+try:
+    import equinox as eqx
+    import jax
+    import jax.numpy as jnp
+    import jax.scipy as jsp
+
+    from .jax_vjps import (
+        beamsplitter_jax,
+        displacement_jax,
+        hermite_renormalized_batched_jax,
+        hermite_renormalized_unbatched_jax,
+    )
+except ImportError:
+    raise ImportError(
+        "The JAX backend requires the `jax_backend` group. Please install it using `uv pip install -g jax_backend`."
+    ) from None
 
 jax.config.update("jax_enable_x64", True)
 jax.config.update("jax_compilation_cache_dir", f"{user_cache_dir('mrmustard')}/jax_cache")

--- a/mrmustard/math/backend_jax.py
+++ b/mrmustard/math/backend_jax.py
@@ -122,6 +122,9 @@ class BackendJax(BackendBase):
     def asnumpy(self, tensor: jnp.ndarray) -> np.ndarray:
         return np.array(tensor)
 
+    def BackendError(self):
+        return jax.errors.TracerArrayConversionError
+
     @partial(jax.jit, static_argnames=["shape"])
     def broadcast_to(self, array: jnp.ndarray, shape: tuple[int]) -> jnp.ndarray:
         return jnp.broadcast_to(array, shape)

--- a/mrmustard/math/backend_manager.py
+++ b/mrmustard/math/backend_manager.py
@@ -23,7 +23,6 @@ from functools import lru_cache
 from typing import Any
 
 import numpy as np
-from jax.errors import TracerArrayConversionError
 from opt_einsum import contract
 from scipy.stats import ortho_group, unitary_group
 
@@ -163,7 +162,7 @@ class BackendManager:
         Note that currently this only applies to the case where
         ``auto_shape`` is jitted  via the ``jax`` backend.
         """
-        return TracerArrayConversionError
+        return self._apply("BackendError")
 
     def change_backend(self, name: str) -> None:
         r"""

--- a/mrmustard/math/backend_numpy.py
+++ b/mrmustard/math/backend_numpy.py
@@ -88,6 +88,7 @@ class BackendNumpy(BackendBase):
         return np.array(array, ndmin=n, dtype=dtype)
 
     def BackendError(self):
+        # no numpy backend specific errors
         raise NotImplementedError
 
     def broadcast_to(self, array: np.ndarray, shape: tuple[int]) -> np.ndarray:

--- a/mrmustard/math/backend_numpy.py
+++ b/mrmustard/math/backend_numpy.py
@@ -87,6 +87,9 @@ class BackendNumpy(BackendBase):
     def atleast_nd(self, array: np.ndarray, n: int, dtype=None) -> np.ndarray:
         return np.array(array, ndmin=n, dtype=dtype)
 
+    def BackendError(self):
+        raise NotImplementedError
+
     def broadcast_to(self, array: np.ndarray, shape: tuple[int]) -> np.ndarray:
         return np.broadcast_to(array, shape)
 

--- a/mrmustard/physics/fock_utils.py
+++ b/mrmustard/physics/fock_utils.py
@@ -30,7 +30,7 @@ from mrmustard.utils.typing import Batch, Scalar, Tensor, Vector
 
 try:
     import jax
-except ImportError:
+except ImportError:  # pragma: no cover
     jax = None
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/mrmustard/physics/fock_utils.py
+++ b/mrmustard/physics/fock_utils.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 from collections.abc import Iterable, Sequence
 from functools import lru_cache
 
-import jax
 import numpy as np
 from scipy.special import comb, factorial
 
@@ -58,6 +57,8 @@ def fock_state(n: int | Sequence[int], cutoff: int | None = None) -> Tensor:
             raise ValueError("Photon numbers cannot be larger than the corresponding cutoff.")
 
     if math.backend_name == "jax":  # pragma: no cover
+        import jax  # noqa: PLC0415
+
         jax.debug.callback(check_photon_numbers, n, cutoff)
     else:
         check_photon_numbers(n, cutoff)

--- a/mrmustard/training/__init__.py
+++ b/mrmustard/training/__init__.py
@@ -20,4 +20,4 @@ Euclidean parameters and a custom Symplectic optimizer for Gaussian gates and
 states and an Orthogonal optimizer for interferometers.
 """
 
-# from .optimizer import Optimizer as Optimizer
+from .optimizer import Optimizer as Optimizer

--- a/mrmustard/training/__init__.py
+++ b/mrmustard/training/__init__.py
@@ -20,4 +20,4 @@ Euclidean parameters and a custom Symplectic optimizer for Gaussian gates and
 states and an Orthogonal optimizer for interferometers.
 """
 
-from .optimizer import Optimizer as Optimizer
+# from .optimizer import Optimizer as Optimizer

--- a/mrmustard/training/optimizer.py
+++ b/mrmustard/training/optimizer.py
@@ -20,195 +20,206 @@ from __future__ import annotations
 
 from collections.abc import Callable, Sequence
 
-import equinox as eqx
-import jax
-from optax import GradientTransformation, OptState, adamw, multi_transform
-
 from mrmustard import math, settings
 from mrmustard.lab import Circuit, CircuitComponent
 from mrmustard.math.parameters import Variable
-from mrmustard.training.parameter_update import (
-    update_orthogonal,
-    update_symplectic,
-    update_unitary,
-)
 from mrmustard.training.progress_bar import ProgressBar
 from mrmustard.utils.logger import create_logger
 
+try:
+    import equinox as eqx
+    import jax
+    from optax import GradientTransformation, OptState, adamw, multi_transform
 
-class Optimizer:
-    r"""
-    A Jax based optimizer for any parametrized object.
+    from mrmustard.training.parameter_update import (
+        update_orthogonal,
+        update_symplectic,
+        update_unitary,
+    )
 
-    Args:
-        euclidean_lr: The euclidean learning rate of the optimizer.
-        symplectic_lr: The symplectic learning rate of the optimizer.
-        unitary_lr: The unitary learning rate of the optimizer.
-        orthogonal_lr: The orthogonal learning rate of the optimizer.
-        stable_threshold: The threshold for the loss to be considered stable.
+    class Optimizer:
+        r"""
+        A Jax based optimizer for any parametrized object.
 
-    Raises:
-        ValueError: If the set backend is not "jax".
-    """
+        Args:
+            euclidean_lr: The euclidean learning rate of the optimizer.
+            symplectic_lr: The symplectic learning rate of the optimizer.
+            unitary_lr: The unitary learning rate of the optimizer.
+            orthogonal_lr: The orthogonal learning rate of the optimizer.
+            stable_threshold: The threshold for the loss to be considered stable.
 
-    def __init__(
-        self,
-        euclidean_lr: float = 0.001,
-        symplectic_lr: float = 0.001,
-        unitary_lr: float = 0.001,
-        orthogonal_lr: float = 0.1,
-        stable_threshold: float = 1e-6,
-    ):
-        if math.backend_name != "jax":
-            raise ValueError(
-                "Optimizer only supports the Jax backend. Please set the backend to Jax using `math.change_backend('jax')`.",
+        Raises:
+            ValueError: If the set backend is not "jax".
+        """
+
+        def __init__(
+            self,
+            euclidean_lr: float = 0.001,
+            symplectic_lr: float = 0.001,
+            unitary_lr: float = 0.001,
+            orthogonal_lr: float = 0.1,
+            stable_threshold: float = 1e-6,
+        ):
+            if math.backend_name != "jax":
+                raise ValueError(
+                    "Optimizer only supports the Jax backend. Please set the backend to Jax using `math.change_backend('jax')`.",
+                )
+            self.euclidean_lr = euclidean_lr
+            self.symplectic_lr = symplectic_lr
+            self.unitary_lr = unitary_lr
+            self.orthogonal_lr = orthogonal_lr
+            self.opt_history = [0]
+            self.log = create_logger(__name__)
+            self.stable_threshold = stable_threshold
+
+        @eqx.filter_jit
+        def make_step(
+            self,
+            optim: GradientTransformation,
+            cost_fn: Callable,
+            by_optimizing: Sequence[Variable | CircuitComponent | Circuit],
+            opt_state: OptState,
+        ) -> tuple[Sequence[Variable | CircuitComponent | Circuit], OptState, float]:
+            r"""
+            Make a step of the optimization.
+
+            Args:
+                optim: The optimizer to use.
+                cost_fn: The cost function to minimize.
+                by_optimizing: The items to optimize.
+                opt_state: The current state of the optimizer.
+
+            Returns:
+                The updated by_optimizing, the updated optimizer state, and the loss value.
+            """
+            loss_value, grads = jax.value_and_grad(
+                cost_fn, argnums=tuple(range(len(by_optimizing)))
+            )(
+                *by_optimizing,
             )
-        self.euclidean_lr = euclidean_lr
-        self.symplectic_lr = symplectic_lr
-        self.unitary_lr = unitary_lr
-        self.orthogonal_lr = orthogonal_lr
-        self.opt_history = [0]
-        self.log = create_logger(__name__)
-        self.stable_threshold = stable_threshold
+            updates, opt_state = optim.update(grads, opt_state, by_optimizing)
+            by_optimizing = eqx.apply_updates(by_optimizing, updates)
+            return by_optimizing, opt_state, loss_value
 
-    @eqx.filter_jit
-    def make_step(
-        self,
-        optim: GradientTransformation,
-        cost_fn: Callable,
-        by_optimizing: Sequence[Variable | CircuitComponent | Circuit],
-        opt_state: OptState,
-    ) -> tuple[Sequence[Variable | CircuitComponent | Circuit], OptState, float]:
-        r"""
-        Make a step of the optimization.
+        def minimize(
+            self,
+            cost_fn: Callable,
+            by_optimizing: Sequence[Variable | CircuitComponent | Circuit],
+            max_steps: int = 1000,
+            euclidean_optim: type[GradientTransformation] | None = None,
+        ) -> Sequence[Variable | CircuitComponent | Circuit]:
+            r"""
+            Minimizes the given cost function by optimizing ``Variable``s either on their own or within a ``CircuitComponent`` / ``Circuit``.
 
-        Args:
-            optim: The optimizer to use.
-            cost_fn: The cost function to minimize.
-            by_optimizing: The items to optimize.
-            opt_state: The current state of the optimizer.
+            Args:
+                cost_fn: A function that will be executed in a differentiable context in
+                    order to compute gradients as needed.
+                by_optimizing: A list of elements that contain the parameters to optimize.
+                max_steps: The minimization keeps going until the loss is stable or max_steps are
+                    reached (if ``max_steps=0`` it will only stop when the loss is stable).
+                euclidean_optim: The type of euclidean optimizer to use. If ``None``, the default optimizer used is ``optax.adamw``.
 
-        Returns:
-            The updated by_optimizing, the updated optimizer state, and the loss value.
-        """
-        loss_value, grads = jax.value_and_grad(cost_fn, argnums=tuple(range(len(by_optimizing))))(
-            *by_optimizing,
-        )
-        updates, opt_state = optim.update(grads, opt_state, by_optimizing)
-        by_optimizing = eqx.apply_updates(by_optimizing, updates)
-        return by_optimizing, opt_state, loss_value
-
-    def minimize(
-        self,
-        cost_fn: Callable,
-        by_optimizing: Sequence[Variable | CircuitComponent | Circuit],
-        max_steps: int = 1000,
-        euclidean_optim: type[GradientTransformation] | None = None,
-    ) -> Sequence[Variable | CircuitComponent | Circuit]:
-        r"""
-        Minimizes the given cost function by optimizing ``Variable``s either on their own or within a ``CircuitComponent`` / ``Circuit``.
-
-        Args:
-            cost_fn: A function that will be executed in a differentiable context in
-                order to compute gradients as needed.
-            by_optimizing: A list of elements that contain the parameters to optimize.
-            max_steps: The minimization keeps going until the loss is stable or max_steps are
-                reached (if ``max_steps=0`` it will only stop when the loss is stable).
-            euclidean_optim: The type of euclidean optimizer to use. If ``None``, the default optimizer used is ``optax.adamw``.
-
-        Returns:
-            The list of elements optimized.
-        """
-        self.opt_history = [0]
-        if settings.PROGRESSBAR:
-            progress_bar = ProgressBar(max_steps)
-            with progress_bar:
+            Returns:
+                The list of elements optimized.
+            """
+            self.opt_history = [0]
+            if settings.PROGRESSBAR:
+                progress_bar = ProgressBar(max_steps)
+                with progress_bar:
+                    by_optimizing = self._optimization_loop(
+                        cost_fn,
+                        by_optimizing,
+                        max_steps=max_steps,
+                        progress_bar=progress_bar,
+                        euclidean_optim=euclidean_optim,
+                    )
+            else:
                 by_optimizing = self._optimization_loop(
                     cost_fn,
                     by_optimizing,
                     max_steps=max_steps,
-                    progress_bar=progress_bar,
                     euclidean_optim=euclidean_optim,
                 )
-        else:
-            by_optimizing = self._optimization_loop(
-                cost_fn,
-                by_optimizing,
-                max_steps=max_steps,
-                euclidean_optim=euclidean_optim,
+            return by_optimizing
+
+        def should_stop(self, max_steps: int) -> bool:
+            r"""
+            Returns a boolean indicating whether the optimization should stop.
+            An optimization should stop either because the loss is stable or because
+            the maximum number of steps is reached.
+
+            Args:
+                max_steps: The maximum number of steps to run.
+
+            Returns:
+                A boolean indicating whether the optimization should stop.
+            """
+            if max_steps != 0 and len(self.opt_history) > max_steps:
+                return True
+            # if cost varies less than threshold over 20 steps
+            if (
+                len(self.opt_history) > 20
+                and sum(abs(self.opt_history[-i - 1] - self.opt_history[-i]) for i in range(1, 20))
+                < self.stable_threshold
+            ):
+                self.log.info("Loss looks stable, stopping here.")
+                return True
+            return False
+
+        def _optimization_loop(
+            self,
+            cost_fn: Callable,
+            by_optimizing: Sequence[Variable | CircuitComponent | Circuit],
+            max_steps: int,
+            progress_bar: ProgressBar | None = None,
+            euclidean_optim: type[GradientTransformation] | None = None,
+        ) -> Sequence[Variable | CircuitComponent | Circuit]:
+            r"""
+            The core optimization loop.
+            """
+            by_optimizing = tuple(by_optimizing)
+            euclidean_optim = (
+                euclidean_optim(learning_rate=self.euclidean_lr)
+                if euclidean_optim is not None
+                else adamw(learning_rate=self.euclidean_lr)
             )
-        return by_optimizing
 
-    def should_stop(self, max_steps: int) -> bool:
-        r"""
-        Returns a boolean indicating whether the optimization should stop.
-        An optimization should stop either because the loss is stable or because
-        the maximum number of steps is reached.
-
-        Args:
-            max_steps: The maximum number of steps to run.
-
-        Returns:
-            A boolean indicating whether the optimization should stop.
-        """
-        if max_steps != 0 and len(self.opt_history) > max_steps:
-            return True
-        # if cost varies less than threshold over 20 steps
-        if (
-            len(self.opt_history) > 20
-            and sum(abs(self.opt_history[-i - 1] - self.opt_history[-i]) for i in range(1, 20))
-            < self.stable_threshold
-        ):
-            self.log.info("Loss looks stable, stopping here.")
-            return True
-        return False
-
-    def _optimization_loop(
-        self,
-        cost_fn: Callable,
-        by_optimizing: Sequence[Variable | CircuitComponent | Circuit],
-        max_steps: int,
-        progress_bar: ProgressBar | None = None,
-        euclidean_optim: type[GradientTransformation] | None = None,
-    ) -> Sequence[Variable | CircuitComponent | Circuit]:
-        r"""
-        The core optimization loop.
-        """
-        by_optimizing = tuple(by_optimizing)
-        euclidean_optim = (
-            euclidean_optim(learning_rate=self.euclidean_lr)
-            if euclidean_optim is not None
-            else adamw(learning_rate=self.euclidean_lr)
-        )
-
-        labels_pytree = jax.tree_util.tree_map(
-            lambda node: str(node.update_fn),
-            by_optimizing,
-            is_leaf=lambda n: isinstance(n, Variable),
-        )
-
-        optim = multi_transform(
-            {
-                "update_euclidean": euclidean_optim,
-                "update_unitary": update_unitary(self.unitary_lr),
-                "update_symplectic": update_symplectic(self.symplectic_lr),
-                "update_orthogonal": update_orthogonal(self.orthogonal_lr),
-            },
-            labels_pytree,
-        )
-
-        opt_state = optim.init(by_optimizing)
-
-        # optimize
-        while not self.should_stop(max_steps):
-            by_optimizing, opt_state, loss_value = self.make_step(
-                optim,
-                cost_fn,
+            labels_pytree = jax.tree_util.tree_map(
+                lambda node: str(node.update_fn),
                 by_optimizing,
-                opt_state,
+                is_leaf=lambda n: isinstance(n, Variable),
             )
-            self.opt_history.append(loss_value)
-            if progress_bar is not None:
-                progress_bar.step(math.asnumpy(loss_value))
 
-        return by_optimizing
+            optim = multi_transform(
+                {
+                    "update_euclidean": euclidean_optim,
+                    "update_unitary": update_unitary(self.unitary_lr),
+                    "update_symplectic": update_symplectic(self.symplectic_lr),
+                    "update_orthogonal": update_orthogonal(self.orthogonal_lr),
+                },
+                labels_pytree,
+            )
+
+            opt_state = optim.init(by_optimizing)
+
+            # optimize
+            while not self.should_stop(max_steps):
+                by_optimizing, opt_state, loss_value = self.make_step(
+                    optim,
+                    cost_fn,
+                    by_optimizing,
+                    opt_state,
+                )
+                self.opt_history.append(loss_value)
+                if progress_bar is not None:
+                    progress_bar.step(math.asnumpy(loss_value))
+
+            return by_optimizing
+
+except ImportError:
+
+    class Optimizer:  # pragma: no cover
+        def __init__(self, *args, **kwargs):
+            raise ImportError(
+                "Optimizer only supports the Jax backend. Please install the `jax_backend` group using `uv pip install -g jax_backend` and set the backend to Jax using `math.change_backend('jax')`."
+            )

--- a/mrmustard/training/optimizer.py
+++ b/mrmustard/training/optimizer.py
@@ -37,189 +37,185 @@ try:
         update_unitary,
     )
 
-    class Optimizer:
+except ImportError:
+    raise ImportError(
+        "Optimizer only supports the Jax backend. Please install the `jax_backend` group using `uv pip install -g jax_backend` and set the backend to Jax using `math.change_backend('jax')`."
+    ) from None
+
+
+class Optimizer:
+    r"""
+    A Jax based optimizer for any parametrized object.
+
+    Args:
+        euclidean_lr: The euclidean learning rate of the optimizer.
+        symplectic_lr: The symplectic learning rate of the optimizer.
+        unitary_lr: The unitary learning rate of the optimizer.
+        orthogonal_lr: The orthogonal learning rate of the optimizer.
+        stable_threshold: The threshold for the loss to be considered stable.
+
+    Raises:
+        ValueError: If the set backend is not "jax".
+    """
+
+    def __init__(
+        self,
+        euclidean_lr: float = 0.001,
+        symplectic_lr: float = 0.001,
+        unitary_lr: float = 0.001,
+        orthogonal_lr: float = 0.1,
+        stable_threshold: float = 1e-6,
+    ):
+        if math.backend_name != "jax":
+            raise ValueError(
+                "Optimizer only supports the Jax backend. Please set the backend to Jax using `math.change_backend('jax')`.",
+            )
+        self.euclidean_lr = euclidean_lr
+        self.symplectic_lr = symplectic_lr
+        self.unitary_lr = unitary_lr
+        self.orthogonal_lr = orthogonal_lr
+        self.opt_history = [0]
+        self.log = create_logger(__name__)
+        self.stable_threshold = stable_threshold
+
+    @eqx.filter_jit
+    def make_step(
+        self,
+        optim: GradientTransformation,
+        cost_fn: Callable,
+        by_optimizing: Sequence[Variable | CircuitComponent | Circuit],
+        opt_state: OptState,
+    ) -> tuple[Sequence[Variable | CircuitComponent | Circuit], OptState, float]:
         r"""
-        A Jax based optimizer for any parametrized object.
+        Make a step of the optimization.
 
         Args:
-            euclidean_lr: The euclidean learning rate of the optimizer.
-            symplectic_lr: The symplectic learning rate of the optimizer.
-            unitary_lr: The unitary learning rate of the optimizer.
-            orthogonal_lr: The orthogonal learning rate of the optimizer.
-            stable_threshold: The threshold for the loss to be considered stable.
+            optim: The optimizer to use.
+            cost_fn: The cost function to minimize.
+            by_optimizing: The items to optimize.
+            opt_state: The current state of the optimizer.
 
-        Raises:
-            ValueError: If the set backend is not "jax".
+        Returns:
+            The updated by_optimizing, the updated optimizer state, and the loss value.
         """
+        loss_value, grads = jax.value_and_grad(cost_fn, argnums=tuple(range(len(by_optimizing))))(
+            *by_optimizing,
+        )
+        updates, opt_state = optim.update(grads, opt_state, by_optimizing)
+        by_optimizing = eqx.apply_updates(by_optimizing, updates)
+        return by_optimizing, opt_state, loss_value
 
-        def __init__(
-            self,
-            euclidean_lr: float = 0.001,
-            symplectic_lr: float = 0.001,
-            unitary_lr: float = 0.001,
-            orthogonal_lr: float = 0.1,
-            stable_threshold: float = 1e-6,
-        ):
-            if math.backend_name != "jax":
-                raise ValueError(
-                    "Optimizer only supports the Jax backend. Please set the backend to Jax using `math.change_backend('jax')`.",
-                )
-            self.euclidean_lr = euclidean_lr
-            self.symplectic_lr = symplectic_lr
-            self.unitary_lr = unitary_lr
-            self.orthogonal_lr = orthogonal_lr
-            self.opt_history = [0]
-            self.log = create_logger(__name__)
-            self.stable_threshold = stable_threshold
+    def minimize(
+        self,
+        cost_fn: Callable,
+        by_optimizing: Sequence[Variable | CircuitComponent | Circuit],
+        max_steps: int = 1000,
+        euclidean_optim: type[GradientTransformation] | None = None,
+    ) -> Sequence[Variable | CircuitComponent | Circuit]:
+        r"""
+        Minimizes the given cost function by optimizing ``Variable``s either on their own or within a ``CircuitComponent`` / ``Circuit``.
 
-        @eqx.filter_jit
-        def make_step(
-            self,
-            optim: GradientTransformation,
-            cost_fn: Callable,
-            by_optimizing: Sequence[Variable | CircuitComponent | Circuit],
-            opt_state: OptState,
-        ) -> tuple[Sequence[Variable | CircuitComponent | Circuit], OptState, float]:
-            r"""
-            Make a step of the optimization.
+        Args:
+            cost_fn: A function that will be executed in a differentiable context in
+                order to compute gradients as needed.
+            by_optimizing: A list of elements that contain the parameters to optimize.
+            max_steps: The minimization keeps going until the loss is stable or max_steps are
+                reached (if ``max_steps=0`` it will only stop when the loss is stable).
+            euclidean_optim: The type of euclidean optimizer to use. If ``None``, the default optimizer used is ``optax.adamw``.
 
-            Args:
-                optim: The optimizer to use.
-                cost_fn: The cost function to minimize.
-                by_optimizing: The items to optimize.
-                opt_state: The current state of the optimizer.
-
-            Returns:
-                The updated by_optimizing, the updated optimizer state, and the loss value.
-            """
-            loss_value, grads = jax.value_and_grad(
-                cost_fn, argnums=tuple(range(len(by_optimizing)))
-            )(
-                *by_optimizing,
-            )
-            updates, opt_state = optim.update(grads, opt_state, by_optimizing)
-            by_optimizing = eqx.apply_updates(by_optimizing, updates)
-            return by_optimizing, opt_state, loss_value
-
-        def minimize(
-            self,
-            cost_fn: Callable,
-            by_optimizing: Sequence[Variable | CircuitComponent | Circuit],
-            max_steps: int = 1000,
-            euclidean_optim: type[GradientTransformation] | None = None,
-        ) -> Sequence[Variable | CircuitComponent | Circuit]:
-            r"""
-            Minimizes the given cost function by optimizing ``Variable``s either on their own or within a ``CircuitComponent`` / ``Circuit``.
-
-            Args:
-                cost_fn: A function that will be executed in a differentiable context in
-                    order to compute gradients as needed.
-                by_optimizing: A list of elements that contain the parameters to optimize.
-                max_steps: The minimization keeps going until the loss is stable or max_steps are
-                    reached (if ``max_steps=0`` it will only stop when the loss is stable).
-                euclidean_optim: The type of euclidean optimizer to use. If ``None``, the default optimizer used is ``optax.adamw``.
-
-            Returns:
-                The list of elements optimized.
-            """
-            self.opt_history = [0]
-            if settings.PROGRESSBAR:
-                progress_bar = ProgressBar(max_steps)
-                with progress_bar:
-                    by_optimizing = self._optimization_loop(
-                        cost_fn,
-                        by_optimizing,
-                        max_steps=max_steps,
-                        progress_bar=progress_bar,
-                        euclidean_optim=euclidean_optim,
-                    )
-            else:
+        Returns:
+            The list of elements optimized.
+        """
+        self.opt_history = [0]
+        if settings.PROGRESSBAR:
+            progress_bar = ProgressBar(max_steps)
+            with progress_bar:
                 by_optimizing = self._optimization_loop(
                     cost_fn,
                     by_optimizing,
                     max_steps=max_steps,
+                    progress_bar=progress_bar,
                     euclidean_optim=euclidean_optim,
                 )
-            return by_optimizing
-
-        def should_stop(self, max_steps: int) -> bool:
-            r"""
-            Returns a boolean indicating whether the optimization should stop.
-            An optimization should stop either because the loss is stable or because
-            the maximum number of steps is reached.
-
-            Args:
-                max_steps: The maximum number of steps to run.
-
-            Returns:
-                A boolean indicating whether the optimization should stop.
-            """
-            if max_steps != 0 and len(self.opt_history) > max_steps:
-                return True
-            # if cost varies less than threshold over 20 steps
-            if (
-                len(self.opt_history) > 20
-                and sum(abs(self.opt_history[-i - 1] - self.opt_history[-i]) for i in range(1, 20))
-                < self.stable_threshold
-            ):
-                self.log.info("Loss looks stable, stopping here.")
-                return True
-            return False
-
-        def _optimization_loop(
-            self,
-            cost_fn: Callable,
-            by_optimizing: Sequence[Variable | CircuitComponent | Circuit],
-            max_steps: int,
-            progress_bar: ProgressBar | None = None,
-            euclidean_optim: type[GradientTransformation] | None = None,
-        ) -> Sequence[Variable | CircuitComponent | Circuit]:
-            r"""
-            The core optimization loop.
-            """
-            by_optimizing = tuple(by_optimizing)
-            euclidean_optim = (
-                euclidean_optim(learning_rate=self.euclidean_lr)
-                if euclidean_optim is not None
-                else adamw(learning_rate=self.euclidean_lr)
-            )
-
-            labels_pytree = jax.tree_util.tree_map(
-                lambda node: str(node.update_fn),
+        else:
+            by_optimizing = self._optimization_loop(
+                cost_fn,
                 by_optimizing,
-                is_leaf=lambda n: isinstance(n, Variable),
+                max_steps=max_steps,
+                euclidean_optim=euclidean_optim,
             )
+        return by_optimizing
 
-            optim = multi_transform(
-                {
-                    "update_euclidean": euclidean_optim,
-                    "update_unitary": update_unitary(self.unitary_lr),
-                    "update_symplectic": update_symplectic(self.symplectic_lr),
-                    "update_orthogonal": update_orthogonal(self.orthogonal_lr),
-                },
-                labels_pytree,
+    def should_stop(self, max_steps: int) -> bool:
+        r"""
+        Returns a boolean indicating whether the optimization should stop.
+        An optimization should stop either because the loss is stable or because
+        the maximum number of steps is reached.
+
+        Args:
+            max_steps: The maximum number of steps to run.
+
+        Returns:
+            A boolean indicating whether the optimization should stop.
+        """
+        if max_steps != 0 and len(self.opt_history) > max_steps:
+            return True
+        # if cost varies less than threshold over 20 steps
+        if (
+            len(self.opt_history) > 20
+            and sum(abs(self.opt_history[-i - 1] - self.opt_history[-i]) for i in range(1, 20))
+            < self.stable_threshold
+        ):
+            self.log.info("Loss looks stable, stopping here.")
+            return True
+        return False
+
+    def _optimization_loop(
+        self,
+        cost_fn: Callable,
+        by_optimizing: Sequence[Variable | CircuitComponent | Circuit],
+        max_steps: int,
+        progress_bar: ProgressBar | None = None,
+        euclidean_optim: type[GradientTransformation] | None = None,
+    ) -> Sequence[Variable | CircuitComponent | Circuit]:
+        r"""
+        The core optimization loop.
+        """
+        by_optimizing = tuple(by_optimizing)
+        euclidean_optim = (
+            euclidean_optim(learning_rate=self.euclidean_lr)
+            if euclidean_optim is not None
+            else adamw(learning_rate=self.euclidean_lr)
+        )
+
+        labels_pytree = jax.tree_util.tree_map(
+            lambda node: str(node.update_fn),
+            by_optimizing,
+            is_leaf=lambda n: isinstance(n, Variable),
+        )
+
+        optim = multi_transform(
+            {
+                "update_euclidean": euclidean_optim,
+                "update_unitary": update_unitary(self.unitary_lr),
+                "update_symplectic": update_symplectic(self.symplectic_lr),
+                "update_orthogonal": update_orthogonal(self.orthogonal_lr),
+            },
+            labels_pytree,
+        )
+
+        opt_state = optim.init(by_optimizing)
+
+        # optimize
+        while not self.should_stop(max_steps):
+            by_optimizing, opt_state, loss_value = self.make_step(
+                optim,
+                cost_fn,
+                by_optimizing,
+                opt_state,
             )
+            self.opt_history.append(loss_value)
+            if progress_bar is not None:
+                progress_bar.step(math.asnumpy(loss_value))
 
-            opt_state = optim.init(by_optimizing)
-
-            # optimize
-            while not self.should_stop(max_steps):
-                by_optimizing, opt_state, loss_value = self.make_step(
-                    optim,
-                    cost_fn,
-                    by_optimizing,
-                    opt_state,
-                )
-                self.opt_history.append(loss_value)
-                if progress_bar is not None:
-                    progress_bar.step(math.asnumpy(loss_value))
-
-            return by_optimizing
-
-except ImportError:
-
-    class Optimizer:  # pragma: no cover
-        def __init__(self, *args, **kwargs):
-            raise ImportError(
-                "Optimizer only supports the Jax backend. Please install the `jax_backend` group using `uv pip install -g jax_backend` and set the backend to Jax using `math.change_backend('jax')`."
-            )
+        return by_optimizing

--- a/mrmustard/training/optimizer.py
+++ b/mrmustard/training/optimizer.py
@@ -35,8 +35,6 @@ from mrmustard.training.parameter_update import (
 from mrmustard.training.progress_bar import ProgressBar
 from mrmustard.utils.logger import create_logger
 
-__all__ = ["Optimizer"]
-
 
 class Optimizer:
     r"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-jax = [
+jax_backend = [
     "equinox>=0.11.10",
     "jax>=0.5.1,<0.6.0",
     "optax>=0.2.4,<0.3",
@@ -57,8 +57,10 @@ jax = [
 
 [dependency-groups]
 dev = [
+    "equinox>=0.11.10",
     "hypothesis==6.31.6",
-    "jax",
+    "jax>=0.5.1,<0.6.0",
+    "optax>=0.2.4,<0.3",    
     "pre-commit==3.7.1",
     "pytest-cov==3.0.0",
     "pytest==8.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ classifiers = [
 ]
 requires-python = ">=3.10,<3.13"
 dependencies = [
-    "equinox>=0.11.10",
     "grpcio == 1.60.0",
     "importlib-resources>=6.5.2,<7",
     "ipython >=8.18.1",
@@ -40,13 +39,19 @@ dependencies = [
     "networkx >=3.1, <4",
     "numba >=0.59, <1",
     "numpy >=2.0.0, <3",
-    "optax>=0.2.4,<0.3",
+    "opt_einsum>=3.4.0,<4",
     "platformdirs >=2.2.0",
     "plotly >=5.20.0, <6",
     "rich >=13.9.0, <14",
     "scipy >=1.8.0, <2",
     "semantic-version >=2.10.0, <3",
     "thewalrus >=0.19.0,<1",
+]
+
+[project.optional-dependencies]
+jax = [
+    "equinox>=0.11.10",
+    "optax>=0.2.4,<0.3",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,10 +57,7 @@ jax_backend = [
 
 [dependency-groups]
 dev = [
-    "equinox>=0.11.10",
-    "hypothesis==6.31.6",
-    "jax>=0.5.1,<0.6.0",
-    "optax>=0.2.4,<0.3",    
+    "hypothesis==6.31.6",   
     "pre-commit==3.7.1",
     "pytest-cov==3.0.0",
     "pytest==8.0",
@@ -80,6 +77,11 @@ doc = [
 interactive = [
     "ipykernel >=6.21.2, <7.0.0",
     "ipywidgets >=8.0.4, <9.0.0"
+]
+jax_backend = [
+    "equinox>=0.11.10",
+    "jax>=0.5.1,<0.6.0",
+    "optax>=0.2.4,<0.3",
 ]
 
 [tool.coverage.run]
@@ -179,3 +181,6 @@ filterwarnings = "ignore::DeprecationWarning"
 
 [tool.setuptools.packages.find]
 where = ["."]
+
+[tool.uv]
+default-groups = ["dev", "jax_backend"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,12 +51,14 @@ dependencies = [
 [project.optional-dependencies]
 jax = [
     "equinox>=0.11.10",
+    "jax>=0.5.1,<0.6.0",
     "optax>=0.2.4,<0.3",
 ]
 
 [dependency-groups]
 dev = [
     "hypothesis==6.31.6",
+    "jax",
     "pre-commit==3.7.1",
     "pytest-cov==3.0.0",
     "pytest==8.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ jax_backend = [
 
 [dependency-groups]
 dev = [
-    "hypothesis==6.31.6",   
+    "hypothesis==6.31.6",
     "pre-commit==3.7.1",
     "pytest-cov==3.0.0",
     "pytest==8.0",

--- a/tests/test_math/test_backend_manager.py
+++ b/tests/test_math/test_backend_manager.py
@@ -24,6 +24,13 @@ from scipy.special import loggamma as scipy_loggamma
 
 from mrmustard import math, settings
 
+try:
+    import jax.numpy as jnp
+    from jax.errors import TracerArrayConversionError
+except ImportError:
+    jnp = None
+    TracerArrayConversionError = None
+
 
 class TestBackendManager:
     r"""
@@ -47,8 +54,6 @@ class TestBackendManager:
         r"""
         Tests the ``BackendError`` property.
         """
-        from jax.errors import TracerArrayConversionError  # noqa: PLC0415
-
         assert math.BackendError is TracerArrayConversionError
 
     def test_get_backend(self):
@@ -175,8 +180,6 @@ class TestBackendManager:
         if math.backend_name == "numpy":
             assert math.allclose(res, arr.astype(dtype or np.float64))
         elif math.backend_name == "jax":
-            import jax.numpy as jnp  # noqa: PLC0415
-
             exp = jnp.array(arr, dtype=dtype or jnp.float64)
             assert math.allclose(res, exp)
 

--- a/tests/test_math/test_backend_manager.py
+++ b/tests/test_math/test_backend_manager.py
@@ -61,7 +61,7 @@ class TestBackendManager:
         Tests the ``get_backend`` method.
         """
         assert math.get_backend("numpy").name == "numpy"
-        with contextlib.suppress(ModuleNotFoundError):
+        with contextlib.suppress(ImportError):
             assert math.get_backend("jax").name == "jax"
 
     def test_einsum(self):

--- a/tests/test_math/test_backend_manager.py
+++ b/tests/test_math/test_backend_manager.py
@@ -16,8 +16,6 @@
 Unit tests for the :class:`BackendManager`.
 """
 
-import contextlib
-
 import numpy as np
 import pytest
 from scipy.special import loggamma as scipy_loggamma
@@ -56,15 +54,32 @@ class TestBackendManager:
         """
         assert math.BackendError is TracerArrayConversionError
 
-    def test_get_backend(self):
+    @pytest.mark.requires_backend("jax")
+    def test_get_backend_jax(self):
         r"""
-        Tests the ``get_backend`` method.
+        Tests the ``get_backend`` method for the jax backend.
+        """
+        assert math.get_backend("jax").name == "jax"
+
+    @pytest.mark.requires_backend("numpy")
+    def test_get_backend_numpy(self):
+        r"""
+        Tests the ``get_backend`` method for the numpy backend.
         """
         assert math.get_backend("numpy").name == "numpy"
-        with contextlib.suppress(ImportError):
-            assert math.get_backend("jax").name == "jax"
 
-    def test_einsum(self):
+    @pytest.mark.requires_backend("jax")
+    def test_einsum_jax(self):
+        r"""
+        Tests the ``einsum`` method for the jax backend.
+        """
+        ar = math.astensor([[1, 2], [3, 4]])
+        res = math.astensor([[7, 10], [15, 22]])
+
+        assert math.allclose(math.einsum("ij,jk->ik", ar, ar, backend="jax"), res)
+
+    @pytest.mark.requires_backend("numpy")
+    def test_einsum_numpy(self):
         r"""
         Tests the ``einsum`` method.
         """
@@ -72,8 +87,6 @@ class TestBackendManager:
         res = math.astensor([[7, 10], [15, 22]])
 
         assert math.allclose(math.einsum("ij,jk->ik", ar, ar), res)
-        with contextlib.suppress(ModuleNotFoundError):
-            assert math.allclose(math.einsum("ij,jk->ik", ar, ar, backend="jax"), res)
 
     def test_error(self):
         r"""

--- a/tests/test_math/test_compactFock.py
+++ b/tests/test_math/test_compactFock.py
@@ -9,7 +9,11 @@ from mrmustard import math
 from mrmustard.lab import DM, Ggate, SqueezedVacuum, Vacuum
 from mrmustard.lab.transformations.attenuator import Attenuator
 from mrmustard.physics import gaussian
-from mrmustard.training import Optimizer
+
+try:
+    from mrmustard.training import Optimizer
+except ImportError:
+    Optimizer = None
 
 
 def test_compactFock_diagonal():

--- a/tests/test_math/test_compactFock.py
+++ b/tests/test_math/test_compactFock.py
@@ -9,7 +9,6 @@ from mrmustard import math
 from mrmustard.lab import DM, Ggate, SqueezedVacuum, Vacuum
 from mrmustard.lab.transformations.attenuator import Attenuator
 from mrmustard.physics import gaussian
-from mrmustard.training import Optimizer
 
 
 def test_compactFock_diagonal():
@@ -71,6 +70,8 @@ def test_compactFock_diagonal_gradients():
     Test getting Fock amplitudes and gradients if all modes
     are detected (math.hermite_renormalized_diagonal).
     """
+    from mrmustard.training import Optimizer  # noqa: PLC0415
+
     G = Ggate(0, symplectic_trainable=True)
     Att = Attenuator(0, 0.9)
 
@@ -99,6 +100,8 @@ def test_compactFock_1leftover_gradients():
     Test getting Fock amplitudes and if all but the first
     mode are detected (math.hermite_renormalized_1leftoverMode).
     """
+    from mrmustard.training import Optimizer  # noqa: PLC0415
+
     G = Ggate((0, 1), symplectic_trainable=True)
     Att = Attenuator(0, 0.9)
 

--- a/tests/test_math/test_compactFock.py
+++ b/tests/test_math/test_compactFock.py
@@ -9,6 +9,7 @@ from mrmustard import math
 from mrmustard.lab import DM, Ggate, SqueezedVacuum, Vacuum
 from mrmustard.lab.transformations.attenuator import Attenuator
 from mrmustard.physics import gaussian
+from mrmustard.training import Optimizer
 
 
 def test_compactFock_diagonal():
@@ -70,8 +71,6 @@ def test_compactFock_diagonal_gradients():
     Test getting Fock amplitudes and gradients if all modes
     are detected (math.hermite_renormalized_diagonal).
     """
-    from mrmustard.training import Optimizer  # noqa: PLC0415
-
     G = Ggate(0, symplectic_trainable=True)
     Att = Attenuator(0, 0.9)
 
@@ -100,8 +99,6 @@ def test_compactFock_1leftover_gradients():
     Test getting Fock amplitudes and if all but the first
     mode are detected (math.hermite_renormalized_1leftoverMode).
     """
-    from mrmustard.training import Optimizer  # noqa: PLC0415
-
     G = Ggate((0, 1), symplectic_trainable=True)
     Att = Attenuator(0, 0.9)
 

--- a/tests/test_math/test_jitting.py
+++ b/tests/test_math/test_jitting.py
@@ -21,6 +21,9 @@ import pytest
 from mrmustard import math
 from mrmustard.lab import Attenuator, BSgate, SqueezedVacuum
 
+jax = pytest.importorskip("jax")
+jnp = pytest.importorskip("jax.numpy")
+
 
 @pytest.mark.requires_backend("jax")
 class TestJitting:
@@ -30,8 +33,6 @@ class TestJitting:
 
     def test_jit_complete_circuit(self):
         r"""Tests if entire circuit with component definitions can be jitted."""
-        import jax  # noqa: PLC0415
-        import jax.numpy as jnp  # noqa: PLC0415
 
         def evaluate_circuit(params):
             r"""
@@ -99,9 +100,6 @@ class TestJitting:
 
     def test_jit_circuit_with_parameters(self):
         r"""Tests if circuit with pre-defined elements can be jitted."""
-        import jax  # noqa: PLC0415
-        import jax.numpy as jnp  # noqa: PLC0415
-
         initial_state = SqueezedVacuum(mode=0, r=0.5, phi=0.5, r_trainable=True, phi_trainable=True)
         BS_01 = BSgate(modes=(0, 1), theta=0.5, phi=0.5, theta_trainable=True, phi_trainable=True)
         BS_12 = BSgate(modes=(1, 2), theta=0.5, phi=0.5, theta_trainable=True, phi_trainable=True)

--- a/tests/test_math/test_jitting.py
+++ b/tests/test_math/test_jitting.py
@@ -16,132 +16,138 @@
 
 import time
 
-import jax
-import jax.numpy as jnp
 import pytest
 
 from mrmustard import math
 from mrmustard.lab import Attenuator, BSgate, SqueezedVacuum
 
 
-def evaluate_circuit(params):
+@pytest.mark.requires_backend("jax")
+class TestJitting:
     r"""
-    Defines and evaluates a sample circuit with the given parameters.
+    Tests the jitting functionality within JAX backend.
     """
-    params = jnp.asarray(params)
-    BS_01 = BSgate(
-        modes=(0, 1),
-        theta=params[0],
-        phi=params[1],
-        theta_trainable=False,
-        phi_trainable=False,
-    )
-    BS_12 = BSgate(
-        modes=(1, 2),
-        theta=params[2],
-        phi=params[3],
-        theta_trainable=False,
-        phi_trainable=False,
-    )
-    att = Attenuator(mode=0, transmissivity=params[4], transmissivity_trainable=False)
-    initial_state = SqueezedVacuum(
-        mode=0,
-        r=params[5],
-        phi=params[6],
-        r_trainable=False,
-        phi_trainable=False,
-    )
-    state_out = (
-        initial_state
-        >> initial_state.on(1)
-        >> initial_state.on(2)
-        >> BS_01
-        >> BS_12
-        >> att
-        >> att.on(1)
-        >> att.on(2)
-    )
-    output_fock_state = state_out.fock_array(shape=(20, 5, 5, 20, 5, 5))
-    marginal = output_fock_state[:, 4, 4, :, 4, 4]
-    return math.real(math.trace(marginal))
 
+    def test_jit_complete_circuit(self):
+        r"""Tests if entire circuit with component definitions can be jitted."""
+        import jax  # noqa: PLC0415
+        import jax.numpy as jnp  # noqa: PLC0415
 
-@pytest.mark.requires_backend("jax")
-def test_jit_complete_circuit():
-    r"""Tests if entire circuit with component definitions can be jitted."""
-    unjitted_evaluate_circuit = evaluate_circuit
-    start_time = time.time()
-    for k in range(100):
-        rng = jax.random.PRNGKey(k)
-        params = jax.random.uniform(rng, (7,), minval=0.1, maxval=0.8)
-        _ = unjitted_evaluate_circuit(params)
-    end_time = time.time()
-    unjitted_routine_time = end_time - start_time
+        def evaluate_circuit(params):
+            r"""
+            Defines and evaluates a sample circuit with the given parameters.
+            """
+            params = jnp.asarray(params)
+            BS_01 = BSgate(
+                modes=(0, 1),
+                theta=params[0],
+                phi=params[1],
+                theta_trainable=False,
+                phi_trainable=False,
+            )
+            BS_12 = BSgate(
+                modes=(1, 2),
+                theta=params[2],
+                phi=params[3],
+                theta_trainable=False,
+                phi_trainable=False,
+            )
+            att = Attenuator(mode=0, transmissivity=params[4], transmissivity_trainable=False)
+            initial_state = SqueezedVacuum(
+                mode=0,
+                r=params[5],
+                phi=params[6],
+                r_trainable=False,
+                phi_trainable=False,
+            )
+            state_out = (
+                initial_state
+                >> initial_state.on(1)
+                >> initial_state.on(2)
+                >> BS_01
+                >> BS_12
+                >> att
+                >> att.on(1)
+                >> att.on(2)
+            )
+            output_fock_state = state_out.fock_array(shape=(20, 5, 5, 20, 5, 5))
+            marginal = output_fock_state[:, 4, 4, :, 4, 4]
+            return math.real(math.trace(marginal))
 
-    jitted_evaluate_circuit = jax.jit(evaluate_circuit)
-    _ = jitted_evaluate_circuit(jnp.array([0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]))
-    start_time = time.time()
-    for k in range(100):
-        rng = jax.random.PRNGKey(k)
-        params = jax.random.uniform(rng, (7,), minval=0.1, maxval=0.8)
-        _ = jitted_evaluate_circuit(params)
-    end_time = time.time()
-    jitted_routine_time = end_time - start_time
+        unjitted_evaluate_circuit = evaluate_circuit
+        start_time = time.time()
+        for k in range(100):
+            rng = jax.random.PRNGKey(k)
+            params = jax.random.uniform(rng, (7,), minval=0.1, maxval=0.8)
+            _ = unjitted_evaluate_circuit(params)
+        end_time = time.time()
+        unjitted_routine_time = end_time - start_time
 
-    assert jitted_routine_time < unjitted_routine_time, (
-        "Jitting should be make circuit evaluation faster."
-    )
+        jitted_evaluate_circuit = jax.jit(evaluate_circuit)
+        _ = jitted_evaluate_circuit(jnp.array([0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]))
+        start_time = time.time()
+        for k in range(100):
+            rng = jax.random.PRNGKey(k)
+            params = jax.random.uniform(rng, (7,), minval=0.1, maxval=0.8)
+            _ = jitted_evaluate_circuit(params)
+        end_time = time.time()
+        jitted_routine_time = end_time - start_time
 
-
-@pytest.mark.requires_backend("jax")
-def test_jit_circuit_with_parameters():
-    r"""Tests if circuit with pre-defined elements can be jitted."""
-    initial_state = SqueezedVacuum(mode=0, r=0.5, phi=0.5, r_trainable=True, phi_trainable=True)
-    BS_01 = BSgate(modes=(0, 1), theta=0.5, phi=0.5, theta_trainable=True, phi_trainable=True)
-    BS_12 = BSgate(modes=(1, 2), theta=0.5, phi=0.5, theta_trainable=True, phi_trainable=True)
-    att = Attenuator(mode=0, transmissivity=0.5, transmissivity_trainable=True)
-
-    def evaluate_parameters(params):
-        r"""
-        Evaluate pre-defined circuit elements with the given parameters.
-        """
-        BS_01.parameters.all_parameters["theta"].value = params[0]
-        BS_01.parameters.all_parameters["phi"].value = params[1]
-        BS_12.parameters.all_parameters["theta"].value = params[2]
-        BS_12.parameters.all_parameters["phi"].value = params[3]
-        state_out = (
-            initial_state
-            >> initial_state.on(1)
-            >> initial_state.on(2)
-            >> BS_01
-            >> BS_12
-            >> att
-            >> att.on(1)
-            >> att.on(2)
+        assert jitted_routine_time < unjitted_routine_time, (
+            "Jitting should be make circuit evaluation faster."
         )
-        output_fock_state = state_out.fock_array(shape=(20, 5, 5, 20, 5, 5))
-        marginal = output_fock_state[:, 4, 4, :, 4, 4]
-        return math.real(math.trace(marginal))
 
-    unjitted_evaluate_parameters = evaluate_parameters
-    start_time = time.time()
-    for k in range(100):
-        rng = jax.random.PRNGKey(k)
-        params = jax.random.uniform(rng, (4,), minval=0.1, maxval=0.8)
-        _ = unjitted_evaluate_parameters(params)
-    end_time = time.time()
-    unjitted_routine_time = end_time - start_time
+    def test_jit_circuit_with_parameters(self):
+        r"""Tests if circuit with pre-defined elements can be jitted."""
+        import jax  # noqa: PLC0415
+        import jax.numpy as jnp  # noqa: PLC0415
 
-    jitted_evaluate_parameters = jax.jit(evaluate_parameters)
-    _ = jitted_evaluate_parameters(jnp.array([0.5, 0.5, 0.5, 0.5]))
-    start_time = time.time()
-    for k in range(100):
-        rng = jax.random.PRNGKey(k)
-        params = jax.random.uniform(rng, (4,), minval=0.1, maxval=0.8)
-        _ = jitted_evaluate_parameters(params)
-    end_time = time.time()
-    jitted_routine_time = end_time - start_time
+        initial_state = SqueezedVacuum(mode=0, r=0.5, phi=0.5, r_trainable=True, phi_trainable=True)
+        BS_01 = BSgate(modes=(0, 1), theta=0.5, phi=0.5, theta_trainable=True, phi_trainable=True)
+        BS_12 = BSgate(modes=(1, 2), theta=0.5, phi=0.5, theta_trainable=True, phi_trainable=True)
+        att = Attenuator(mode=0, transmissivity=0.5, transmissivity_trainable=True)
 
-    assert jitted_routine_time < unjitted_routine_time, (
-        "Jitting should be make circuit evaluation faster."
-    )
+        def evaluate_parameters(params):
+            r"""
+            Evaluate pre-defined circuit elements with the given parameters.
+            """
+            BS_01.parameters.all_parameters["theta"].value = params[0]
+            BS_01.parameters.all_parameters["phi"].value = params[1]
+            BS_12.parameters.all_parameters["theta"].value = params[2]
+            BS_12.parameters.all_parameters["phi"].value = params[3]
+            state_out = (
+                initial_state
+                >> initial_state.on(1)
+                >> initial_state.on(2)
+                >> BS_01
+                >> BS_12
+                >> att
+                >> att.on(1)
+                >> att.on(2)
+            )
+            output_fock_state = state_out.fock_array(shape=(20, 5, 5, 20, 5, 5))
+            marginal = output_fock_state[:, 4, 4, :, 4, 4]
+            return math.real(math.trace(marginal))
+
+        unjitted_evaluate_parameters = evaluate_parameters
+        start_time = time.time()
+        for k in range(100):
+            rng = jax.random.PRNGKey(k)
+            params = jax.random.uniform(rng, (4,), minval=0.1, maxval=0.8)
+            _ = unjitted_evaluate_parameters(params)
+        end_time = time.time()
+        unjitted_routine_time = end_time - start_time
+
+        jitted_evaluate_parameters = jax.jit(evaluate_parameters)
+        _ = jitted_evaluate_parameters(jnp.array([0.5, 0.5, 0.5, 0.5]))
+        start_time = time.time()
+        for k in range(100):
+            rng = jax.random.PRNGKey(k)
+            params = jax.random.uniform(rng, (4,), minval=0.1, maxval=0.8)
+            _ = jitted_evaluate_parameters(params)
+        end_time = time.time()
+        jitted_routine_time = end_time - start_time
+
+        assert jitted_routine_time < unjitted_routine_time, (
+            "Jitting should be make circuit evaluation faster."
+        )

--- a/tests/test_utils/test_logger.py
+++ b/tests/test_utils/test_logger.py
@@ -50,10 +50,14 @@ import sys
 
 import pytest
 
-from mrmustard.training import optimizer
 from mrmustard.utils.logger import create_logger, default_handler, logging_handler_defined
 
-modules_contain_logging = [optimizer]
+try:
+    from mrmustard.training import optimizer
+
+    modules_contain_logging = [optimizer]
+except ImportError:
+    modules_contain_logging = []
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_utils/test_logger.py
+++ b/tests/test_utils/test_logger.py
@@ -50,14 +50,10 @@ import sys
 
 import pytest
 
+from mrmustard.training import optimizer
 from mrmustard.utils.logger import create_logger, default_handler, logging_handler_defined
 
-try:
-    from mrmustard.training import optimizer
-
-    modules_contain_logging = [optimizer]
-except ImportError:
-    modules_contain_logging = []
+modules_contain_logging = [optimizer]
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_utils/test_serialize.py
+++ b/tests/test_utils/test_serialize.py
@@ -17,7 +17,6 @@
 import json
 from dataclasses import dataclass
 
-import jax
 import numpy as np
 import pytest
 
@@ -143,6 +142,8 @@ class TestSerialize:
     @pytest.mark.requires_backend("jax")
     def test_jax_support(self):
         """Test that JAX data is supported."""
+        import jax  # noqa: PLC0415
+
         x = math.astensor([1.1, 2.2])
         loaded = load(save(DummyOneNP, name="myname", arrays={"array": x}))
         assert isinstance(loaded.array, jax.Array)

--- a/tests/test_utils/test_serialize.py
+++ b/tests/test_utils/test_serialize.py
@@ -46,6 +46,11 @@ from mrmustard.lab import (
 )
 from mrmustard.utils.serialize import load, save
 
+try:
+    import jax
+except ImportError:
+    jax = None
+
 
 class Deserialize:
     """Base class with a simple deserialization implementation."""
@@ -142,8 +147,6 @@ class TestSerialize:
     @pytest.mark.requires_backend("jax")
     def test_jax_support(self):
         """Test that JAX data is supported."""
-        import jax  # noqa: PLC0415
-
         x = math.astensor([1.1, 2.2])
         loaded = load(save(DummyOneNP, name="myname", arrays={"array": x}))
         assert isinstance(loaded.array, jax.Array)

--- a/uv.lock
+++ b/uv.lock
@@ -1103,7 +1103,7 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
-jax = [
+jax-backend = [
     { name = "equinox" },
     { name = "jax" },
     { name = "optax" },
@@ -1111,8 +1111,10 @@ jax = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "equinox" },
     { name = "hypothesis" },
     { name = "jax" },
+    { name = "optax" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -1136,19 +1138,19 @@ interactive = [
 
 [package.metadata]
 requires-dist = [
-    { name = "equinox", marker = "extra == 'jax'", specifier = ">=0.11.10" },
+    { name = "equinox", marker = "extra == 'jax-backend'", specifier = ">=0.11.10" },
     { name = "grpcio", specifier = "==1.60.0" },
     { name = "importlib-resources", specifier = ">=6.5.2,<7" },
     { name = "ipython", specifier = ">=8.18.1" },
     { name = "ipywidgets", specifier = ">=8.1.3,<9" },
-    { name = "jax", marker = "extra == 'jax'", specifier = ">=0.5.1,<0.6.0" },
+    { name = "jax", marker = "extra == 'jax-backend'", specifier = ">=0.5.1,<0.6.0" },
     { name = "matplotlib", specifier = ">=3.5.0,<4" },
     { name = "nbformat", specifier = ">=5.10,<6" },
     { name = "networkx", specifier = ">=3.1,<4" },
     { name = "numba", specifier = ">=0.59,<1" },
     { name = "numpy", specifier = ">=2.0.0,<3" },
     { name = "opt-einsum", specifier = ">=3.4.0,<4" },
-    { name = "optax", marker = "extra == 'jax'", specifier = ">=0.2.4,<0.3" },
+    { name = "optax", marker = "extra == 'jax-backend'", specifier = ">=0.2.4,<0.3" },
     { name = "platformdirs", specifier = ">=2.2.0" },
     { name = "plotly", specifier = ">=5.20.0,<6" },
     { name = "rich", specifier = ">=13.9.0,<14" },
@@ -1159,8 +1161,10 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "equinox", specifier = ">=0.11.10" },
     { name = "hypothesis", specifier = "==6.31.6" },
-    { name = "jax" },
+    { name = "jax", specifier = ">=0.5.1,<0.6.0" },
+    { name = "optax", specifier = ">=0.2.4,<0.3" },
     { name = "pre-commit", specifier = "==3.7.1" },
     { name = "pytest", specifier = "==8.0" },
     { name = "pytest-cov", specifier = "==3.0.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -1084,7 +1084,6 @@ name = "mrmustard"
 version = "1.0.0a1"
 source = { editable = "." }
 dependencies = [
-    { name = "equinox" },
     { name = "grpcio" },
     { name = "importlib-resources" },
     { name = "ipython" },
@@ -1094,13 +1093,19 @@ dependencies = [
     { name = "networkx" },
     { name = "numba" },
     { name = "numpy" },
-    { name = "optax" },
+    { name = "opt-einsum" },
     { name = "platformdirs" },
     { name = "plotly" },
     { name = "rich" },
     { name = "scipy" },
     { name = "semantic-version" },
     { name = "thewalrus" },
+]
+
+[package.optional-dependencies]
+jax = [
+    { name = "equinox" },
+    { name = "optax" },
 ]
 
 [package.dev-dependencies]
@@ -1129,7 +1134,7 @@ interactive = [
 
 [package.metadata]
 requires-dist = [
-    { name = "equinox", specifier = ">=0.11.10" },
+    { name = "equinox", marker = "extra == 'jax'", specifier = ">=0.11.10" },
     { name = "grpcio", specifier = "==1.60.0" },
     { name = "importlib-resources", specifier = ">=6.5.2,<7" },
     { name = "ipython", specifier = ">=8.18.1" },
@@ -1139,7 +1144,8 @@ requires-dist = [
     { name = "networkx", specifier = ">=3.1,<4" },
     { name = "numba", specifier = ">=0.59,<1" },
     { name = "numpy", specifier = ">=2.0.0,<3" },
-    { name = "optax", specifier = ">=0.2.4,<0.3" },
+    { name = "opt-einsum", specifier = ">=3.4.0,<4" },
+    { name = "optax", marker = "extra == 'jax'", specifier = ">=0.2.4,<0.3" },
     { name = "platformdirs", specifier = ">=2.2.0" },
     { name = "plotly", specifier = ">=5.20.0,<6" },
     { name = "rich", specifier = ">=13.9.0,<14" },

--- a/uv.lock
+++ b/uv.lock
@@ -1105,12 +1105,14 @@ dependencies = [
 [package.optional-dependencies]
 jax = [
     { name = "equinox" },
+    { name = "jax" },
     { name = "optax" },
 ]
 
 [package.dev-dependencies]
 dev = [
     { name = "hypothesis" },
+    { name = "jax" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -1139,6 +1141,7 @@ requires-dist = [
     { name = "importlib-resources", specifier = ">=6.5.2,<7" },
     { name = "ipython", specifier = ">=8.18.1" },
     { name = "ipywidgets", specifier = ">=8.1.3,<9" },
+    { name = "jax", marker = "extra == 'jax'", specifier = ">=0.5.1,<0.6.0" },
     { name = "matplotlib", specifier = ">=3.5.0,<4" },
     { name = "nbformat", specifier = ">=5.10,<6" },
     { name = "networkx", specifier = ">=3.1,<4" },
@@ -1157,6 +1160,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "hypothesis", specifier = "==6.31.6" },
+    { name = "jax" },
     { name = "pre-commit", specifier = "==3.7.1" },
     { name = "pytest", specifier = "==8.0" },
     { name = "pytest-cov", specifier = "==3.0.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -1111,10 +1111,7 @@ jax-backend = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "equinox" },
     { name = "hypothesis" },
-    { name = "jax" },
-    { name = "optax" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -1134,6 +1131,11 @@ doc = [
 interactive = [
     { name = "ipykernel" },
     { name = "ipywidgets" },
+]
+jax-backend = [
+    { name = "equinox" },
+    { name = "jax" },
+    { name = "optax" },
 ]
 
 [package.metadata]
@@ -1161,10 +1163,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "equinox", specifier = ">=0.11.10" },
     { name = "hypothesis", specifier = "==6.31.6" },
-    { name = "jax", specifier = ">=0.5.1,<0.6.0" },
-    { name = "optax", specifier = ">=0.2.4,<0.3" },
     { name = "pre-commit", specifier = "==3.7.1" },
     { name = "pytest", specifier = "==8.0" },
     { name = "pytest-cov", specifier = "==3.0.0" },
@@ -1184,6 +1183,11 @@ doc = [
 interactive = [
     { name = "ipykernel", specifier = ">=6.21.2,<7.0.0" },
     { name = "ipywidgets", specifier = ">=8.0.4,<9.0.0" },
+]
+jax-backend = [
+    { name = "equinox", specifier = ">=0.11.10" },
+    { name = "jax", specifier = ">=0.5.1,<0.6.0" },
+    { name = "optax", specifier = ">=0.2.4,<0.3" },
 ]
 
 [[package]]


### PR DESCRIPTION
**Context:** We can have a more lightweight Mr Mustard experience if we make JAX an optional dependency as it is not always used. In this PR we introduce the `jax_backend` optional dependency group.

**Description of the Change:** `jax`, `equinox`, `optax` are optional. `opt_einsum` is included as a direct dependency. Necessary changes to make backend JAX optional.

**Benefits:** Can now install Mr Mustard without having to install JAX
