### PR TITLE
add seed keyword on random methods, plus tests

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -13,11 +13,14 @@
 * Added a ``rich`` based repr to ``ParameterSet``.
 [(#616)](https://github.com/XanaduAI/MrMustard/pull/616)
 
+* Added vjps to the JAX backend. Added ``numba`` based Fock lattice strategies to `SqueezedVacuum` and `Sgate`.
+[(#636)](https://github.com/XanaduAI/MrMustard/pull/636)
+
 * Made `JAX` an optional `jax_backend` dependency.
 [(#637)](https://github.com/XanaduAI/MrMustard/pull/637)
 
-* Added vjps to the JAX backend. Added ``numba`` based Fock lattice strategies to `SqueezedVacuum` and `Sgate`.
-[(#636)](https://github.com/XanaduAI/MrMustard/pull/636)
+* Added a `seed` keyword for `DM.random`, `Ket.random`, `Channel.random` and `Unitary.random`
+[(#638)](https://github.com/XanaduAI/MrMustard/pull/638)
 
 ### Bug fixes
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -13,11 +13,11 @@
 * Added a ``rich`` based repr to ``ParameterSet``.
 [(#616)](https://github.com/XanaduAI/MrMustard/pull/616)
 
-* Added vjps to the JAX backend. Added ``numba`` based Fock lattice strategies to `SqueezedVacuum` and `Sgate`.
-[(#636)](https://github.com/XanaduAI/MrMustard/pull/636)
-
 * Made `JAX` an optional `jax_backend` dependency.
 [(#637)](https://github.com/XanaduAI/MrMustard/pull/637)
+
+* Added vjps to the JAX backend. Added ``numba`` based Fock lattice strategies to `SqueezedVacuum` and `Sgate`.
+[(#636)](https://github.com/XanaduAI/MrMustard/pull/636)
 
 * Added a `seed` keyword for `DM.random`, `Ket.random`, `Channel.random` and `Unitary.random`
 [(#638)](https://github.com/XanaduAI/MrMustard/pull/638)

--- a/mrmustard/lab/states/dm.py
+++ b/mrmustard/lab/states/dm.py
@@ -190,7 +190,9 @@ class DM(State):
         )
 
     @classmethod
-    def random(cls, modes: Collection[int], m: int | None = None, max_r: float = 1.0) -> DM:
+    def random(
+        cls, modes: Collection[int], m: int | None = None, max_r: float = 1.0, seed: int | None = None
+    ) -> DM:
         r"""
         Returns a random ``DM`` with zero displacement.
 
@@ -198,14 +200,18 @@ class DM(State):
             modes: The modes of the ``DM``.
             m: The number modes to be considered for tracing out from a random pure state (Ket)
                 if not specified, m is considered to be len(modes)
+            max_r: Maximum squeezing parameter over which we make random choices.
+            seed: The random seed. If ``None``, the global seed is used.
         """
+        if not modes:
+            raise ValueError("Cannot create a random state with no modes.")
         if m is None:
             m = len(modes)
         max_idx = max(modes)
         ancilla = list(range(max_idx + 1, max_idx + m + 1))
         full_modes = list(modes) + ancilla
         m = len(full_modes)
-        S = math.random_symplectic(m, max_r)
+        S = math.random_symplectic(m, max_r, seed=seed)
         I = math.eye(m, dtype=math.complex128)
         transformation = math.block([[I, I], [-1j * I, 1j * I]]) / np.sqrt(2)
         S = math.conj(math.transpose(transformation)) @ S @ transformation

--- a/mrmustard/lab/states/dm.py
+++ b/mrmustard/lab/states/dm.py
@@ -191,7 +191,11 @@ class DM(State):
 
     @classmethod
     def random(
-        cls, modes: Collection[int], m: int | None = None, max_r: float = 1.0, seed: int | None = None
+        cls,
+        modes: Collection[int],
+        m: int | None = None,
+        max_r: float = 1.0,
+        seed: int | None = None,
     ) -> DM:
         r"""
         Returns a random ``DM`` with zero displacement.

--- a/mrmustard/lab/states/ket.py
+++ b/mrmustard/lab/states/ket.py
@@ -174,13 +174,14 @@ class Ket(State):
         )
 
     @classmethod
-    def random(cls, modes: Collection[int], max_r: float = 1.0) -> Ket:
+    def random(cls, modes: Collection[int], max_r: float = 1.0, seed: int | None = None) -> Ket:
         r"""
         Generates a random zero displacement state.
 
         Args:
             modes: The modes of the state.
             max_r: Maximum squeezing parameter over which we make random choices.
+            seed: The random seed. If ``None``, the global seed is used.
 
         Returns:
             A ``Ket`` object.
@@ -196,9 +197,11 @@ class Ket(State):
             >>> from mrmustard.lab import Ket
             >>> assert isinstance(Ket.random([0,1]), Ket)
         """
+        if not modes:
+            raise ValueError("Cannot create a random state with no modes.")
 
         m = len(modes)
-        S = math.random_symplectic(m, max_r)
+        S = math.random_symplectic(m, max_r, seed=seed)
         transformation = (
             1
             / math.sqrt(complex(2))

--- a/mrmustard/lab/transformations/base.py
+++ b/mrmustard/lab/transformations/base.py
@@ -275,13 +275,14 @@ class Unitary(Operation):
         return Unitary.from_bargmann(modes, modes, (A, b, c))
 
     @classmethod
-    def random(cls, modes: Sequence[int], max_r: float = 1.0) -> Unitary:
+    def random(cls, modes: Sequence[int], max_r: float = 1.0, seed: int | None = None) -> Unitary:
         r"""
         Returns a random unitary.
 
         Args:
             modes: The modes of the unitary.
             max_r: The maximum squeezing parameter.
+            seed: The random seed. If ``None``, the global seed is used.
 
         .. code-block::
 
@@ -290,8 +291,10 @@ class Unitary(Operation):
             >>> U = Unitary.random((0, 1, 2), max_r=1.2)
             >>> assert U.modes == (0,1,2)
         """
+        if not modes:
+            raise ValueError("Cannot create a random unitary with no modes.")
         m = len(modes)
-        S = math.random_symplectic(m, max_r)
+        S = math.random_symplectic(m, max_r, seed=seed)
         return Unitary.from_symplectic(modes, S)
 
     def inverse(self) -> Unitary:
@@ -540,13 +543,14 @@ class Channel(Map):
         return Channel.from_bargmann(modes_out, modes_in, XY_to_channel_Abc(X, Y, d))
 
     @classmethod
-    def random(cls, modes: Sequence[int], max_r: float = 1.0) -> Channel:
+    def random(cls, modes: Sequence[int], max_r: float = 1.0, seed: int | None = None) -> Channel:
         r"""
         A random channel without displacement.
 
         Args:
             modes: The modes of the channel.
             max_r: The maximum squeezing parameter.
+            seed: The random seed. If ``None``, the global seed is used.
 
         .. code-block::
 
@@ -555,10 +559,12 @@ class Channel(Map):
             >>> channel = Channel.random((0, 1, 2), max_r=1.2)
             >>> assert channel.modes == (0, 1, 2)
         """
+        if not modes:
+            raise ValueError("Cannot create a random channel with no modes.")
         from mrmustard.lab.states import Vacuum  # noqa: PLC0415
 
         m = len(modes)
-        U = Unitary.random(range(3 * m), max_r)
+        U = Unitary.random(range(3 * m), max_r, seed=seed)
         u_psi = Vacuum(range(2 * m)) >> U
         ansatz = u_psi.ansatz
         kraus = ansatz.conj.contract(

--- a/mrmustard/math/backend_manager.py
+++ b/mrmustard/math/backend_manager.py
@@ -1526,19 +1526,25 @@ class BackendManager:
         Y = self.imag(U)
         return self.block([[X, -Y], [Y, X]])
 
-    def random_symplectic(self, num_modes: int, max_r: float = 1.0) -> Tensor:
+    def random_symplectic(self, num_modes: int, max_r: float = 1.0, seed: int | None = None) -> Tensor:
         r"""
         A random symplectic matrix in ``Sp(2*num_modes)``.
 
         Squeezing is sampled uniformly from 0.0 to ``max_r`` (1.0 by default).
+
+        Args:
+            num_modes (int): The number of modes.
+            max_r (float): The maximum squeezing value.
+            seed (int | None): The random seed. If ``None``, the global seed is used.
         """
+        rng = np.random.default_rng(seed) if seed is not None else settings.rng
         if num_modes == 1:
-            W = self.exp(1j * 2 * np.pi * settings.rng.uniform(size=(1, 1)))
-            V = self.exp(1j * 2 * np.pi * settings.rng.uniform(size=(1, 1)))
+            W = self.exp(1j * 2 * np.pi * rng.uniform(size=(1, 1)))
+            V = self.exp(1j * 2 * np.pi * rng.uniform(size=(1, 1)))
         else:
-            W = unitary_group.rvs(dim=num_modes, random_state=settings.rng)
-            V = unitary_group.rvs(dim=num_modes, random_state=settings.rng)
-        r = settings.rng.uniform(low=0.0, high=max_r, size=num_modes)
+            W = unitary_group.rvs(dim=num_modes, random_state=rng)
+            V = unitary_group.rvs(dim=num_modes, random_state=rng)
+        r = rng.uniform(low=0.0, high=max_r, size=num_modes)
         OW = self.unitary_to_orthogonal(W)
         OV = self.unitary_to_orthogonal(V)
         dd = self.diag(self.concat([self.exp(-r), np.exp(r)], axis=0), k=0)

--- a/mrmustard/math/backend_manager.py
+++ b/mrmustard/math/backend_manager.py
@@ -1526,7 +1526,9 @@ class BackendManager:
         Y = self.imag(U)
         return self.block([[X, -Y], [Y, X]])
 
-    def random_symplectic(self, num_modes: int, max_r: float = 1.0, seed: int | None = None) -> Tensor:
+    def random_symplectic(
+        self, num_modes: int, max_r: float = 1.0, seed: int | None = None
+    ) -> Tensor:
         r"""
         A random symplectic matrix in ``Sp(2*num_modes)``.
 

--- a/tests/test_lab/test_states/test_dm.py
+++ b/tests/test_lab/test_states/test_dm.py
@@ -534,7 +534,6 @@ class TestDM:
         with pytest.raises(ValueError, match="Cannot create a random state with no modes."):
             DM.random(modes=[])
 
-
     def test_is_positive(self):
         assert (Ket.random((2, 9)) >> Attenuator(2) >> Attenuator(9)).is_positive
         assert (

--- a/tests/test_lab/test_states/test_dm.py
+++ b/tests/test_lab/test_states/test_dm.py
@@ -510,6 +510,31 @@ class TestDM:
         assert np.all(np.linalg.eigvals(Gamma) < 1)
         assert np.all(np.linalg.eigvals(Temp) < 1)
 
+    def test_random_seed(self):
+        # same seed should produce same state
+        assert DM.random(modes=[0, 1], seed=42) == DM.random(modes=[0, 1], seed=42)
+        # different seeds should produce different states
+        assert DM.random(modes=[0, 1], seed=42) != DM.random(modes=[0, 1], seed=43)
+
+        # local seed should not affect global seed
+        settings.SEED = 42
+        dm_from_global_1 = DM.random(modes=[0, 1])
+        dm_from_global_2 = DM.random(modes=[0, 1])
+
+        settings.SEED = 42
+        dm_from_global_1_redux = DM.random(modes=[0, 1])
+        # this call should not affect the global RNG
+        _ = DM.random(modes=[0, 1], seed=123)
+        dm_from_global_2_redux = DM.random(modes=[0, 1])
+
+        assert dm_from_global_1 == dm_from_global_1_redux
+        assert dm_from_global_2 == dm_from_global_2_redux
+
+        # no modes should raise error
+        with pytest.raises(ValueError, match="Cannot create a random state with no modes."):
+            DM.random(modes=[])
+
+
     def test_is_positive(self):
         assert (Ket.random((2, 9)) >> Attenuator(2) >> Attenuator(9)).is_positive
         assert (

--- a/tests/test_lab/test_states/test_ket.py
+++ b/tests/test_lab/test_states/test_ket.py
@@ -559,6 +559,30 @@ class TestKet:
             math.zeros((2, 2)),
         )  # checks if the A matrix is symmetric
 
+    def test_random_seed(self):
+        # same seed should produce same state
+        assert Ket.random(modes=[0, 1], seed=42) == Ket.random(modes=[0, 1], seed=42)
+        # different seeds should produce different states
+        assert Ket.random(modes=[0, 1], seed=42) != Ket.random(modes=[0, 1], seed=43)
+
+        # local seed should not affect global seed
+        settings.SEED = 42
+        ket_from_global_1 = Ket.random(modes=[0, 1])
+        ket_from_global_2 = Ket.random(modes=[0, 1])
+
+        settings.SEED = 42
+        ket_from_global_1_redux = Ket.random(modes=[0, 1])
+        # this call should not affect the global RNG
+        _ = Ket.random(modes=[0, 1], seed=123)
+        ket_from_global_2_redux = Ket.random(modes=[0, 1])
+
+        assert ket_from_global_1 == ket_from_global_1_redux
+        assert ket_from_global_2 == ket_from_global_2_redux
+
+        # no modes should raise error
+        with pytest.raises(ValueError, match="Cannot create a random state with no modes."):
+            Ket.random(modes=[])
+
     def test_ipython_repr(self):
         """
         Test the widgets.state function.

--- a/tests/test_lab/test_transformations/test_transformations_base.py
+++ b/tests/test_lab/test_transformations/test_transformations_base.py
@@ -128,6 +128,31 @@ class TestUnitary:
         u = Unitary.random(modes)
         assert (u >> u.dual) == Identity(modes)
 
+    def test_random_seed(self):
+        # same seed should produce same unitary
+        assert Unitary.random(modes=[0, 1], seed=42) == Unitary.random(modes=[0, 1], seed=42)
+        # different seeds should produce different unitaries
+        assert Unitary.random(modes=[0, 1], seed=42) != Unitary.random(modes=[0, 1], seed=43)
+
+        # local seed should not affect global seed
+        settings.SEED = 42
+        u_from_global_1 = Unitary.random(modes=[0, 1])
+        u_from_global_2 = Unitary.random(modes=[0, 1])
+
+        settings.SEED = 42
+        u_from_global_1_redux = Unitary.random(modes=[0, 1])
+        # this call should not affect the global RNG
+        _ = Unitary.random(modes=[0, 1], seed=123)
+        u_from_global_2_redux = Unitary.random(modes=[0, 1])
+
+        assert u_from_global_1 == u_from_global_1_redux
+        assert u_from_global_2 == u_from_global_2_redux
+
+        # no modes should raise error
+        with pytest.raises(ValueError, match="Cannot create a random unitary with no modes."):
+            Unitary.random(modes=[])
+
+
 
 class TestMap:
     r"""
@@ -205,6 +230,31 @@ class TestChannel:
     def test_random(self):
         modes = (1, 2, 6)
         assert math.allclose((Vacuum(modes) >> Channel.random(modes)).probability, 1)
+
+    def test_random_seed(self):
+        # same seed should produce same channel
+        assert Channel.random(modes=[0, 1], seed=42) == Channel.random(modes=[0, 1], seed=42)
+        # different seeds should produce different channels
+        assert Channel.random(modes=[0, 1], seed=42) != Channel.random(modes=[0, 1], seed=43)
+
+        # local seed should not affect global seed
+        settings.SEED = 42
+        ch_from_global_1 = Channel.random(modes=[0, 1])
+        ch_from_global_2 = Channel.random(modes=[0, 1])
+
+        settings.SEED = 42
+        ch_from_global_1_redux = Channel.random(modes=[0, 1])
+        # this call should not affect the global RNG
+        _ = Channel.random(modes=[0, 1], seed=123)
+        ch_from_global_2_redux = Channel.random(modes=[0, 1])
+
+        assert ch_from_global_1 == ch_from_global_1_redux
+        assert ch_from_global_2 == ch_from_global_2_redux
+
+        # no modes should raise error
+        with pytest.raises(ValueError, match="Cannot create a random channel with no modes."):
+            Channel.random(modes=[])
+
 
     @pytest.mark.parametrize("modes", [(0,), (0, 1), (0, 1, 2)])
     def test_is_CP(self, modes):

--- a/tests/test_lab/test_transformations/test_transformations_base.py
+++ b/tests/test_lab/test_transformations/test_transformations_base.py
@@ -153,7 +153,6 @@ class TestUnitary:
             Unitary.random(modes=[])
 
 
-
 class TestMap:
     r"""
     Tests the Map class.
@@ -254,7 +253,6 @@ class TestChannel:
         # no modes should raise error
         with pytest.raises(ValueError, match="Cannot create a random channel with no modes."):
             Channel.random(modes=[])
-
 
     @pytest.mark.parametrize("modes", [(0,), (0, 1), (0, 1, 2)])
     def test_is_CP(self, modes):


### PR DESCRIPTION
### **User description**
**Context:**
Random DM, Ket, Unitary and Channel rely on settings.SEED. It's more ergonomic to allow setting a local seed.

**Description of the Change:**
This PR introduces an optional `seed` keyword for the `random` methods

**Benefits:**
Can set local seed without affecting the global one

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None, but this was requested by @aplund a while back


___

### **PR Type**
Enhancement


___

### **Description**
- Add optional `seed` parameter to random methods

- Enable local seed control without affecting global RNG

- Add validation for empty modes input

- Comprehensive test coverage for seed functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Global RNG"] --> B["random_symplectic()"]
  C["Local seed"] --> B
  B --> D["DM.random()"]
  B --> E["Ket.random()"]
  B --> F["Unitary.random()"]
  B --> G["Channel.random()"]
  H["Validation"] --> D
  H --> E
  H --> F
  H --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dm.py</strong><dd><code>Add seed parameter to DM random method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mrmustard/lab/states/dm.py

<ul><li>Add optional <code>seed</code> parameter to <code>random()</code> method<br> <li> Pass seed to <code>random_symplectic()</code> call<br> <li> Add validation for empty modes list<br> <li> Update docstring with seed parameter description</ul>


</details>


  </td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/638/files#diff-f9b98b4641c859234fec47a33a027a8fab73e968947677d999bca2c271ee457e">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ket.py</strong><dd><code>Add seed parameter to Ket random method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mrmustard/lab/states/ket.py

<ul><li>Add optional <code>seed</code> parameter to <code>random()</code> method<br> <li> Pass seed to <code>random_symplectic()</code> call<br> <li> Add validation for empty modes list<br> <li> Update docstring with seed parameter description</ul>


</details>


  </td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/638/files#diff-ef0056ee2fe39a989ae0a994e92f211eafaffa1b7867c50f86598acff5bdf902">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>base.py</strong><dd><code>Add seed parameter to Unitary and Channel random methods</code>&nbsp; </dd></summary>
<hr>

mrmustard/lab/transformations/base.py

<ul><li>Add optional <code>seed</code> parameter to <code>Unitary.random()</code> and <code>Channel.random()</code> <br>methods<br> <li> Pass seed through to underlying random generation calls<br> <li> Add validation for empty modes in both methods<br> <li> Update docstrings with seed parameter descriptions</ul>


</details>


  </td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/638/files#diff-9be4c7da501b8fc3d02ec755aaa096a7149cf4ce6ff8c74508d42568145577a1">+10/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>backend_manager.py</strong><dd><code>Add seed support to random symplectic generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mrmustard/math/backend_manager.py

<ul><li>Add optional <code>seed</code> parameter to <code>random_symplectic()</code> method<br> <li> Create local RNG instance when seed provided, otherwise use global<br> <li> Update all random number generation calls to use appropriate RNG<br> <li> Improve docstring with parameter descriptions</ul>


</details>


  </td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/638/files#diff-272a316cdf15707ddb7384f13258135f593fc560e21dc19cf17c16cfb5d0aa1c">+12/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_dm.py</strong><dd><code>Add seed tests for DM random method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_lab/test_states/test_dm.py

<ul><li>Add comprehensive test for seed functionality<br> <li> Test deterministic behavior with same seed<br> <li> Test different outputs with different seeds<br> <li> Test global RNG isolation and empty modes validation</ul>


</details>


  </td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/638/files#diff-92b208e99965a24ee820848f3d43865bc43abc257e7914610c8d2b0a310c51f5">+25/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_ket.py</strong><dd><code>Add seed tests for Ket random method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_lab/test_states/test_ket.py

<ul><li>Add comprehensive test for seed functionality<br> <li> Test deterministic behavior with same seed<br> <li> Test different outputs with different seeds<br> <li> Test global RNG isolation and empty modes validation</ul>


</details>


  </td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/638/files#diff-5869918c4cfc48673f243d14d12565cb45913adc8af694d42a39eddd171a344f">+24/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_transformations_base.py</strong><dd><code>Add seed tests for Unitary and Channel random methods</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_lab/test_transformations/test_transformations_base.py

<ul><li>Add comprehensive tests for seed functionality in both Unitary and <br>Channel<br> <li> Test deterministic behavior with same seed<br> <li> Test different outputs with different seeds<br> <li> Test global RNG isolation and empty modes validation</ul>


</details>


  </td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/638/files#diff-003f186e1823c07091297ad36c3ceae25eef99f2af61b02d6d3e7cceeaee4222">+50/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

