### PR TITLE
Bugfix: DM.expectation Fock shape lookahead

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -27,6 +27,9 @@
 * Fixed a bug in `Optimizer` where complex gradients were the conjugate of the expected.
 [(#617)](https://github.com/XanaduAI/MrMustard/pull/617)
 
+* Fixed a bug in `DM.expectation` where the Fock shape lookahead wasn't setting certain wires correctly.
+[(#639)](https://github.com/XanaduAI/MrMustard/pull/639)
+
 ---
 
 # Release 1.0.0a1

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # Code owners are not automatically requested to review draft pull requests.
 # When you mark a draft pull request as ready for review, code owners are automatically notified.
 # If you convert a pull request to a draft, people who are already subscribed to notifications are not automatically unsubscribed.
-# * @XanaduAI/mrmustard-dev-team
+* @XanaduAI/mrmustard-dev-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # Code owners are not automatically requested to review draft pull requests.
 # When you mark a draft pull request as ready for review, code owners are automatically notified.
 # If you convert a pull request to a draft, people who are already subscribed to notifications are not automatically unsubscribed.
-* @XanaduAI/mrmustard-dev-team
+@XanaduAI/mrmustard-dev-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # Code owners are not automatically requested to review draft pull requests.
 # When you mark a draft pull request as ready for review, code owners are automatically notified.
 # If you convert a pull request to a draft, people who are already subscribed to notifications are not automatically unsubscribed.
-@XanaduAI/mrmustard-dev-team
+# * @XanaduAI/mrmustard-dev-team

--- a/mrmustard/lab/circuit_components.py
+++ b/mrmustard/lab/circuit_components.py
@@ -711,7 +711,7 @@ class CircuitComponent:
         batch_dims = self.ansatz.batch_dims - 1 if self.ansatz._lin_sup else self.ansatz.batch_dims
         fock = ArrayAnsatz(self.fock_array(shape), batch_dims=batch_dims)
         try:
-            if self.ansatz.num_derived_vars == 0:
+            if self.ansatz.num_derived_vars == 0 and not self.ansatz._lin_sup:
                 fock._original_abc_data = self.ansatz.triple
         except AttributeError:
             fock._original_abc_data = None

--- a/mrmustard/lab/states/dm.py
+++ b/mrmustard/lab/states/dm.py
@@ -306,22 +306,17 @@ class DM(State):
         elif op_type is OperatorType.DM_LIKE:
             result = self.contract(operator.dual, mode=mode) >> TraceOut(leftover_modes)
         else:
-            if type(self.ansatz) is not type(operator.ansatz):
-                if settings.DEFAULT_REPRESENTATION == "Bargmann":
-                    self_rep = self.to_bargmann()
-                    other_rep = operator.to_bargmann()
-                else:
-                    # custom shape handling from contract
-                    # since input and output wires are contracted
-                    # to do the trace out
-                    self_shapes = list(self.auto_shape())
-                    other_shapes = list(operator.auto_shape())
-                    for idx, (self_shape, other_shape) in enumerate(zip(self_shapes, other_shapes)):
-                        max_shape = max(self_shape, other_shape)
-                        self_shapes[idx] = max_shape
-                        other_shapes[idx] = max_shape
-                    self_rep = self.to_fock(tuple(self_shapes))
-                    other_rep = operator.to_fock(tuple(other_shapes))
+            if type(self.ansatz) is not type(operator.ansatz) and (
+                isinstance(self.ansatz, ArrayAnsatz) or isinstance(operator.ansatz, ArrayAnsatz)
+            ):
+                self_shapes = list(self.auto_shape())
+                other_shapes = list(operator.auto_shape())
+                for idx, (self_shape, other_shape) in enumerate(zip(self_shapes, other_shapes)):
+                    max_shape = max(self_shape, other_shape)
+                    self_shapes[idx] = max_shape
+                    other_shapes[idx] = max_shape
+                self_rep = self.to_fock(tuple(self_shapes))
+                other_rep = operator.to_fock(tuple(other_shapes))
             else:
                 self_rep = self
                 other_rep = operator

--- a/mrmustard/lab/states/dm.py
+++ b/mrmustard/lab/states/dm.py
@@ -306,8 +306,9 @@ class DM(State):
         elif op_type is OperatorType.DM_LIKE:
             result = self.contract(operator.dual, mode=mode) >> TraceOut(leftover_modes)
         else:
-            if type(self.ansatz) is not type(operator.ansatz) and (
-                isinstance(self.ansatz, ArrayAnsatz) or isinstance(operator.ansatz, ArrayAnsatz)
+            if (
+                type(self.ansatz) is not type(operator.ansatz)
+                and settings.DEFAULT_REPRESENTATION == "Fock"
             ):
                 self_shapes = list(self.auto_shape())
                 other_shapes = list(operator.auto_shape())

--- a/mrmustard/lab/states/dm.py
+++ b/mrmustard/lab/states/dm.py
@@ -313,14 +313,15 @@ class DM(State):
                 type(self.ansatz) is not type(operator.ansatz)
                 and settings.DEFAULT_REPRESENTATION == "Fock"
             ):
-                self_shapes = list(self.auto_shape())
-                other_shapes = list(operator.auto_shape())
-                for idx, (self_shape, other_shape) in enumerate(zip(self_shapes, other_shapes)):
-                    max_shape = max(self_shape, other_shape)
-                    self_shapes[idx] = max_shape
-                    other_shapes[idx] = max_shape
-                self_rep = self.to_fock(tuple(self_shapes))
-                other_rep = operator.to_fock(tuple(other_shapes))
+                self_shape = list(self.auto_shape())
+                other_shape = list(operator.auto_shape())
+                for m in self.modes:
+                    for idx1, idx2 in zip(self.wires[m].indices, operator.wires[m].indices):
+                        max_shape = max(self_shape[idx1], other_shape[idx2])
+                        self_shape[idx1] = max_shape
+                        other_shape[idx2] = max_shape
+                self_rep = self.to_fock(tuple(self_shape))
+                other_rep = operator.to_fock(tuple(other_shape))
             else:
                 self_rep = self
                 other_rep = operator

--- a/mrmustard/lab/states/dm.py
+++ b/mrmustard/lab/states/dm.py
@@ -315,7 +315,9 @@ class DM(State):
             ):
                 self_shape = list(self.auto_shape())
                 other_shape = list(operator.auto_shape())
-                for m in self.modes:
+                # want to make sure that only the operator modes use shape lookahead
+                # for efficiency
+                for m in operator.modes:
                     for idx1, idx2 in zip(self.wires[m].indices, operator.wires[m].indices):
                         max_shape = max(self_shape[idx1], other_shape[idx2])
                         self_shape[idx1] = max_shape

--- a/mrmustard/lab/states/dm.py
+++ b/mrmustard/lab/states/dm.py
@@ -306,6 +306,9 @@ class DM(State):
         elif op_type is OperatorType.DM_LIKE:
             result = self.contract(operator.dual, mode=mode) >> TraceOut(leftover_modes)
         else:
+            # custom shape handling from contract
+            # since input and output wires are contracted
+            # to do the trace out
             if (
                 type(self.ansatz) is not type(operator.ansatz)
                 and settings.DEFAULT_REPRESENTATION == "Fock"

--- a/mrmustard/lab/states/dm.py
+++ b/mrmustard/lab/states/dm.py
@@ -306,7 +306,26 @@ class DM(State):
         elif op_type is OperatorType.DM_LIKE:
             result = self.contract(operator.dual, mode=mode) >> TraceOut(leftover_modes)
         else:
-            result = (self.contract(operator, mode=mode)) >> TraceOut(self.modes)
+            if type(self.ansatz) is not type(operator.ansatz):
+                if settings.DEFAULT_REPRESENTATION == "Bargmann":
+                    self_rep = self.to_bargmann()
+                    other_rep = operator.to_bargmann()
+                else:
+                    # custom shape handling from contract
+                    # since input and output wires are contracted
+                    # to do the trace out
+                    self_shapes = list(self.auto_shape())
+                    other_shapes = list(operator.auto_shape())
+                    for idx, (self_shape, other_shape) in enumerate(zip(self_shapes, other_shapes)):
+                        max_shape = max(self_shape, other_shape)
+                        self_shapes[idx] = max_shape
+                        other_shapes[idx] = max_shape
+                    self_rep = self.to_fock(tuple(self_shapes))
+                    other_rep = operator.to_fock(tuple(other_shapes))
+            else:
+                self_rep = self
+                other_rep = operator
+            result = (self_rep.contract(other_rep, mode=mode)) >> TraceOut(self.modes)
 
         return result
 

--- a/tests/test_lab/test_states/test_dm.py
+++ b/tests/test_lab/test_states/test_dm.py
@@ -440,6 +440,16 @@ class TestDM:
         exp_u0 = dm.expectation(u0)
         assert exp_u0.shape == batch_shape + batch_shape_2
 
+    def test_expectation_shape_handling(self):
+        cutoff = 150
+        fock_dm = DM.random((0,), max_r=2).to_fock(cutoff)
+        dgate = Dgate(0, alpha=0.769j)
+        expectation_default = math.abs(fock_dm.expectation(dgate))
+        expectation_fock = math.abs(fock_dm.expectation(dgate.to_fock(cutoff)))
+        expectation_bargmann = math.abs(fock_dm.to_bargmann().expectation(dgate))
+        assert math.allclose(expectation_default, expectation_fock)
+        assert math.allclose(expectation_default, expectation_bargmann)
+
     def test_expectation_lin_sup(self):
         cat = (Coherent(0, alpha=1 + 2j) + Coherent(0, alpha=-1 + 2j)).normalize()
         cat_dm = cat.dm()


### PR DESCRIPTION
### **User description**
**Context:** Currently, when calling `DM.expectation` on a non-state operator the shape lookahead functionality does not account for the final trace out where the output wires and input wires are contracted. This can lead to cutoff issues and should be fixed. The solution is to duplicate the Fock shape lookahead logic in `CircuitComponent.contract` but instead of only using the shape lookahead for the wires contracted when `contract` is called we do it for all the wires. 

**Description of the Change:** Included logic in the `else` statement of `DM.expectation` to set the max shape for all the wires. Fixed an issue in `to_fock` that would store the `_original_abc_data` for a linear superposition. 

**Benefits:** No more cutoff issues with expectation.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed Fock shape lookahead in `DM.expectation` for non-state operators

- Added proper wire shape handling when contracting different representations

- Fixed `to_fock` method to handle linear superposition correctly

- Added test to verify expectation value consistency across representations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["DM.expectation"] --> B["Shape Lookahead Fix"]
  B --> C["Wire Contraction"]
  C --> D["TraceOut Operation"]
  E["to_fock Method"] --> F["Linear Superposition Fix"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dm.py</strong><dd><code>Enhanced expectation method with proper shape handling</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mrmustard/lab/states/dm.py

<ul><li>Added shape handling logic for different representation types<br> <li> Implemented max shape calculation for input/output wire contraction<br> <li> Fixed expectation calculation for non-state operators</ul>


</details>


  </td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/639/files#diff-f9b98b4641c859234fec47a33a027a8fab73e968947677d999bca2c271ee457e">+20/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>circuit_components.py</strong><dd><code>Fixed to_fock method for linear superposition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mrmustard/lab/circuit_components.py

<ul><li>Added condition to prevent storing <code>_original_abc_data</code> for linear <br>superposition<br> <li> Fixed <code>to_fock</code> method behavior with linear superposition ansatz</ul>


</details>


  </td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/639/files#diff-50ad0b3ea7447752f609ad0622db721dc0edcc60b18acad579967136bdf16c9b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_dm.py</strong><dd><code>Added expectation shape handling test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_lab/test_states/test_dm.py

<ul><li>Added test for expectation shape handling with different <br>representations<br> <li> Verified consistency between Fock, Bargmann, and default expectation <br>values</ul>


</details>


  </td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/639/files#diff-92b208e99965a24ee820848f3d43865bc43abc257e7914610c8d2b0a310c51f5">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Updated changelog for bug fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/CHANGELOG.md

<ul><li>Added changelog entry for DM.expectation Fock shape lookahead bug fix</ul>


</details>


  </td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/639/files#diff-2a22f598a15a364508bc9a475e6ec9df31958a753e9401fabaac8df4db5bd853">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

