### PR TITLE
Sc 94945 - Port Gaussian Integrals to Numba

### DIFF
--- a/mrmustard/physics/ansatz/polyexp_ansatz.py
+++ b/mrmustard/physics/ansatz/polyexp_ansatz.py
@@ -32,8 +32,8 @@ from mrmustard.physics.fock_utils import c_in_PS
 from mrmustard.physics.gaussian_integrals import (
     complex_gaussian_integral_1,
     complex_gaussian_integral_2,
-    join_Abc,
 )
+from mrmustard.physics.gaussian_integrals_numba import join_Abc_numba
 from mrmustard.physics.utils import generate_batch_str, verify_batch_triple
 from mrmustard.utils.argsort import argsort_gen
 from mrmustard.utils.typing import (
@@ -899,7 +899,7 @@ class PolyExpAnsatz(Ansatz):
         Returns:
             The tensor product of this PolyExpAnsatz and other.
         """
-        As, bs, cs = join_Abc(
+        As, bs, cs = join_Abc_numba(
             self.triple,
             other.triple,
             outer_product_batch_str(

--- a/mrmustard/physics/gaussian_integrals.py
+++ b/mrmustard/physics/gaussian_integrals.py
@@ -285,9 +285,6 @@ def join_Abc(
     c1_broadcasted = math.broadcast_to(c1_reshaped, c1_broadcast_shape, dtype=math.complex128)
     c2_broadcasted = math.broadcast_to(c2_reshaped, c2_broadcast_shape, dtype=math.complex128)
 
-    # Already ported to numba
-    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
     c1_flat_shape = (*output_batch_shape, int(np.prod(poly_shape1)))
     c2_flat_shape = (*output_batch_shape, int(np.prod(poly_shape2)))
     c1_flat = math.reshape(c1_broadcasted, c1_flat_shape)

--- a/mrmustard/physics/gaussian_integrals.py
+++ b/mrmustard/physics/gaussian_integrals.py
@@ -222,12 +222,6 @@ def join_Abc(
     n1 = nA1 - m1
     n2 = nA2 - m2
 
-    # Step 0: Flatten the non-batch dimensions of c1 and c2
-    c1_flat_shape = (*batch1, int(np.prod(poly_shape1)))
-    c2_flat_shape = (*batch2, int(np.prod(poly_shape2)))
-    c1_flat = math.reshape(c1, c1_flat_shape)
-    c2_flat = math.reshape(c2, c2_flat_shape)
-
     # Step 1 & 2: Determine broadcast shape based on batch_string and broadcast tensors
     broadcast_dims = dict(zip(in1, batch1))
     for dim, batch in zip(in2, batch2):
@@ -263,16 +257,16 @@ def join_Abc(
     A2_new_shape = (*tuple(broadcast_shape2), nA2, mA2)
     b1_new_shape = (*tuple(broadcast_shape1), nb1)
     b2_new_shape = (*tuple(broadcast_shape2), nb2)
-    c1_new_shape = (*tuple(broadcast_shape1), c1_flat.shape[-1])
-    c2_new_shape = (*tuple(broadcast_shape2), c2_flat.shape[-1])
+    c1_new_shape = (*tuple(broadcast_shape1), *poly_shape1)
+    c2_new_shape = (*tuple(broadcast_shape2), *poly_shape2)
 
     # Reshape to add broadcasting dimensions
     A1_reshaped = math.reshape(A1, A1_new_shape)
     A2_reshaped = math.reshape(A2, A2_new_shape)
     b1_reshaped = math.reshape(b1, b1_new_shape)
     b2_reshaped = math.reshape(b2, b2_new_shape)
-    c1_reshaped = math.reshape(c1_flat, c1_new_shape)
-    c2_reshaped = math.reshape(c2_flat, c2_new_shape)
+    c1_reshaped = math.reshape(c1, c1_new_shape)
+    c2_reshaped = math.reshape(c2, c2_new_shape)
 
     # Create full output shape for broadcasting
     output_batch_shape = tuple(output_shape)
@@ -280,8 +274,8 @@ def join_Abc(
     A2_broadcast_shape = (*output_batch_shape, nA2, mA2)
     b1_broadcast_shape = (*output_batch_shape, nb1)
     b2_broadcast_shape = (*output_batch_shape, nb2)
-    c1_broadcast_shape = (*output_batch_shape, c1_flat.shape[-1])
-    c2_broadcast_shape = (*output_batch_shape, c2_flat.shape[-1])
+    c1_broadcast_shape = (*output_batch_shape, *poly_shape1)
+    c2_broadcast_shape = (*output_batch_shape, *poly_shape2)
 
     # Step 2: Broadcast tensors to the output shape
     A1_broadcasted = math.broadcast_to(A1_reshaped, A1_broadcast_shape, dtype=math.complex128)
@@ -290,6 +284,14 @@ def join_Abc(
     b2_broadcasted = math.broadcast_to(b2_reshaped, b2_broadcast_shape, dtype=math.complex128)
     c1_broadcasted = math.broadcast_to(c1_reshaped, c1_broadcast_shape, dtype=math.complex128)
     c2_broadcasted = math.broadcast_to(c2_reshaped, c2_broadcast_shape, dtype=math.complex128)
+
+    # Step 0: Flatten the non-batch dimensions of c1 and c2
+    c1_flat_shape = (*output_batch_shape, int(np.prod(poly_shape1)))
+    c2_flat_shape = (*output_batch_shape, int(np.prod(poly_shape2)))
+    c1_flat = math.reshape(c1_broadcasted, c1_flat_shape)
+    c2_flat = math.reshape(c2_broadcasted, c2_flat_shape)
+
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
     # Step 3: Join A1 and A2
     A1Z = math.concat(
@@ -337,8 +339,8 @@ def join_Abc(
     )
 
     # Step 5 & 6: Compute outer product of the last dimensions of c1 and c2
-    c1_expanded = c1_broadcasted[..., :, None]
-    c2_expanded = c2_broadcasted[..., None, :]
+    c1_expanded = c1_flat[..., :, None]
+    c2_expanded = c2_flat[..., None, :]
     c = c1_expanded * c2_expanded
     # Reshape c to the desired output shape
     c_shape = output_batch_shape + poly_shape1 + poly_shape2

--- a/mrmustard/physics/gaussian_integrals.py
+++ b/mrmustard/physics/gaussian_integrals.py
@@ -21,6 +21,7 @@ from collections.abc import Sequence
 import numpy as np
 
 from mrmustard import math
+from mrmustard.physics.gaussian_integrals_numba import join_Abc_numba
 from mrmustard.physics.utils import outer_product_batch_str, verify_batch_triple
 from mrmustard.utils.typing import ComplexMatrix, ComplexTensor, ComplexVector
 
@@ -538,7 +539,16 @@ def complex_gaussian_integral_2(
     Returns:
         The ``(A,b,c)`` triple which parametrizes the result of the integral with batch dimension preserved (if any).
     """
-    A, b, c = join_Abc(Abc1, Abc2, batch_string=batch_string)
+    A1, b1, c1 = Abc1
+    A2, b2, c2 = Abc2
+
+    batch1, batch2 = A1.shape[:-2], A2.shape[:-2]
+    batch_dim1, batch_dim2 = len(batch1), len(batch2)
+
+    if batch_dim1 == 0 and batch_dim2 == 0:
+        A, b, c = join_Abc_numba((A1, b1, c1), (A2, b2, c2))
+    else:
+        A, b, c = join_Abc(Abc1, Abc2, batch_string=batch_string)
 
     # offset idx2 to account for the core variables of the first triple
     A1, _, c1 = Abc1

--- a/mrmustard/physics/gaussian_integrals.py
+++ b/mrmustard/physics/gaussian_integrals.py
@@ -285,13 +285,13 @@ def join_Abc(
     c1_broadcasted = math.broadcast_to(c1_reshaped, c1_broadcast_shape, dtype=math.complex128)
     c2_broadcasted = math.broadcast_to(c2_reshaped, c2_broadcast_shape, dtype=math.complex128)
 
-    # Step 0: Flatten the non-batch dimensions of c1 and c2
+    # Already ported to numba
+    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
     c1_flat_shape = (*output_batch_shape, int(np.prod(poly_shape1)))
     c2_flat_shape = (*output_batch_shape, int(np.prod(poly_shape2)))
     c1_flat = math.reshape(c1_broadcasted, c1_flat_shape)
     c2_flat = math.reshape(c2_broadcasted, c2_flat_shape)
-
-    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
     # Step 3: Join A1 and A2
     A1Z = math.concat(
@@ -544,13 +544,7 @@ def complex_gaussian_integral_2(
     A1, b1, c1 = Abc1
     A2, b2, c2 = Abc2
 
-    batch1, batch2 = A1.shape[:-2], A2.shape[:-2]
-    batch_dim1, batch_dim2 = len(batch1), len(batch2)
-
-    if batch_dim1 == 0 and batch_dim2 == 0:
-        A, b, c = join_Abc_numba((A1, b1, c1), (A2, b2, c2))
-    else:
-        A, b, c = join_Abc(Abc1, Abc2, batch_string=batch_string)
+    A, b, c = join_Abc_numba((A1, b1, c1), (A2, b2, c2), batch_string=batch_string)
 
     # offset idx2 to account for the core variables of the first triple
     A1, _, c1 = Abc1

--- a/mrmustard/physics/gaussian_integrals_numba.py
+++ b/mrmustard/physics/gaussian_integrals_numba.py
@@ -19,6 +19,7 @@ This module contains gaussian integral functions and related helper functions.
 import numpy as np
 from numba import njit
 
+from mrmustard.physics.utils import outer_product_batch_str, verify_batch_triple
 from mrmustard.utils.typing import ComplexMatrix, ComplexTensor, ComplexVector
 
 
@@ -88,19 +89,20 @@ def join_Abc_numba(
     A1, b1, c1 = Abc1
     A2, b2, c2 = Abc2
 
+    verify_batch_triple(A1, b1, c1)
+    verify_batch_triple(A2, b2, c2)
+
+    batch1, batch2 = A1.shape[:-2], A2.shape[:-2]
+
+    if batch_string is None:
+        batch_string = outer_product_batch_str(len(batch1), len(batch2))
+
     A1 = np.array(A1, dtype=np.complex128)
     A2 = np.array(A2, dtype=np.complex128)
     b1 = np.array(b1, dtype=np.complex128)
     b2 = np.array(b2, dtype=np.complex128)
     c1 = np.array(c1, dtype=np.complex128)
     c2 = np.array(c2, dtype=np.complex128)
-
-    # broadcasting to be done here
-    batch1, batch2 = A1.shape[:-2], A2.shape[:-2]
-
-    if batch1 or batch2:
-        raise NotImplementedError("Batching not implemented for numba version")
-
     return _join_Abc_numba((A1, b1, c1), (A2, b2, c2))
 
 

--- a/mrmustard/physics/gaussian_integrals_numba.py
+++ b/mrmustard/physics/gaussian_integrals_numba.py
@@ -86,6 +86,37 @@ def join_Abc_numba(
     Abc2: tuple[ComplexMatrix, ComplexVector, ComplexTensor],
     batch_string: str | None = None,
 ) -> tuple[ComplexMatrix, ComplexVector, ComplexTensor]:
+    r"""
+    Joins two ``(A,b,c)`` triples into a single ``(A,b,c)``.
+
+    It supports arbitrary batch dimensions using an einsum-like string notation.
+    For example:
+    - "i,j->ij" is like a "kron" mode (Kronecker product of batch dimensions)
+    - "i,i->i" is like a "zip" mode (parallel processing of same-sized batches)
+    - "i,j->ij", "ij,ik->ijk", "i,->i" are all valid batch dimension specifications
+
+    The string only refers to the batch dimensions. The core (non-batch) dimensions are handled
+    as follows: the A matrices and b vectors are joined, and the shape of c is the
+    concatenation of the shapes of c1 and c2 (batch excluded).
+
+    Input parameters are expected to have arbitrary batch dimensions, e.g. ``A1.shape = (batch1, n1, n1)``,
+    ``b1.shape = (batch1, n1)``, ``c1.shape = (batch1, *d1)``.
+    The number of non-batch dimensions in ``ci`` (i.e. ``len(di)``) corresponds to the number
+    of rows and columns of ``Ai`` and ``bi`` that are kept last (derived variables).
+    For instance, if ``d1 = (4, 3)`` and ``d2=(7,)``, then the last 2 rows and columns of
+    ``A1`` and ``b1`` and the last 1 row and column of ``A2`` and ``b2`` are kept last in the
+    joined ``A`` and ``b``.
+
+    Arguments:
+        Abc1: The first ``(A,b,c)`` triple
+        Abc2: The second ``(A,b,c)`` triple
+        batch_string: An (optional) einsum-like string in the format "in1,in2->out" that specifies
+            how batch dimensions should be handled. If ``None``, defaults to a kronecker product i.e.
+            "i,j->ij".
+
+    Returns:
+        The joined ``(A,b,c)`` triple
+    """
     A1, b1, c1 = Abc1
     A2, b2, c2 = Abc2
 

--- a/mrmustard/physics/gaussian_integrals_numba.py
+++ b/mrmustard/physics/gaussian_integrals_numba.py
@@ -89,6 +89,7 @@ def join_Abc_numba(
     A1, b1, c1 = Abc1
     A2, b2, c2 = Abc2
 
+    # TODO: numbafy broadcasting
     verify_batch_triple(A1, b1, c1)
     verify_batch_triple(A2, b2, c2)
 

--- a/mrmustard/physics/gaussian_integrals_numba.py
+++ b/mrmustard/physics/gaussian_integrals_numba.py
@@ -1,0 +1,80 @@
+# Copyright 2024 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module contains gaussian integral functions and related helper functions.
+"""
+
+import numpy as np
+from numba import njit
+
+from mrmustard.utils.typing import ComplexMatrix, ComplexTensor, ComplexVector
+
+
+@njit(cache=True)
+def real_gaussian_integral_numba(
+    A: ComplexMatrix,
+    b: ComplexVector,
+    c: ComplexTensor,
+    idx: tuple[int, ...],
+):
+    r"""Computes the Gaussian integral of the exponential of a real quadratic form.
+    The integral is defined as (note that in general we integrate over a subset of `m` dimensions):
+
+    .. :math::
+        \int_{R^m} F(x) dx,
+
+    where
+
+    :math:`F(x) = \textrm{exp}(0.5 x^T A x + b^T x)`
+
+    Here, ``x`` is an ``n``-dim real vector, ``A`` is an ``n x n`` real matrix,
+    ``b`` is an ``n``-dim real vector, ``c`` is a real scalar. The integral indices
+    are specified by ``idx``.
+
+    Arguments:
+        Abc: the ``(A,b,c)`` triple
+        idx: the tuple of indices of the x variables
+
+    Returns:
+        The ``(A,b,c)`` triple of the result of the integral.
+    """
+    idx = np.array(idx, dtype=np.int64)
+    if len(idx) == 0:
+        return A, b, c
+    not_idx = np.array([i for i in range(A.shape[-1]) if i not in idx])
+
+    M = A[..., :, idx][..., idx, :]
+    bM = b[..., idx]
+
+    if not_idx.shape != (0,):
+        D = A[..., idx][..., not_idx, :]
+        R = A[..., not_idx][..., not_idx, :]
+        bR = b[..., not_idx]
+        T = np.transpose
+        L = T(np.linalg.solve(T(M), T(D)))
+        A_post = R - (L @ T(D))
+        b_post = bR - (L @ bM)
+    else:
+        A_post = np.empty((0, 0), dtype=np.complex128)
+        b_post = np.empty((0,), dtype=np.complex128)
+
+    c_post = np.array(
+        c
+        * np.sqrt((2 * np.pi) ** len(idx))
+        * np.sqrt((-1) ** len(idx) / np.linalg.det(M))
+        * np.exp(-0.5 * np.sum(bM * np.linalg.solve(M, bM)))
+    )
+
+    return A_post, b_post, c_post

--- a/mrmustard/physics/gaussian_integrals_numba.py
+++ b/mrmustard/physics/gaussian_integrals_numba.py
@@ -112,14 +112,17 @@ def _join_Abc_numba(
     A1, b1, c1 = Abc1
     A2, b2, c2 = Abc2
 
+    output_batch_shape = ()
+    batch1, batch2 = A1.shape[:-2], A2.shape[:-2]
+
     core1 = A1.shape[-1]
     core2 = A2.shape[-1]
 
     poly_shape1 = c1.shape[0:]
     poly_shape2 = c2.shape[0:]
 
-    c1_flat_shape = (int(np.prod(np.array(poly_shape1))),)
-    c2_flat_shape = (int(np.prod(np.array(poly_shape2))),)
+    c1_flat_shape = (*batch1, int(np.prod(np.array(poly_shape1))))
+    c2_flat_shape = (*batch2, int(np.prod(np.array(poly_shape2))))
     c1_flat = np.reshape(c1, c1_flat_shape)
     c2_flat = np.reshape(c2, c2_flat_shape)
 
@@ -129,32 +132,32 @@ def _join_Abc_numba(
     n2 = core2 - m2
 
     # Create a joint A1 and A2 array
-    joint_A = np.zeros((core1 + core2, core1 + core2), dtype=np.complex128)
-    joint_A[:core1, :core1] = A1
-    joint_A[core1:, core1:] = A2
+    joint_A = np.zeros((*output_batch_shape, core1 + core2, core1 + core2), dtype=np.complex128)
+    joint_A[..., :core1, :core1] = A1
+    joint_A[..., core1:, core1:] = A2
 
     # Reorder the rows to group core and derived variables
-    rows_A = np.empty((core1 + core2, core1 + core2), dtype=np.complex128)
-    rows_A[:n1, :] = joint_A[:n1, :]
-    rows_A[n1 : (n1 + n2), :] = joint_A[core1 : core1 + n2, :]
-    rows_A[(n1 + n2) : (n1 + n2 + m1), :] = joint_A[n1:core1, :]
-    rows_A[(n1 + n2 + m1) : (n1 + n2 + m1 + m2), :] = joint_A[core1 + n2 :, :]
+    rows_A = np.empty((*output_batch_shape, core1 + core2, core1 + core2), dtype=np.complex128)
+    rows_A[..., :n1, :] = joint_A[..., :n1, :]
+    rows_A[..., n1 : (n1 + n2), :] = joint_A[..., core1 : core1 + n2, :]
+    rows_A[..., (n1 + n2) : (n1 + n2 + m1), :] = joint_A[..., n1:core1, :]
+    rows_A[..., (n1 + n2 + m1) : (n1 + n2 + m1 + m2), :] = joint_A[..., core1 + n2 :, :]
 
     # Reorder the columns to group core and derived variables
-    A = np.empty((core1 + core2, core1 + core2), dtype=np.complex128)
-    A[:, :n1] = rows_A[:, :n1]
-    A[:, n1 : (n1 + n2)] = rows_A[:, core1 : core1 + n2]
-    A[:, (n1 + n2) : (n1 + n2 + m1)] = rows_A[:, n1:core1]
-    A[:, (n1 + n2 + m1) : (n1 + n2 + m1 + m2)] = rows_A[:, core1 + n2 :]
+    A = np.empty((*output_batch_shape, core1 + core2, core1 + core2), dtype=np.complex128)
+    A[..., :, :n1] = rows_A[..., :, :n1]
+    A[..., :, n1 : (n1 + n2)] = rows_A[..., :, core1 : core1 + n2]
+    A[..., :, (n1 + n2) : (n1 + n2 + m1)] = rows_A[..., :, n1:core1]
+    A[..., :, (n1 + n2 + m1) : (n1 + n2 + m1 + m2)] = rows_A[..., :, core1 + n2 :]
 
-    b = np.empty((core1 + core2,), dtype=np.complex128)
-    b[:n1] = b1[:n1]
-    b[n1 : (n1 + n2)] = b2[:n2]
-    b[(n1 + n2) : (n1 + n2 + m1)] = b1[n1:]
-    b[(n1 + n2 + m1) : (n1 + n2 + m1 + m2)] = b2[n2:]
+    b = np.empty((*output_batch_shape, core1 + core2), dtype=np.complex128)
+    b[..., :n1] = b1[..., :n1]
+    b[..., n1 : (n1 + n2)] = b2[..., :n2]
+    b[..., (n1 + n2) : (n1 + n2 + m1)] = b1[..., n1:]
+    b[..., (n1 + n2 + m1) : (n1 + n2 + m1 + m2)] = b2[..., n2:]
 
     c1_expanded = np.expand_dims(c1_flat, axis=-1)
     c2_expanded = np.expand_dims(c2_flat, axis=-2)
     c = c1_expanded * c2_expanded
-    c = np.reshape(c, poly_shape1 + poly_shape2)
+    c = np.reshape(c, (*output_batch_shape, *poly_shape1, *poly_shape2))
     return A, b, c

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dev = [
     "hypothesis==6.31.6",
     "pre-commit==3.7.1",
     "pytest-cov==3.0.0",
-    "pytest==8.0",
+    "pytest==8.4.1",
     "ruff>=0.12.0",
     "thewalrus >=0.19.0,<1",
 ]

--- a/tests/test_lab/test_circuit_components_utils/test_b_to_q.py
+++ b/tests/test_lab/test_circuit_components_utils/test_b_to_q.py
@@ -20,9 +20,7 @@ import pytest
 from mrmustard import math, settings
 from mrmustard.lab import BtoQ, Coherent, Identity
 from mrmustard.physics.gaussian_integrals import (
-    complex_gaussian_integral_1,
     complex_gaussian_integral_2,
-    join_Abc,
     join_Abc_real,
     real_gaussian_integral,
 )
@@ -82,12 +80,11 @@ class TestBtoQ:
         modes = (0,)
         BtoQ_CC1 = BtoQ(modes, 0.0)
         step1A, step1b, step1c = BtoQ_CC1.bargmann_triple()
-        Ainter, binter, cinter = complex_gaussian_integral_1(
-            join_Abc((A0, b0, c0), (step1A, step1b, step1c)),
-            idx_z=[
-                0,
-            ],
-            idx_zconj=[2],
+        Ainter, binter, cinter = complex_gaussian_integral_2(
+            (A0, b0, c0),
+            (step1A, step1b, step1c),
+            [0],
+            [1],
             measure=-1,
         )
         QtoBMap_CC2 = BtoQ(modes, 0.0).dual
@@ -99,7 +96,6 @@ class TestBtoQ:
             [0],
             [1],
         )
-
         Af, bf, cf = real_gaussian_integral((new_A, new_b, new_c), idx=[0])
 
         assert math.allclose(A0, Af)

--- a/tests/test_lab/test_circuit_components_utils/test_b_to_q.py
+++ b/tests/test_lab/test_circuit_components_utils/test_b_to_q.py
@@ -21,6 +21,7 @@ from mrmustard import math, settings
 from mrmustard.lab import BtoQ, Coherent, Identity
 from mrmustard.physics.gaussian_integrals import (
     complex_gaussian_integral_1,
+    complex_gaussian_integral_2,
     join_Abc,
     join_Abc_real,
     real_gaussian_integral,
@@ -49,12 +50,15 @@ class TestBtoQ:
         modes = (0, 1)
         BtoQ_CC1 = BtoQ(modes, 0.0)
         step1A, step1b, step1c = BtoQ_CC1.bargmann_triple()
-        Ainter, binter, cinter = complex_gaussian_integral_1(
-            join_Abc((A0, b0, c0), (step1A, step1b, step1c)),
-            idx_z=[0, 1],
-            idx_zconj=[4, 5],
+
+        Ainter, binter, cinter = complex_gaussian_integral_2(
+            (A0, b0, c0),
+            (step1A, step1b, step1c),
+            [0, 1],
+            [2, 3],
             measure=-1,
         )
+
         QtoBMap_CC2 = BtoQ(modes, 0.0).dual
         step2A, step2b, step2c = QtoBMap_CC2.bargmann_triple()
 

--- a/tests/test_lab/test_circuit_components_utils/test_b_to_q.py
+++ b/tests/test_lab/test_circuit_components_utils/test_b_to_q.py
@@ -22,8 +22,8 @@ from mrmustard.lab import BtoQ, Coherent, Identity
 from mrmustard.physics.gaussian_integrals import (
     complex_gaussian_integral_2,
     join_Abc_real,
-    real_gaussian_integral,
 )
+from mrmustard.physics.gaussian_integrals_numba import real_gaussian_integral_numba
 
 
 class TestBtoQ:
@@ -67,7 +67,7 @@ class TestBtoQ:
             [2, 3],
         )
 
-        Af, bf, cf = real_gaussian_integral(new_A, new_b, new_c, idx=(0, 1))
+        Af, bf, cf = real_gaussian_integral_numba(new_A, new_b, new_c, idx=(0, 1))
 
         assert math.allclose(A0, Af)
         assert math.allclose(b0, bf)
@@ -96,7 +96,7 @@ class TestBtoQ:
             [0],
             [1],
         )
-        Af, bf, cf = real_gaussian_integral(new_A, new_b, new_c, idx=(0,))
+        Af, bf, cf = real_gaussian_integral_numba(new_A, new_b, new_c, idx=(0,))
 
         assert math.allclose(A0, Af)
         assert math.allclose(b0, bf)

--- a/tests/test_lab/test_circuit_components_utils/test_b_to_q.py
+++ b/tests/test_lab/test_circuit_components_utils/test_b_to_q.py
@@ -67,7 +67,7 @@ class TestBtoQ:
             [2, 3],
         )
 
-        Af, bf, cf = real_gaussian_integral((new_A, new_b, new_c), idx=[0, 1])
+        Af, bf, cf = real_gaussian_integral(new_A, new_b, new_c, idx=(0, 1))
 
         assert math.allclose(A0, Af)
         assert math.allclose(b0, bf)
@@ -96,7 +96,7 @@ class TestBtoQ:
             [0],
             [1],
         )
-        Af, bf, cf = real_gaussian_integral((new_A, new_b, new_c), idx=[0])
+        Af, bf, cf = real_gaussian_integral(new_A, new_b, new_c, idx=(0,))
 
         assert math.allclose(A0, Af)
         assert math.allclose(b0, bf)

--- a/tests/test_physics/test_gaussian_integrals.py
+++ b/tests/test_physics/test_gaussian_integrals.py
@@ -23,12 +23,12 @@ from mrmustard.physics.gaussian_integrals import (
     complex_gaussian_integral_2,
     join_Abc,
     join_Abc_real,
-    real_gaussian_integral,
 )
+from mrmustard.physics.gaussian_integrals_numba import real_gaussian_integral_numba
 
 
-def test_real_gaussian_integral():
-    """Tests the ``real_gaussian_integral`` method with a hard-coded A matric from a Gaussian(3) state."""
+def test_real_gaussian_integral_numba():
+    """Tests the ``real_gaussian_integral_numba`` method with a hard-coded A matric from a Gaussian(3) state."""
     A = math.astensor(
         [
             [
@@ -50,7 +50,7 @@ def test_real_gaussian_integral():
     )
     b = math.arange(3, dtype=math.complex128)
     c = math.astensor(1.0 + 0j)
-    res = real_gaussian_integral(A, b, c, idx=(0, 1))
+    res = real_gaussian_integral_numba(A, b, c, idx=(0, 1))
     assert math.allclose(res[0], A[2, 2] - A[2:, :2] @ math.inv(A[:2, :2]) @ A[:2, 2:])
     assert math.allclose(
         res[1],
@@ -63,7 +63,7 @@ def test_real_gaussian_integral():
         / math.sqrt(math.det(A[:2, :2]))
         * math.exp(-0.5 * math.sum(b[:2] * math.matvec(math.inv(A[:2, :2]), b[:2]))),
     )
-    res2 = real_gaussian_integral(A, b, c, idx=())
+    res2 = real_gaussian_integral_numba(A, b, c, idx=())
     assert math.allclose(res2[0], A)
     assert math.allclose(res2[1], b)
     assert math.allclose(res2[2], c)
@@ -76,7 +76,7 @@ def test_real_gaussian_integral():
     )
     b2 = math.cast(math.arange(2), dtype=math.complex128)
     c2 = math.astensor(1.0 + 0j)
-    res3 = real_gaussian_integral(A2, b2, c2, idx=(0, 1))
+    res3 = real_gaussian_integral_numba(A2, b2, c2, idx=(0, 1))
     assert math.allclose(res3[0], math.astensor([]))
     assert math.allclose(res3[1], math.astensor([]))
     assert math.allclose(

--- a/tests/test_physics/test_gaussian_integrals.py
+++ b/tests/test_physics/test_gaussian_integrals.py
@@ -21,10 +21,9 @@ from mrmustard.physics import triples
 from mrmustard.physics.gaussian_integrals import (
     complex_gaussian_integral_1,
     complex_gaussian_integral_2,
-    join_Abc,
     join_Abc_real,
 )
-from mrmustard.physics.gaussian_integrals_numba import real_gaussian_integral_numba
+from mrmustard.physics.gaussian_integrals_numba import join_Abc_numba, real_gaussian_integral_numba
 
 
 def test_real_gaussian_integral_numba():
@@ -116,7 +115,7 @@ def test_join_Abc_nonbatched():
     b2 = math.astensor([12, 13])
     c2 = math.astensor(10)
 
-    A, b, c = join_Abc((A1, b1, c1), (A2, b2, c2), batch_string=None)
+    A, b, c = join_Abc_numba((A1, b1, c1), (A2, b2, c2), batch_string=None)
 
     assert math.allclose(
         A,
@@ -136,7 +135,7 @@ def test_join_Abc_batched_zip():
     b2 = math.astensor([[12, 13], [14, 15]])
     c2 = math.astensor([10, 100])
 
-    A, b, c = join_Abc((A1, b1, c1), (A2, b2, c2), batch_string="i,i->i")
+    A, b, c = join_Abc_numba((A1, b1, c1), (A2, b2, c2), batch_string="i,i->i")
 
     assert math.allclose(
         A,
@@ -161,7 +160,7 @@ def test_join_Abc_batched_kron():
     b2 = math.astensor([[12, 13], [14, 15]])
     c2 = math.astensor([10, 100])
 
-    A, b, c = join_Abc((A1, b1, c1), (A2, b2, c2), batch_string="i,j->ij")
+    A, b, c = join_Abc_numba((A1, b1, c1), (A2, b2, c2), batch_string="i,j->ij")
 
     assert math.allclose(
         A,
@@ -218,7 +217,7 @@ def test_complex_gaussian_integral_1_not_batched():
     A2, b2, c2 = triples.displacement_gate_Abc(0.1 + 0.3j)
     A3, b3, c3 = triples.displaced_squeezed_vacuum_state_Abc(0.1 + 0.3j)
 
-    A, b, c = join_Abc((A1, b1, c1), (A2, b2, c2))
+    A, b, c = join_Abc_numba((A1, b1, c1), (A2, b2, c2))
 
     res = complex_gaussian_integral_1((A, b, c), [0, 1], [2, 3])
     assert math.allclose(res[0], A3)
@@ -236,7 +235,7 @@ def test_complex_gaussian_integral_1_batched():
     b1 = math.astensor([b1, b1, b1])
     c1 = math.astensor([c1, c1, c1])
 
-    A, b, c = join_Abc((A1, b1, c1), (A2, b2, c2), batch_string="i,i->i")
+    A, b, c = join_Abc_numba((A1, b1, c1), (A2, b2, c2), batch_string="i,i->i")
     res1 = complex_gaussian_integral_1((A, b, c), [0], [2])
     assert math.allclose(res1[0], A3)
     assert math.allclose(res1[1], b3)
@@ -259,7 +258,7 @@ def test_complex_gaussian_integral_1_multidim_batched():
     b1 = math.astensor([[b1, b1, b1], [b1, b1, b1]])
     c1 = math.astensor([[c1, c1, c1], [c1, c1, c1]])
 
-    A, b, c = join_Abc((A1, b1, c1), (A2, b2, c2), batch_string="ij,ij->ij")
+    A, b, c = join_Abc_numba((A1, b1, c1), (A2, b2, c2), batch_string="ij,ij->ij")
     res1 = complex_gaussian_integral_1((A, b, c), [0], [2])
     assert math.allclose(res1[0], A3)
     assert math.allclose(res1[1], b3)

--- a/tests/test_physics/test_gaussian_integrals.py
+++ b/tests/test_physics/test_gaussian_integrals.py
@@ -49,8 +49,8 @@ def test_real_gaussian_integral():
         ],
     )
     b = math.arange(3, dtype=math.complex128)
-    c = 1.0 + 0j
-    res = real_gaussian_integral((A, b, c), idx=[0, 1])
+    c = math.astensor(1.0 + 0j)
+    res = real_gaussian_integral(A, b, c, idx=(0, 1))
     assert math.allclose(res[0], A[2, 2] - A[2:, :2] @ math.inv(A[:2, :2]) @ A[:2, 2:])
     assert math.allclose(
         res[1],
@@ -63,7 +63,7 @@ def test_real_gaussian_integral():
         / math.sqrt(math.det(A[:2, :2]))
         * math.exp(-0.5 * math.sum(b[:2] * math.matvec(math.inv(A[:2, :2]), b[:2]))),
     )
-    res2 = real_gaussian_integral((A, b, c), idx=[])
+    res2 = real_gaussian_integral(A, b, c, idx=())
     assert math.allclose(res2[0], A)
     assert math.allclose(res2[1], b)
     assert math.allclose(res2[2], c)
@@ -75,8 +75,8 @@ def test_real_gaussian_integral():
         ],
     )
     b2 = math.cast(math.arange(2), dtype=math.complex128)
-    c2 = 1.0 + 0j
-    res3 = real_gaussian_integral((A2, b2, c2), idx=[0, 1])
+    c2 = math.astensor(1.0 + 0j)
+    res3 = real_gaussian_integral(A2, b2, c2, idx=(0, 1))
     assert math.allclose(res3[0], math.astensor([]))
     assert math.allclose(res3[1], math.astensor([]))
     assert math.allclose(

--- a/uv.lock
+++ b/uv.lock
@@ -1230,7 +1230,7 @@ requires-dist = [
 dev = [
     { name = "hypothesis", specifier = "==6.31.6" },
     { name = "pre-commit", specifier = "==3.7.1" },
-    { name = "pytest", specifier = "==8.0" },
+    { name = "pytest", specifier = "==8.4.1" },
     { name = "pytest-cov", specifier = "==3.0.0" },
     { name = "ruff", specifier = ">=0.12.0" },
     { name = "thewalrus", specifier = ">=0.19.0,<1" },
@@ -1658,7 +1658,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.0.0"
+version = "8.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1666,11 +1666,12 @@ dependencies = [
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
+    { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/50/fd/af2d835eed57448960c4e7e9ab76ee42f24bcdd521e967191bc26fa2dece/pytest-8.0.0.tar.gz", hash = "sha256:249b1b0864530ba251b7438274c4d251c58d868edaaec8762893ad4a0d71c36c", size = 1395242 }
+sdist = { url = "https://files.pythonhosted.org/packages/08/ba/45911d754e8eba3d5a841a5ce61a65a685ff1798421ac054f85aa8747dfb/pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c", size = 1517714 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/10/727155d44c5e04bb08e880668e53079547282e4f950535234e5a80690564/pytest-8.0.0-py3-none-any.whl", hash = "sha256:50fb9cbe836c3f20f0dfa99c565201fb75dc54c8d76373cd1bde06b06657bdb6", size = 334024 },
+    { url = "https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7", size = 365474 },
 ]
 
 [[package]]


### PR DESCRIPTION
**Context:** `gaussian_integrals.py` contains some of our most fundamental functionality and is used whenever we do Bargmann-Bargmann contractions. An easy way to boost the performance of Mr Mustard across the board is to speed these methods up. In this PR, we do so by porting said methods into numba. As a result, we consistently have a 10(?)x speed up.

TODO:
- Batching of `complex_gaussian_integral_1`
- Port broadcasting logic to numba
- Single point of entry for the integrals
- Make it work with JAX 

**Description of the Change:** Cleaning up and porting `gaussian_integrals.py` to numba 

**Benefits:** Significant speed up 
