### PR TITLE
Bugfix: Ket.expectation Fock shape lookahead

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -42,8 +42,11 @@
 * Fixed a bug with `State.fock_distribution` where batch dimensions and mult-mode states were not handled correctly.
 [(#635)](https://github.com/XanaduAI/MrMustard/pull/635)
 
-* Fixed a bug where `CircuitComponent.fock_array` was not passing `c` directly into `math.hermite_renormalize` for `num_derived_vars=0`. 
+* Fixed a bug where `CircuitComponent.fock_array` was not passing `c` directly into `math.hermite_renormalize` for `num_derived_vars=0`.
 [(#643)](https://github.com/XanaduAI/MrMustard/pull/643)
+
+* Fixed a bug in `Ket.expectation` where the Fock shape lookahead wasn't setting certain wires correctly.
+[(#646)](https://github.com/XanaduAI/MrMustard/pull/646)
 
 ---
 

--- a/mrmustard/lab/states/base.py
+++ b/mrmustard/lab/states/base.py
@@ -84,7 +84,7 @@ def _validate_operator(operator: CircuitComponent) -> tuple[OperatorType, str]:
         return OperatorType.DM_LIKE, ""
 
     # check if operator is unitary-like
-    if w.ket.input and w.ket.output and not w.bra.input and not w.bra.input:
+    if w.ket.input and w.ket.output and not w.bra:
         if w.ket.input.modes != w.ket.output.modes:
             msg = "Found unitary-like operator with different modes for input and output wires."
             return OperatorType.INVALID_TYPE, msg

--- a/mrmustard/lab/states/dm.py
+++ b/mrmustard/lab/states/dm.py
@@ -292,13 +292,34 @@ class DM(State):
             raise ValueError(msg)
 
         leftover_modes = self.wires.modes - operator.wires.modes
+        # custom shape handling from contract
+        # since input and output wires are contracted
+        # to do the trace out
+        if (
+            type(self.ansatz) is not type(operator.ansatz)
+            and settings.DEFAULT_REPRESENTATION == "Fock"
+        ):
+            self_shape = list(self.auto_shape())
+            other_shape = list(operator.auto_shape())
+            # want to make sure that only the operator modes use shape lookahead
+            # for efficiency
+            for m in operator.modes:
+                for idx1, idx2 in zip(self.wires[m].indices, operator.wires[m].indices):
+                    max_shape = max(self_shape[idx1], other_shape[idx2])
+                    self_shape[idx1] = max_shape
+                    other_shape[idx2] = max_shape
+            self_rep = self.to_fock(tuple(self_shape))
+            other_rep = operator.to_fock(tuple(other_shape))
+        else:
+            self_rep = self
+            other_rep = operator
         if op_type is OperatorType.KET_LIKE:
             # if mode is not zip we need to generate a new eins_str for the second contraction
             if mode != "zip":
                 eins_str = (
                     outer_product_batch_str(
-                        self.ansatz.batch_dims - self.ansatz._lin_sup,
-                        operator.ansatz.batch_dims - operator.ansatz._lin_sup,
+                        self_rep.ansatz.batch_dims - self_rep.ansatz._lin_sup,
+                        other_rep.ansatz.batch_dims - other_rep.ansatz._lin_sup,
                     )
                     if mode == "kron"
                     else mode
@@ -309,35 +330,14 @@ class DM(State):
             else:
                 eins_str = mode
                 eins_str2 = mode
-            result = self.contract(operator.dual.adjoint, mode=eins_str).contract(
-                operator.dual,
+            result = self_rep.contract(other_rep.dual.adjoint, mode=eins_str).contract(
+                other_rep.dual,
                 mode=eins_str2,
             ) >> TraceOut(leftover_modes)
         elif op_type is OperatorType.DM_LIKE:
-            result = self.contract(operator.dual, mode=mode) >> TraceOut(leftover_modes)
+            result = self_rep.contract(other_rep.dual, mode=mode) >> TraceOut(leftover_modes)
         else:
-            # custom shape handling from contract
-            # since input and output wires are contracted
-            # to do the trace out
-            if (
-                type(self.ansatz) is not type(operator.ansatz)
-                and settings.DEFAULT_REPRESENTATION == "Fock"
-            ):
-                self_shape = list(self.auto_shape())
-                other_shape = list(operator.auto_shape())
-                # want to make sure that only the operator modes use shape lookahead
-                # for efficiency
-                for m in operator.modes:
-                    for idx1, idx2 in zip(self.wires[m].indices, operator.wires[m].indices):
-                        max_shape = max(self_shape[idx1], other_shape[idx2])
-                        self_shape[idx1] = max_shape
-                        other_shape[idx2] = max_shape
-                self_rep = self.to_fock(tuple(self_shape))
-                other_rep = operator.to_fock(tuple(other_shape))
-            else:
-                self_rep = self
-                other_rep = operator
-            result = (self_rep.contract(other_rep, mode=mode)) >> TraceOut(self.modes)
+            result = (self_rep.contract(other_rep, mode=mode)) >> TraceOut(self_rep.modes)
 
         return result
 

--- a/mrmustard/lab/states/dm.py
+++ b/mrmustard/lab/states/dm.py
@@ -300,26 +300,26 @@ class DM(State):
             and settings.DEFAULT_REPRESENTATION == "Fock"
         ):
             self_shape = list(self.auto_shape())
-            other_shape = list(operator.auto_shape())
+            operator_shape = list(operator.auto_shape())
             # want to make sure that only the operator modes use shape lookahead
             # for efficiency
             for m in operator.modes:
                 for idx1, idx2 in zip(self.wires[m].indices, operator.wires[m].indices):
-                    max_shape = max(self_shape[idx1], other_shape[idx2])
+                    max_shape = max(self_shape[idx1], operator_shape[idx2])
                     self_shape[idx1] = max_shape
-                    other_shape[idx2] = max_shape
+                    operator_shape[idx2] = max_shape
             self_rep = self.to_fock(tuple(self_shape))
-            other_rep = operator.to_fock(tuple(other_shape))
+            operator_rep = operator.to_fock(tuple(operator_shape))
         else:
             self_rep = self
-            other_rep = operator
+            operator_rep = operator
         if op_type is OperatorType.KET_LIKE:
             # if mode is not zip we need to generate a new eins_str for the second contraction
             if mode != "zip":
                 eins_str = (
                     outer_product_batch_str(
                         self_rep.ansatz.batch_dims - self_rep.ansatz._lin_sup,
-                        other_rep.ansatz.batch_dims - other_rep.ansatz._lin_sup,
+                        operator_rep.ansatz.batch_dims - operator_rep.ansatz._lin_sup,
                     )
                     if mode == "kron"
                     else mode
@@ -330,14 +330,14 @@ class DM(State):
             else:
                 eins_str = mode
                 eins_str2 = mode
-            result = self_rep.contract(other_rep.dual.adjoint, mode=eins_str).contract(
-                other_rep.dual,
+            result = self_rep.contract(operator_rep.dual.adjoint, mode=eins_str).contract(
+                operator_rep.dual,
                 mode=eins_str2,
             ) >> TraceOut(leftover_modes)
         elif op_type is OperatorType.DM_LIKE:
-            result = self_rep.contract(other_rep.dual, mode=mode) >> TraceOut(leftover_modes)
+            result = self_rep.contract(operator_rep.dual, mode=mode) >> TraceOut(leftover_modes)
         else:
-            result = (self_rep.contract(other_rep, mode=mode)) >> TraceOut(self_rep.modes)
+            result = (self_rep.contract(operator_rep, mode=mode)) >> TraceOut(self_rep.modes)
 
         return result
 

--- a/mrmustard/lab/states/ket.py
+++ b/mrmustard/lab/states/ket.py
@@ -311,11 +311,10 @@ class Ket(State):
                 # want to make sure that only the operator modes use shape lookahead
                 # for efficiency
                 for m in operator.modes:
-                    for idx1 in self.wires[m].indices:
-                        for idx2 in operator.wires[m].indices:
-                            max_shape = max(self_shape[idx1], other_shape[idx2])
-                            self_shape[idx1] = max_shape
-                            other_shape[idx2] = max_shape
+                    for idx in operator.wires[m].indices:
+                        max_shape = max(self_shape[idx], other_shape[idx])
+                        self_shape[idx] = max_shape
+                        other_shape[idx] = max_shape
                 self_rep = self.to_fock(tuple(self_shape))
                 other_rep = operator.to_fock(tuple(other_shape))
             else:

--- a/mrmustard/lab/states/ket.py
+++ b/mrmustard/lab/states/ket.py
@@ -295,30 +295,32 @@ class Ket(State):
             and settings.DEFAULT_REPRESENTATION == "Fock"
         ):
             self_shape = list(self.auto_shape())
-            other_shape = list(operator.auto_shape())
+            operator_shape = list(operator.auto_shape())
             # want to make sure that only the operator modes use shape lookahead
             # for efficiency
             for m in operator.modes:
                 idx1 = self.wires[m].indices[0]
                 for idx2 in operator.wires[m].indices:
-                    max_shape = max(self_shape[idx1], other_shape[idx2])
+                    max_shape = max(self_shape[idx1], operator_shape[idx2])
                     self_shape[idx1] = max_shape
-                    other_shape[idx2] = max_shape
+                    operator_shape[idx2] = max_shape
             self_rep = self.to_fock(tuple(self_shape))
-            other_rep = operator.to_fock(tuple(other_shape))
+            operator_rep = operator.to_fock(tuple(operator_shape))
         else:
             self_rep = self
-            other_rep = operator
+            operator_rep = operator
         if op_type is OperatorType.KET_LIKE:
-            result = self_rep.contract(other_rep.dual, mode=mode)
+            result = self_rep.contract(operator_rep.dual, mode=mode)
             result = result.contract(result.adjoint, mode="zip") >> TraceOut(leftover_modes)
         elif op_type is OperatorType.DM_LIKE:
             result = self_rep.adjoint.contract(
-                self_rep.contract(other_rep.dual, mode=mode),
+                self_rep.contract(operator_rep.dual, mode=mode),
                 mode="zip",
             ) >> TraceOut(leftover_modes)
         else:
-            result = (self_rep.contract(other_rep, mode=mode)).contract(self_rep.dual, mode="zip")
+            result = (self_rep.contract(operator_rep, mode=mode)).contract(
+                self_rep.dual, mode="zip"
+            )
             result = result >> TraceOut(result.modes)
         return result
 

--- a/mrmustard/lab/states/ket.py
+++ b/mrmustard/lab/states/ket.py
@@ -311,10 +311,11 @@ class Ket(State):
                 # want to make sure that only the operator modes use shape lookahead
                 # for efficiency
                 for m in operator.modes:
-                    for idx in operator.wires[m].indices:
-                        max_shape = max(self_shape[idx], other_shape[idx])
-                        self_shape[idx] = max_shape
-                        other_shape[idx] = max_shape
+                    idx1 = self.wires[m].indices[0]
+                    for idx2 in operator.wires[m].indices:
+                        max_shape = max(self_shape[idx1], other_shape[idx2])
+                        self_shape[idx1] = max_shape
+                        other_shape[idx2] = max_shape
                 self_rep = self.to_fock(tuple(self_shape))
                 other_rep = operator.to_fock(tuple(other_shape))
             else:

--- a/tests/test_lab/test_states/test_ket.py
+++ b/tests/test_lab/test_states/test_ket.py
@@ -530,14 +530,30 @@ class TestKet:
             ket.expectation(op3)
 
     def test_expectation_shape_handling(self):
-        cutoff = 150
-        fock_ket = (SqueezedVacuum(0, 1.5) >> SqueezedVacuum(1, 1.5)).to_fock(cutoff)
-        dgate = Dgate(0, alpha=1j)
-        expectation_default = math.abs(fock_ket.expectation(dgate))
-        expectation_fock = math.abs(fock_ket.expectation(dgate.to_fock(cutoff)))
-        expectation_bargmann = math.abs(fock_ket.to_bargmann().expectation(dgate))
-        assert math.allclose(expectation_default, expectation_fock)
-        assert math.allclose(expectation_default, expectation_bargmann)
+        cutoff = 200
+        ket = SqueezedVacuum(0, 1.5)
+
+        dm_like = DM.random((0,), max_r=10)
+        expectation_barg_fock = math.abs(ket.to_bargmann().expectation(dm_like.to_fock(cutoff)))
+        expectation_fock_barg = math.abs(ket.to_fock(cutoff).expectation(dm_like.to_bargmann()))
+        expectation_fock_fock = math.abs(ket.to_fock(cutoff).expectation(dm_like.to_fock(cutoff)))
+
+        assert math.allclose(expectation_fock_fock, expectation_barg_fock)
+        assert math.allclose(expectation_fock_fock, expectation_fock_barg)
+
+        unitary_like = Dgate(0, alpha=5 + 12j)
+        expectation_barg_fock = math.abs(
+            ket.to_bargmann().expectation(unitary_like.to_fock(cutoff))
+        )
+        expectation_fock_barg = math.abs(
+            ket.to_fock(cutoff).expectation(unitary_like.to_bargmann())
+        )
+        expectation_fock_fock = math.abs(
+            ket.to_fock(cutoff).expectation(unitary_like.to_fock(cutoff))
+        )
+
+        assert math.allclose(expectation_fock_fock, expectation_barg_fock)
+        assert math.allclose(expectation_fock_fock, expectation_fock_barg)
 
     def test_rshift(self):
         ket = Coherent(0, 1) >> Coherent(1, 1)

--- a/tests/test_lab/test_states/test_ket.py
+++ b/tests/test_lab/test_states/test_ket.py
@@ -529,6 +529,16 @@ class TestKet:
         with pytest.raises(ValueError, match="Expected an operator defined on"):
             ket.expectation(op3)
 
+    def test_expectation_shape_handling(self):
+        cutoff = 150
+        fock_ket = (SqueezedVacuum(0, 1.5) >> SqueezedVacuum(1, 1.5)).to_fock(cutoff)
+        dgate = Dgate(0, alpha=1j)
+        expectation_default = math.abs(fock_ket.expectation(dgate))
+        expectation_fock = math.abs(fock_ket.expectation(dgate.to_fock(cutoff)))
+        expectation_bargmann = math.abs(fock_ket.to_bargmann().expectation(dgate))
+        assert math.allclose(expectation_default, expectation_fock)
+        assert math.allclose(expectation_default, expectation_bargmann)
+
     def test_rshift(self):
         ket = Coherent(0, 1) >> Coherent(1, 1)
         unitary = Dgate(0, 1)

--- a/tests/test_lab/test_states/test_ket.py
+++ b/tests/test_lab/test_states/test_ket.py
@@ -529,28 +529,14 @@ class TestKet:
         with pytest.raises(ValueError, match="Expected an operator defined on"):
             ket.expectation(op3)
 
-    def test_expectation_shape_handling(self):
+    @pytest.mark.parametrize("operator", [DM.random((0,), max_r=10), Dgate(0, alpha=5 + 12j)])
+    def test_expectation_shape_handling(self, operator):
         cutoff = 200
         ket = SqueezedVacuum(0, 1.5)
 
-        dm_like = DM.random((0,), max_r=10)
-        expectation_barg_fock = math.abs(ket.to_bargmann().expectation(dm_like.to_fock(cutoff)))
-        expectation_fock_barg = math.abs(ket.to_fock(cutoff).expectation(dm_like.to_bargmann()))
-        expectation_fock_fock = math.abs(ket.to_fock(cutoff).expectation(dm_like.to_fock(cutoff)))
-
-        assert math.allclose(expectation_fock_fock, expectation_barg_fock)
-        assert math.allclose(expectation_fock_fock, expectation_fock_barg)
-
-        unitary_like = Dgate(0, alpha=5 + 12j)
-        expectation_barg_fock = math.abs(
-            ket.to_bargmann().expectation(unitary_like.to_fock(cutoff))
-        )
-        expectation_fock_barg = math.abs(
-            ket.to_fock(cutoff).expectation(unitary_like.to_bargmann())
-        )
-        expectation_fock_fock = math.abs(
-            ket.to_fock(cutoff).expectation(unitary_like.to_fock(cutoff))
-        )
+        expectation_barg_fock = math.abs(ket.to_bargmann().expectation(operator.to_fock(cutoff)))
+        expectation_fock_barg = math.abs(ket.to_fock(cutoff).expectation(operator.to_bargmann()))
+        expectation_fock_fock = math.abs(ket.to_fock(cutoff).expectation(operator.to_fock(cutoff)))
 
         assert math.allclose(expectation_fock_fock, expectation_barg_fock)
         assert math.allclose(expectation_fock_fock, expectation_fock_barg)

--- a/tests/test_lab/test_states/test_ket.py
+++ b/tests/test_lab/test_states/test_ket.py
@@ -529,7 +529,11 @@ class TestKet:
         with pytest.raises(ValueError, match="Expected an operator defined on"):
             ket.expectation(op3)
 
-    @pytest.mark.parametrize("operator", [DM.random((0,), max_r=10), Dgate(0, alpha=5 + 12j)])
+    @pytest.mark.parametrize(
+        "operator",
+        [Coherent(0, alpha=5 + 12j).dm(), Dgate(0, alpha=5 + 12j)],
+        ids=["DM_LIKE", "UNITARY_LIKE"],
+    )
     def test_expectation_shape_handling(self, operator):
         cutoff = 200
         ket = SqueezedVacuum(0, 1.5)


### PR DESCRIPTION
### **User description**
**Context:** Currently, when calling `Ket.expectation` on a `UNITARY_LIKE` operator the shape lookahead functionality does not account for the final trace out where the output wires and input wires are contracted. This can lead to cutoff issues and should be fixed. The solution is to duplicate the Fock shape lookahead logic in `CircuitComponent.contract` but instead of only using the shape lookahead for the wires contracted when `contract` is called we do it for all the wires.

**Description of the Change:** Included logic in the `else` statement of `Ket.expectation` to set the max shape for all the wires. Also fixed a typo in `_validate_operator`.

**Benefits:** No more cutoff issues with expectation.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed Fock shape lookahead in `Ket.expectation` for unitary operators

- Added custom shape handling to prevent cutoff issues

- Fixed typo in `_validate_operator` condition check

- Added test to verify shape handling correctness


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Ket.expectation"] --> B["Shape lookahead logic"]
  B --> C["Contract with operator"]
  C --> D["Trace out result"]
  E["_validate_operator"] --> F["Fixed condition check"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base.py</strong><dd><code>Fix validation condition typo</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mrmustard/lab/states/base.py

<ul><li>Fixed typo in <code>_validate_operator</code> unitary-like operator condition<br> <li> Changed <code>not w.bra.input and not w.bra.input</code> to <code>not w.bra</code></ul>


</details>


  </td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/646/files#diff-8c6d5d9ad51a9e46813385d5dc59a3789d590c49b6b8bf535a6aa7b490ce3480">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ket.py</strong><dd><code>Add Fock shape lookahead logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mrmustard/lab/states/ket.py

<ul><li>Added custom Fock shape handling for unitary operators in <code>expectation</code><br> <li> Implemented shape lookahead logic to prevent cutoff issues<br> <li> Added shape synchronization between self and operator representations</ul>


</details>


  </td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/646/files#diff-ef0056ee2fe39a989ae0a994e92f211eafaffa1b7867c50f86598acff5bdf902">+23/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_ket.py</strong><dd><code>Add shape handling test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_lab/test_states/test_ket.py

<ul><li>Added <code>test_expectation_shape_handling</code> test method<br> <li> Verifies expectation values match across different representations<br> <li> Tests with squeezed vacuum states and displacement gates</ul>


</details>


  </td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/646/files#diff-5869918c4cfc48673f243d14d12565cb45913adc8af694d42a39eddd171a344f">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Update changelog entry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/CHANGELOG.md

<ul><li>Added changelog entry for Ket.expectation bug fix<br> <li> Documents fix for Fock shape lookahead wire setting issue</ul>


</details>


  </td>
  <td><a href="https://github.com/XanaduAI/MrMustard/pull/646/files#diff-2a22f598a15a364508bc9a475e6ec9df31958a753e9401fabaac8df4db5bd853">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

