### PR TITLE
log(c) for Gaussian integral

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -30,6 +30,9 @@
 * Fixed a bug in `DM.expectation` where the Fock shape lookahead wasn't setting certain wires correctly.
 [(#639)](https://github.com/XanaduAI/MrMustard/pull/639)
 
+* Fixed bug in Gaussian integrals where small/large c values were not multiplying correctly.
+[(#641)](https://github.com/XanaduAI/MrMustard/pull/641)
+
 ---
 
 # Release 1.0.0a1

--- a/mrmustard/physics/ansatz/polyexp_ansatz.py
+++ b/mrmustard/physics/ansatz/polyexp_ansatz.py
@@ -607,7 +607,11 @@ class PolyExpAnsatz(Ansatz):
             raise ValueError(
                 f"All indices must be between 0 and {self.num_CV_vars - 1}. Got {idx_z} and {idx_zconj}.",
             )
-        A, b, c = complex_gaussian_integral_1(self.triple, idx_z, idx_zconj, measure=measure)
+        A_in, b_in, c_in = self.triple
+        log_c_in = math.log(math.cast(c_in, "complex128"))
+        A, b, c = complex_gaussian_integral_1(
+            (A_in, b_in, log_c_in), idx_z, idx_zconj, measure=measure
+        )
         return PolyExpAnsatz(A, b, c, lin_sup=self._lin_sup)
 
     def _combine_exp_and_poly(

--- a/tests/test_lab/test_circuit_components_utils/test_b_to_q.py
+++ b/tests/test_lab/test_circuit_components_utils/test_b_to_q.py
@@ -50,7 +50,7 @@ class TestBtoQ:
         BtoQ_CC1 = BtoQ(modes, 0.0)
         step1A, step1b, step1c = BtoQ_CC1.bargmann_triple()
         Ainter, binter, cinter = complex_gaussian_integral_1(
-            join_Abc((A0, b0, c0), (step1A, step1b, step1c)),
+            join_Abc((A0, b0, c0), (step1A, step1b, step1c), return_log_c=True),
             idx_z=[0, 1],
             idx_zconj=[4, 5],
             measure=-1,
@@ -79,7 +79,7 @@ class TestBtoQ:
         BtoQ_CC1 = BtoQ(modes, 0.0)
         step1A, step1b, step1c = BtoQ_CC1.bargmann_triple()
         Ainter, binter, cinter = complex_gaussian_integral_1(
-            join_Abc((A0, b0, c0), (step1A, step1b, step1c)),
+            join_Abc((A0, b0, c0), (step1A, step1b, step1c), return_log_c=True),
             idx_z=[
                 0,
             ],

--- a/tests/test_lab/test_states/test_coherent.py
+++ b/tests/test_lab/test_states/test_coherent.py
@@ -73,3 +73,9 @@ class TestCoherent:
 
     def test_vacuum_shape(self):
         assert Coherent(0, 0.0).auto_shape() == (1,)
+
+    @pytest.mark.parametrize("alpha", [10 + 10j, 18 + 18j, 25 + 25j])
+    def test_probability(self, alpha):
+        """Tests that highly displaced states are properly normalized."""
+        state = Coherent(mode=0, alpha=alpha)
+        assert math.allclose(state.probability, 1)

--- a/tests/test_lab/test_states/test_displaced_squeezed.py
+++ b/tests/test_lab/test_states/test_displaced_squeezed.py
@@ -62,3 +62,10 @@ class TestDisplacedSqueezed:
             Vacuum(modes) >> Sgate(modes, r, phi).contract(Dgate(modes, alpha), "zip")
         ).ansatz  # TODO: revisit rshift
         assert rep == exp
+
+    @pytest.mark.parametrize("alpha", [10 + 10j, 18 + 18j, 25 + 25j])
+    @pytest.mark.parametrize("r", [0, 1, 2, 3])
+    def test_probability(self, alpha, r):
+        """Tests that highly displaced squeezed states are properly normalized."""
+        state = DisplacedSqueezed(mode=0, alpha=alpha, r=r)
+        assert math.allclose(state.probability, 1)

--- a/tests/test_lab/test_states/test_displaced_squeezed.py
+++ b/tests/test_lab/test_states/test_displaced_squeezed.py
@@ -62,10 +62,3 @@ class TestDisplacedSqueezed:
             Vacuum(modes) >> Sgate(modes, r, phi).contract(Dgate(modes, alpha), "zip")
         ).ansatz  # TODO: revisit rshift
         assert rep == exp
-
-    @pytest.mark.parametrize("alpha", [10 + 10j, 18 + 18j, 25 + 25j])
-    @pytest.mark.parametrize("r", [0, 1, 2, 3])
-    def test_probability(self, alpha, r):
-        """Tests that highly displaced squeezed states are properly normalized."""
-        state = DisplacedSqueezed(mode=0, alpha=alpha, r=r)
-        assert math.allclose(state.probability, 1)

--- a/tests/test_physics/test_ansatz/test_polyexp_ansatz.py
+++ b/tests/test_physics/test_ansatz/test_polyexp_ansatz.py
@@ -407,7 +407,9 @@ class TestPolyExpAnsatz:
     def test_trace(self):
         triple = Abc_triple(4)
         bargmann = PolyExpAnsatz(*triple).trace([0], [2])
-        A, b, c = complex_gaussian_integral_1(triple, [0], [2])
+        A, b, c = complex_gaussian_integral_1(
+            (triple[0], triple[1], math.log(math.cast(triple[2], "complex128"))), [0], [2]
+        )
 
         assert math.allclose(bargmann.A, A)
         assert math.allclose(bargmann.b, b)


### PR DESCRIPTION
### **User description**
**Context:** Sometimes the Gaussian integral functions produced incorrect results because the c values being multiplied together consisted of very small and very large numbers.

**Description of the Change:** Uses logarithms of c values to ensure more stability. This required adding the option for joinAbc to return the logarithm of c directly. Tests are updated accordingly.

**Benefits:** Stable Gaussian integrals.

**Possible Drawbacks:** None as far as I know.

**Related GitHub Issues:**


___

### **PR Type**
Enhancement


___

### **Description**
- Improved numerical stability for Gaussian integrals using logarithms

- Added `return_log_c` parameter to `join_Abc` function

- Updated integration functions to handle log coefficients

- Added tests for highly displaced squeezed states normalization


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["join_Abc function"] -- "adds return_log_c parameter" --> B["log coefficient handling"]
  B -- "passes to" --> C["complex_gaussian_integral_1"]
  C -- "uses log arithmetic" --> D["stable computation"]
  D -- "enables" --> E["normalized displaced states"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gaussian_integrals.py</strong><dd><code>Core Gaussian integral logarithmic coefficient implementation</code></dd></summary>
<hr>

mrmustard/physics/gaussian_integrals.py

<ul><li>Added <code>return_log_c</code> parameter to <code>join_Abc</code> function<br> <li> Modified coefficient computation to use logarithms<br> <li> Updated integration functions to accept log coefficients<br> <li> Changed function signatures to handle <code>log_c</code> instead of <code>c</code></ul>


</details>


  </td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/641/files#diff-a7b779ea109bae98fb3be0cb7ed5f6dba566d967f72666d24fbd01015f7962dc">+26/-22</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>polyexp_ansatz.py</strong><dd><code>Updated ansatz trace method for log coefficients</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mrmustard/physics/ansatz/polyexp_ansatz.py

<ul><li>Modified <code>trace</code> method to compute log of coefficient<br> <li> Updated call to <code>complex_gaussian_integral_1</code> with log coefficient</ul>


</details>


  </td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/641/files#diff-7c01e9c60d2d4a82b42f83c1e79989674c8a3a4a215091a23cfbfb7b4feca1c9">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_gaussian_integrals.py</strong><dd><code>Enhanced tests for logarithmic coefficient functionality</code>&nbsp; </dd></summary>
<hr>

tests/test_physics/test_gaussian_integrals.py

<ul><li>Added parametrized tests for <code>return_log_c</code> parameter<br> <li> Updated test calls to use log coefficients where needed<br> <li> Added assertions for both log and regular coefficient modes</ul>


</details>


  </td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/641/files#diff-f64960aa126fc9053f056b46e568e9a1cd22ccb908dbccad294f7d67a1fbbb1b">+29/-14</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_displaced_squeezed.py</strong><dd><code>Added normalization tests for displaced squeezed states</code>&nbsp; &nbsp; </dd></summary>
<hr>

tests/test_lab/test_states/test_displaced_squeezed.py

<ul><li>Added new test for probability normalization<br> <li> Tests highly displaced squeezed states with large parameters</ul>


</details>


  </td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/641/files#diff-165ef1da79743134a0a62ca2a50fa2ac888a5c6178fc72b6829c0612d06e7aef">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_polyexp_ansatz.py</strong><dd><code>Updated ansatz test for log coefficient usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_physics/test_ansatz/test_polyexp_ansatz.py

- Updated `test_trace` to use log coefficient in function call


</details>


  </td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/641/files#diff-921ac6091261c146640c3b3df644134e8872df68078997207977cb7f4231f158">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_b_to_q.py</strong><dd><code>Updated BtoQ tests for log coefficient parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_lab/test_circuit_components_utils/test_b_to_q.py

- Updated calls to `join_Abc` with `return_log_c=True` parameter


</details>


  </td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/641/files#diff-034dfd11764f85c16e8f21392e2ce9181dc26f97aba39a463b5f3e4a7a453ca9">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

