### PR TITLE
Making `CircuitComponent.fock_array` more memory efficient for scalar c

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -42,6 +42,9 @@
 * Fixed a bug with `State.fock_distribution` where batch dimensions and mult-mode states were not handled correctly.
 [(#635)](https://github.com/XanaduAI/MrMustard/pull/635)
 
+* Fixed a bug where `CircuitComponent.fock_array` was not passing `c` directly into `math.hermite_renormalize` for `num_derived_vars=0`. 
+[(#643)](https://github.com/XanaduAI/MrMustard/pull/643)
+
 ---
 
 # Release 1.0.0a1

--- a/mrmustard/lab/circuit_components.py
+++ b/mrmustard/lab/circuit_components.py
@@ -505,6 +505,7 @@ class CircuitComponent:
         shape = self._check_fock_shape(shape)
         try:
             A, b, c = self.ansatz.triple
+            # TODO: make hermite_renormalized work with num_derived_vars > 0 in sc-97587
             if self.ansatz.num_derived_vars == 0:
                 ret = math.hermite_renormalized(
                     A,

--- a/mrmustard/lab/circuit_components.py
+++ b/mrmustard/lab/circuit_components.py
@@ -505,18 +505,26 @@ class CircuitComponent:
         shape = self._check_fock_shape(shape)
         try:
             A, b, c = self.ansatz.triple
-            G = math.hermite_renormalized(
-                A,
-                b,
-                math.ones(self.ansatz.batch_shape, dtype=math.complex128),
-                shape=shape + self.ansatz.shape_derived_vars,
-            )
-            G = math.reshape(G, self.ansatz.batch_shape + shape + (-1,))
-            cs = math.reshape(c, (*self.ansatz.batch_shape, -1))
-            core_str = "".join(
-                [chr(i) for i in range(97, 97 + len(G.shape[self.ansatz.batch_dims :]))],
-            )
-            ret = math.einsum(f"...{core_str},...{core_str[-1]}->...{core_str[:-1]}", G, cs)
+            if self.ansatz.num_derived_vars == 0:
+                ret = math.hermite_renormalized(
+                    A,
+                    b,
+                    c,
+                    shape=shape,
+                )
+            else:
+                G = math.hermite_renormalized(
+                    A,
+                    b,
+                    math.ones(self.ansatz.batch_shape, dtype=math.complex128),
+                    shape=shape + self.ansatz.shape_derived_vars,
+                )
+                G = math.reshape(G, self.ansatz.batch_shape + shape + (-1,))
+                cs = math.reshape(c, (*self.ansatz.batch_shape, -1))
+                core_str = "".join(
+                    [chr(i) for i in range(97, 97 + len(G.shape[self.ansatz.batch_dims :]))],
+                )
+                ret = math.einsum(f"...{core_str},...{core_str[-1]}->...{core_str[:-1]}", G, cs)
             if self.ansatz._lin_sup:
                 ret = math.sum(ret, axis=self.ansatz.batch_dims - 1)
         except AttributeError:


### PR DESCRIPTION
### **User description**
**Context:** Currently, `CircuitComponent.fock_array` calls `math.hermite_renormalize` with `c=math.ones` and uses `math.einsum` to handle the c of the `(A,b,c)` triple. This is because `hermite_renormalize` does not natively handle polynomial cs. However, this leads to unexpected memory usage where the expected peak memory doubles in the `einsum` call. To fix this we need to have `hermite_renormalize` natively handle polynomial cs. However, `hermite_renormalize` does already handle the scalar c case and we should be making use of it for some added memory efficiency. 

**Description of the Change:** Added logic to `CircuitComponent.fock_array` to pass c directly into `math.hermite_renormalize` when `num_derived_vars == 0`. 

**Benefits:** Memory efficient for scalar c


___

### **PR Type**
Enhancement


___

### **Description**
- Optimize memory usage for scalar c in `CircuitComponent.fock_array`

- Add conditional logic to pass c directly to `hermite_renormalized`

- Maintain backward compatibility for polynomial c cases

- Update changelog with bug fix entry


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Check num_derived_vars"] --> B["num_derived_vars == 0"]
  A --> C["num_derived_vars > 0"]
  B --> D["Pass c directly to hermite_renormalized"]
  C --> E["Use existing einsum approach"]
  D --> F["Memory optimized result"]
  E --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>circuit_components.py</strong><dd><code>Optimize fock_array memory usage for scalar c</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mrmustard/lab/circuit_components.py

<ul><li>Added conditional logic to check <code>num_derived_vars == 0</code><br> <li> Pass <code>c</code> directly to <code>hermite_renormalized</code> for scalar case<br> <li> Preserve existing einsum logic for polynomial c cases<br> <li> Added TODO comment for future enhancement</ul>


</details>


  </td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/643/files#diff-50ad0b3ea7447752f609ad0622db721dc0edcc60b18acad579967136bdf16c9b">+21/-12</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Update changelog with fock_array optimization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/CHANGELOG.md

<ul><li>Added changelog entry for the bug fix<br> <li> Referenced PR #643 in the changelog</ul>


</details>


  </td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/643/files#diff-2a22f598a15a364508bc9a475e6ec9df31958a753e9401fabaac8df4db5bd853">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

