### PR TITLE
Batched displacement in fock

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -48,7 +48,6 @@
 * Fixed a bug where `CircuitComponent.fock_array` was not passing `c` directly into `math.hermite_renormalize` for `num_derived_vars=0`. 
 [(#643)](https://github.com/XanaduAI/MrMustard/pull/643)
 
-
 ---
 
 # Release 1.0.0a1

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -28,6 +28,9 @@
 * Added support for Python 3.13.
 [(#640)](https://github.com/XanaduAI/MrMustard/pull/640)
 
+* Added the ability to compute batched fock arrays of displacements.
+[(#645)](https://github.com/XanaduAI/MrMustard/pull/645)
+
 ### Bug fixes
 
 * Fixed a bug in `OptimizerJax` that would make the optimizer think it reached a stable optimum upon repeat calls to `minimize`.
@@ -44,6 +47,7 @@
 
 * Fixed a bug where `CircuitComponent.fock_array` was not passing `c` directly into `math.hermite_renormalize` for `num_derived_vars=0`. 
 [(#643)](https://github.com/XanaduAI/MrMustard/pull/643)
+
 
 ---
 

--- a/mrmustard/lab/transformations/dgate.py
+++ b/mrmustard/lab/transformations/dgate.py
@@ -108,13 +108,4 @@ class Dgate(Unitary):
             ValueError: If the shape is not valid for the component.
         """
         shape = self._check_fock_shape(shape)
-        if self.ansatz.batch_shape:
-            alpha = self.parameters.alpha.value
-            alpha = math.reshape(alpha, (-1,))
-            ret = math.astensor([math.displacement(alpha_i, shape=shape) for alpha_i in alpha])
-            ret = math.reshape(ret, self.ansatz.batch_shape + shape)
-            if self.ansatz._lin_sup:
-                ret = math.sum(ret, axis=self.ansatz.batch_dims - 1)
-        else:
-            ret = math.displacement(self.parameters.alpha.value, shape=shape)
-        return ret
+        return math.displacement(self.parameters.alpha.value, shape=shape)

--- a/mrmustard/lab/transformations/dgate.py
+++ b/mrmustard/lab/transformations/dgate.py
@@ -108,4 +108,7 @@ class Dgate(Unitary):
             ValueError: If the shape is not valid for the component.
         """
         shape = self._check_fock_shape(shape)
-        return math.displacement(self.parameters.alpha.value, shape=shape)
+        ret = math.displacement(self.parameters.alpha.value, shape=shape)
+        if self.ansatz._lin_sup:
+            ret = math.sum(ret, axis=self.ansatz.batch_dims - 1)
+        return ret

--- a/mrmustard/math/backend_numpy.py
+++ b/mrmustard/math/backend_numpy.py
@@ -459,8 +459,8 @@ class BackendNumpy(BackendBase):
     # ~~~~~~~~~~~~~~~~~~~~~~~
 
     def displacement(self, alpha: complex, shape: tuple[int, int], tol: float):
-        if self.abs(alpha) > tol:
-            gate = strategies.displacement(tuple(shape), complex(alpha))
+        if np.max(self.abs(alpha)) > tol:
+            gate = strategies.displacement(tuple(shape), self.cast(alpha, dtype=self.complex128))
         else:
             gate = self.eye(max(shape), dtype=self.complex128)[: shape[0], : shape[1]]
         return self.astensor(gate, dtype=self.complex128)

--- a/mrmustard/math/lattice/strategies/displacement.py
+++ b/mrmustard/math/lattice/strategies/displacement.py
@@ -36,7 +36,7 @@ def displacement(cutoffs, alpha, dtype=np.complex128):  # pragma: no cover
     alpha = np.asarray(alpha, dtype=dtype)
     batch_shape = alpha.shape
     r = np.abs(alpha)
-    phi = np.angle(alpha)
+    phi = np.log(alpha / r) / 1j
     N, M = cutoffs
     flipped = False
     if N < M:

--- a/tests/test_math/test_lattice/test_lattice_functions.py
+++ b/tests/test_math/test_lattice/test_lattice_functions.py
@@ -147,3 +147,12 @@ def test_vanilla_stable():
         )
         sgate = Sgate(0, r=4.0, phi=2.0).fock_array([1000, 1000])
         assert np.max(np.abs(sgate)) < 1
+
+
+def test_batched_displacement():
+    """Tests the batched displacement against multiple calls to displacement"""
+    alphas = np.array([0.1 + 0.2j, 1.0 + 1.0j, 2.0 + 2.0j])
+    D_batched = displacement((5, 5), alphas)
+    for i in range(len(alphas)):
+        D_single = displacement((5, 5), alphas[i])
+        assert np.allclose(D_batched[i, :, :], D_single)


### PR DESCRIPTION
**Context:**
Currently the ``Dgate``'s ``fock_array`` does not have batched implementation (it's does a for loop)

**Description of the Change:**
The `displacement` function of `math` is batched. (I have not batched the gradients yet.)

**Benefits:**
Faster MM

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None