### PR TITLE
Add Kgate (Kerr) non-Gaussian unitary

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -152,7 +152,7 @@ representations by setting `settings.DEFAULT_REPRESENTATION` to `None`.
 [(#616)](https://github.com/XanaduAI/MrMustard/pull/616)
 
 * Added the `Kgate` (Kerr) non-Gaussian single-mode unitary, diagonal in the Fock basis
-with entries :math:`e^{i\kappa n^2}`.
+with entries :math:`e^{i\kappa n*(n-1)}`.
 [(#653)](https://github.com/XanaduAI/MrMustard/pull/653)
 
 ### Bug fixes

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -153,6 +153,7 @@ representations by setting `settings.DEFAULT_REPRESENTATION` to `None`.
 
 * Added the `Kgate` (Kerr) non-Gaussian single-mode unitary, diagonal in the Fock basis
 with entries :math:`e^{i\kappa n^2}`.
+[(#653)](https://github.com/XanaduAI/MrMustard/pull/653)
 
 ### Bug fixes
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -151,6 +151,9 @@ representations by setting `settings.DEFAULT_REPRESENTATION` to `None`.
 * Added a ``rich`` based repr to ``ParameterSet``.
 [(#616)](https://github.com/XanaduAI/MrMustard/pull/616)
 
+* Added the `Kgate` (Kerr) non-Gaussian single-mode unitary, diagonal in the Fock basis
+with entries :math:`e^{i\kappa n^2}`.
+
 ### Bug fixes
 
 * Fixed a bug in `CircuitComponent.quadrature` where einsum fock indices collided with mode indices for states on non-zero modes (e.g. a single-mode DM on mode 1 after tracing), forcing the number of quadrature points to equal the Fock cutoff and silently giving wrong results.

--- a/doc/code/lab/transformations.rst
+++ b/doc/code/lab/transformations.rst
@@ -18,6 +18,7 @@ Transformations
     GaussianRandomNoise
     Identity
     Interferometer
+    Kgate
     Map
     MZgate
     Operation
@@ -33,7 +34,7 @@ Transformations
 Inheritance Diagram
 -------------------
 
-.. inheritance-diagram:: Transformation Map Channel Amplifier Attenuator GaussianRandomNoise PhaseNoise Operation FockDamping Unitary BSgate CXgate CZgate Dgate Ggate Identity Interferometer MZgate Pgate RealInterferometer Rgate S2gate Sgate
+.. inheritance-diagram:: Transformation Map Channel Amplifier Attenuator GaussianRandomNoise PhaseNoise Operation FockDamping Unitary BSgate CXgate CZgate Dgate Ggate Identity Interferometer Kgate MZgate Pgate RealInterferometer Rgate S2gate Sgate
     :parts: 1
 
 Amplifier
@@ -117,6 +118,13 @@ Interferometer
 --------------
 
 .. autoclass:: mrmustard.lab.transformations::Interferometer
+    :members:
+    :show-inheritance:
+
+Kgate
+-----
+
+.. autoclass:: mrmustard.lab.transformations::Kgate
     :members:
     :show-inheritance:
 

--- a/mrmustard/lab/transformations/__init__.py
+++ b/mrmustard/lab/transformations/__init__.py
@@ -28,6 +28,7 @@ from .gaussrandnoise import *
 from .ggate import *
 from .identity import *
 from .interferometer import *
+from .kgate import *
 from .mzgate import *
 from .pgate import *
 from .phasenoise import *

--- a/mrmustard/lab/transformations/kgate.py
+++ b/mrmustard/lab/transformations/kgate.py
@@ -51,8 +51,7 @@ class Kgate(Unitary):
         normal_ordered: If ``True`` (default), the generator is
             :math:`a^\dagger a^\dagger a a = n(n-1)`. If ``False``, the generator
             is :math:`n^2`. The two differ only by a linear rotation
-            :math:`e^{i\kappa n}`, i.e. a global phase on the vacuum and a
-            ``Rgate`` on the remaining Fock components.
+            :math:`e^{i\kappa n}`, i.e. an  ``Rgate`` .
 
     .. details::
         The Kerr gate is genuinely non-Gaussian and has no Bargmann representation.

--- a/mrmustard/lab/transformations/kgate.py
+++ b/mrmustard/lab/transformations/kgate.py
@@ -1,0 +1,118 @@
+# Copyright 2026 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+The class representing a Kerr gate.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from mrmustard import math
+from mrmustard.lab.circuit_components import CircuitComponent
+from mrmustard.parameters import Parameter
+from mrmustard.physics.ansatz.array_ansatz import ArrayAnsatz
+from mrmustard.physics.wires import Wires
+
+from .base import Unitary
+
+__all__ = ["Kgate"]
+
+
+class Kgate(Unitary):
+    r"""
+    The Kerr gate.
+
+    A non-Gaussian single-mode unitary, diagonal in the Fock basis:
+    :math:`U|n\rangle = e^{i\kappa n^2}|n\rangle`.
+
+    >>> from mrmustard.lab import Kgate, Number
+    >>> gate = Kgate(mode=0, kappa=0.1)
+    >>> assert gate.modes == (0,)
+
+    Args:
+        mode: The mode the gate is applied to.
+        kappa: The Kerr nonlinearity strength.
+
+    .. details::
+        The Kerr gate is genuinely non-Gaussian and has no Bargmann representation.
+        Its action is applied directly in the Fock basis through ``__custom_rrshift__``:
+        on a ket it multiplies the component on mode :math:`m` by :math:`e^{i\kappa n_m^2}`,
+        on a density matrix it multiplies by :math:`e^{i\kappa (n_m^2 - \tilde{n}_m^2)}`,
+        where :math:`n_m` and :math:`\tilde{n}_m` are the ket- and bra-side photon numbers
+        on mode :math:`m`.
+    """
+
+    short_name = "K"
+
+    def __init__(
+        self,
+        mode: int | tuple[int],
+        kappa: float | Parameter = 0.0,
+    ):
+        mode = (mode,) if not isinstance(mode, tuple) else mode
+        super().__init__(
+            wires=Wires(modes_in_ket=set(mode), modes_out_ket=set(mode)),
+            name=self.__class__.__name__,
+        )
+        self.parameters["kappa"] = Parameter.from_cc_init(
+            kappa, "float64", f"{self.name}/kappa"
+        )
+
+    def __custom_rrshift__(self, other: CircuitComponent) -> CircuitComponent:
+        r"""
+        Kerr is diagonal in Fock, so we implement its right-shift directly:
+        multiply the ket-side photon-number axis by :math:`e^{i\kappa n^2}`, and
+        (when present) the bra-side axis by :math:`e^{-i\kappa n^2}`.
+
+        Args:
+            other: the component other than the Kgate in the contraction.
+
+        Output:
+            the result of the contraction.
+        """
+        other = other.to_fock()
+        array = other.fock_array()
+        core_shape = other.ansatz.core_shape
+        state_batch_dims = other.ansatz.batch_dims
+        n_modes = other.n_modes
+        has_ket = bool(other.wires.ket)
+        has_bra = bool(other.wires.bra)
+
+        mode_indices = np.indices(core_shape)
+        kappa = math.cast(math.astensor(self.parameters.kappa.value), "complex128")
+        kappa_shape = kappa.shape
+        kappa = math.reshape(
+            kappa, (*kappa_shape, *((1,) * (state_batch_dims + len(core_shape))))
+        )
+
+        (mode,) = self.modes
+        phase_exp = math.astensor(0, dtype="complex128")
+        if has_ket:
+            ket_axis = (n_modes if has_bra else 0) + mode
+            phase_exp = phase_exp + math.astensor(
+                mode_indices[ket_axis] ** 2, dtype="complex128"
+            )
+        if has_bra:
+            phase_exp = phase_exp - math.astensor(
+                mode_indices[mode] ** 2, dtype="complex128"
+            )
+        array = array * math.exp(1j * kappa * phase_exp)
+
+        return CircuitComponent._from_attributes(
+            ArrayAnsatz(array, batch_dims=state_batch_dims + len(kappa_shape)),
+            other.wires,
+            self.name,
+        )

--- a/mrmustard/lab/transformations/kgate.py
+++ b/mrmustard/lab/transformations/kgate.py
@@ -67,9 +67,7 @@ class Kgate(Unitary):
             wires=Wires(modes_in_ket=set(mode), modes_out_ket=set(mode)),
             name=self.__class__.__name__,
         )
-        self.parameters["kappa"] = Parameter.from_cc_init(
-            kappa, "float64", f"{self.name}/kappa"
-        )
+        self.parameters["kappa"] = Parameter.from_cc_init(kappa, "float64", f"{self.name}/kappa")
 
     def __custom_rrshift__(self, other: CircuitComponent) -> CircuitComponent:
         r"""
@@ -94,21 +92,15 @@ class Kgate(Unitary):
         mode_indices = np.indices(core_shape)
         kappa = math.cast(math.astensor(self.parameters.kappa.value), "complex128")
         kappa_shape = kappa.shape
-        kappa = math.reshape(
-            kappa, (*kappa_shape, *((1,) * (state_batch_dims + len(core_shape))))
-        )
+        kappa = math.reshape(kappa, (*kappa_shape, *((1,) * (state_batch_dims + len(core_shape)))))
 
         (mode,) = self.modes
         phase_exp = math.astensor(0, dtype="complex128")
         if has_ket:
             ket_axis = (n_modes if has_bra else 0) + mode
-            phase_exp = phase_exp + math.astensor(
-                mode_indices[ket_axis] ** 2, dtype="complex128"
-            )
+            phase_exp = phase_exp + math.astensor(mode_indices[ket_axis] ** 2, dtype="complex128")
         if has_bra:
-            phase_exp = phase_exp - math.astensor(
-                mode_indices[mode] ** 2, dtype="complex128"
-            )
+            phase_exp = phase_exp - math.astensor(mode_indices[mode] ** 2, dtype="complex128")
         array = array * math.exp(1j * kappa * phase_exp)
 
         return CircuitComponent._from_attributes(

--- a/mrmustard/lab/transformations/kgate.py
+++ b/mrmustard/lab/transformations/kgate.py
@@ -52,15 +52,6 @@ class Kgate(Unitary):
             :math:`a^\dagger a^\dagger a a = n(n-1)`. If ``False``, the generator
             is :math:`n^2`. The two differ only by a linear rotation
             :math:`e^{i\kappa n}`, i.e. an  ``Rgate`` .
-
-    .. details::
-        The Kerr gate is genuinely non-Gaussian and has no Bargmann representation.
-        Its action is applied directly in the Fock basis through ``__custom_rrshift__``:
-        on a ket it multiplies the Fock component :math:`|n\rangle` by
-        :math:`e^{i\kappa g(n)}`, and on a density matrix it multiplies by
-        :math:`e^{i\kappa (g(n) - g(\tilde{n}))}`, where
-        :math:`g(n) = n(n-1)` when ``normal_ordered`` is ``True`` and
-        :math:`g(n) = n^2` otherwise.
     """
 
     short_name = "K"

--- a/mrmustard/lab/transformations/kgate.py
+++ b/mrmustard/lab/transformations/kgate.py
@@ -35,7 +35,10 @@ class Kgate(Unitary):
     r"""
     The Kerr gate.
 
-    A non-Gaussian single-mode unitary, diagonal in the Fock basis:
+    A non-Gaussian single-mode unitary, diagonal in the Fock basis. By default
+    the generator is the normal-ordered :math:`a^\dagger a^\dagger a a = n(n-1)`,
+    giving :math:`U|n\rangle = e^{i\kappa n(n-1)}|n\rangle`. With
+    ``normal_ordered=False`` the generator is :math:`n^2`, giving
     :math:`U|n\rangle = e^{i\kappa n^2}|n\rangle`.
 
     >>> from mrmustard.lab import Kgate, Number
@@ -45,14 +48,20 @@ class Kgate(Unitary):
     Args:
         mode: The mode the gate is applied to.
         kappa: The Kerr nonlinearity strength.
+        normal_ordered: If ``True`` (default), the generator is
+            :math:`a^\dagger a^\dagger a a = n(n-1)`. If ``False``, the generator
+            is :math:`n^2`. The two differ only by a linear rotation
+            :math:`e^{i\kappa n}`, i.e. a global phase on the vacuum and a
+            ``Rgate`` on the remaining Fock components.
 
     .. details::
         The Kerr gate is genuinely non-Gaussian and has no Bargmann representation.
         Its action is applied directly in the Fock basis through ``__custom_rrshift__``:
-        on a ket it multiplies the component on mode :math:`m` by :math:`e^{i\kappa n_m^2}`,
-        on a density matrix it multiplies by :math:`e^{i\kappa (n_m^2 - \tilde{n}_m^2)}`,
-        where :math:`n_m` and :math:`\tilde{n}_m` are the ket- and bra-side photon numbers
-        on mode :math:`m`.
+        on a ket it multiplies the Fock component :math:`|n\rangle` by
+        :math:`e^{i\kappa g(n)}`, and on a density matrix it multiplies by
+        :math:`e^{i\kappa (g(n) - g(\tilde{n}))}`, where
+        :math:`g(n) = n(n-1)` when ``normal_ordered`` is ``True`` and
+        :math:`g(n) = n^2` otherwise.
     """
 
     short_name = "K"
@@ -61,6 +70,7 @@ class Kgate(Unitary):
         self,
         mode: int | tuple[int],
         kappa: float | Parameter = 0.0,
+        normal_ordered: bool = True,
     ):
         mode = (mode,) if not isinstance(mode, tuple) else mode
         super().__init__(
@@ -68,12 +78,19 @@ class Kgate(Unitary):
             name=self.__class__.__name__,
         )
         self.parameters["kappa"] = Parameter.from_cc_init(kappa, "float64", f"{self.name}/kappa")
+        self._normal_ordered = normal_ordered
+
+    @property
+    def normal_ordered(self) -> bool:
+        r"""Whether the generator is :math:`n(n-1)` (True) or :math:`n^2` (False)."""
+        return self._normal_ordered
 
     def __custom_rrshift__(self, other: CircuitComponent) -> CircuitComponent:
         r"""
         Kerr is diagonal in Fock, so we implement its right-shift directly:
-        multiply the ket-side photon-number axis by :math:`e^{i\kappa n^2}`, and
-        (when present) the bra-side axis by :math:`e^{-i\kappa n^2}`.
+        multiply the ket-side photon-number axis by :math:`e^{i\kappa g(n)}`, and
+        (when present) the bra-side axis by :math:`e^{-i\kappa g(n)}`, where
+        :math:`g(n) = n(n-1)` if ``normal_ordered`` else :math:`n^2`.
 
         Args:
             other: the component other than the Kgate in the contraction.
@@ -94,13 +111,16 @@ class Kgate(Unitary):
         kappa_shape = kappa.shape
         kappa = math.reshape(kappa, (*kappa_shape, *((1,) * (state_batch_dims + len(core_shape)))))
 
+        def g(n: np.ndarray) -> np.ndarray:
+            return n * (n - 1) if self._normal_ordered else n * n
+
         (mode,) = self.modes
         phase_exp = math.astensor(0, dtype="complex128")
         if has_ket:
             ket_axis = (n_modes if has_bra else 0) + mode
-            phase_exp = phase_exp + math.astensor(mode_indices[ket_axis] ** 2, dtype="complex128")
+            phase_exp = phase_exp + math.astensor(g(mode_indices[ket_axis]), dtype="complex128")
         if has_bra:
-            phase_exp = phase_exp - math.astensor(mode_indices[mode] ** 2, dtype="complex128")
+            phase_exp = phase_exp - math.astensor(g(mode_indices[mode]), dtype="complex128")
         array = array * math.exp(1j * kappa * phase_exp)
 
         return CircuitComponent._from_attributes(

--- a/tests/test_lab/test_transformations/test_kgate.py
+++ b/tests/test_lab/test_transformations/test_kgate.py
@@ -1,0 +1,126 @@
+# Copyright 2026 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the ``Kgate`` class."""
+
+import numpy as np
+import pytest
+
+from mrmustard import math
+from mrmustard.lab.states import DM, Coherent, Ket, Number
+from mrmustard.lab.transformations import Dgate, Kgate
+from mrmustard.parameters import Variable
+
+
+class TestKgate:
+    r"""
+    Tests for the ``Kgate`` class.
+    """
+
+    def test_init(self):
+        gate = Kgate(0, 0.3)
+        assert gate.name == "Kgate"
+        assert gate.parameters.kappa.value == 0.3
+        assert gate.modes == (0,)
+        assert gate.ansatz is None
+
+    def test_diagonal_on_number_state(self):
+        "Kerr acts as a pure phase on number eigenstates."
+        kappa = 0.4
+        for n in range(4):
+            psi = Number(0, n) >> Kgate(0, kappa)
+            assert isinstance(psi, Ket)
+            arr = psi.fock_array(5)
+            expected = np.zeros(5, dtype=complex)
+            expected[n] = np.exp(1j * kappa * n**2)
+            assert math.allclose(arr, expected)
+
+    def test_preserves_norm(self):
+        "Kerr is diagonal with unit-modulus entries, so it preserves the Fock norm."
+        psi = Coherent(0, 0.7 + 0.2j).to_fock(shape=12)
+        out = psi >> Kgate(0, 0.25)
+        assert isinstance(out, Ket)
+        assert math.allclose(out.probability, psi.probability)
+
+    def test_superposition_phase(self):
+        "Kerr imparts exp(i kappa n^2) on each Fock component."
+        kappa = 0.3
+        psi = Number(0, 0) + Number(0, 2)
+        before = psi.fock_array(3)
+        after = (psi >> Kgate(0, kappa)).fock_array(3)
+        phases = np.exp(1j * kappa * np.arange(3) ** 2)
+        assert math.allclose(after, before * phases)
+
+    def test_dm_action(self):
+        "On a DM, Kerr multiplies rho[bra,ket] by exp(i kappa (ket^2 - bra^2))."
+        kappa = 0.2
+        rho = (Number(0, 0) + Number(0, 1)).dm()
+        before = rho.fock_array(3)
+        after = (rho >> Kgate(0, kappa)).fock_array(3)
+        assert isinstance(rho >> Kgate(0, kappa), DM)
+        n = np.arange(3)
+        factor = np.exp(1j * kappa * (n[None, :] ** 2 - n[:, None] ** 2))
+        assert math.allclose(after, before * factor)
+
+    def test_consistent_with_ket_vs_dm(self):
+        "Applying Kerr to a ket then taking the DM matches applying it to the DM."
+        kappa = 0.35
+        psi = Coherent(0, 0.5)
+        via_ket = (psi >> Kgate(0, kappa)).dm().fock_array(8)
+        via_dm = (psi.dm() >> Kgate(0, kappa)).fock_array(8)
+        assert math.allclose(via_ket, via_dm)
+
+    def test_zero_kappa_is_identity(self):
+        psi = Coherent(0, 0.6).to_fock(shape=10)
+        before = psi.fock_array()
+        after = (psi >> Kgate(0, 0.0)).fock_array()
+        assert math.allclose(after, before)
+
+    @pytest.mark.parametrize("batch_shape", [(), (2,), (2, 3)])
+    def test_state_batch(self, batch_shape):
+        "State batch dims flow through unchanged; Kerr preserves the Fock norm."
+        alpha = math.broadcast_to(0.5 + 0.5j, batch_shape)
+        psi_in = Coherent(0, alpha).to_fock(shape=12)
+        psi_out = psi_in >> Kgate(0, 0.2)
+        assert isinstance(psi_out, Ket)
+        assert math.allclose(psi_out.probability, psi_in.probability)
+
+    def test_kappa_batch(self):
+        "Batched kappa produces leading batch axis on the output."
+        kappas = math.astensor([0.0, 0.3, 0.7])
+        psi = Number(0, 2)
+        out = psi >> Kgate(0, kappas)
+        arr = out.fock_array(3)
+        expected = np.zeros((3, 3), dtype=complex)
+        for i, k in enumerate([0.0, 0.3, 0.7]):
+            expected[i, 2] = np.exp(1j * k * 4)
+        assert math.allclose(arr, expected)
+
+    def test_trainable_parameters(self):
+        gate1 = Kgate(0, 0.1)
+        kappa_var = Variable(0.1, "kappa", dtype=math.float64)
+        gate2 = Kgate(0, kappa=kappa_var)
+
+        with pytest.raises(AttributeError):
+            gate1.parameters.kappa.value = 0.2
+
+        gate2.parameters.kappa.value = 0.5
+        assert gate2.parameters.kappa.value == 0.5
+
+    def test_compose_kerr_gates(self):
+        "Two Kerr gates on the same mode compose additively in kappa."
+        psi = Number(0, 0) + Number(0, 1) + Number(0, 2)
+        out1 = psi >> Kgate(0, 0.2) >> Kgate(0, 0.3)
+        out2 = psi >> Kgate(0, 0.5)
+        assert math.allclose(out1.fock_array(4), out2.fock_array(4))

--- a/tests/test_lab/test_transformations/test_kgate.py
+++ b/tests/test_lab/test_transformations/test_kgate.py
@@ -19,7 +19,7 @@ import pytest
 
 from mrmustard import math
 from mrmustard.lab.states import DM, Coherent, Ket, Number
-from mrmustard.lab.transformations import Dgate, Kgate
+from mrmustard.lab.transformations import Kgate
 from mrmustard.parameters import Variable
 
 

--- a/tests/test_lab/test_transformations/test_kgate.py
+++ b/tests/test_lab/test_transformations/test_kgate.py
@@ -19,7 +19,7 @@ import pytest
 
 from mrmustard import math
 from mrmustard.lab.states import DM, Coherent, Ket, Number
-from mrmustard.lab.transformations import Kgate
+from mrmustard.lab.transformations import Kgate, Rgate
 from mrmustard.parameters import Variable
 
 
@@ -28,22 +28,38 @@ class TestKgate:
     Tests for the ``Kgate`` class.
     """
 
+    @staticmethod
+    def _g(n, normal_ordered=True):
+        return n * (n - 1) if normal_ordered else n * n
+
     def test_init(self):
         gate = Kgate(0, 0.3)
         assert gate.name == "Kgate"
         assert gate.parameters.kappa.value == 0.3
         assert gate.modes == (0,)
         assert gate.ansatz is None
+        assert gate.normal_ordered is True
+        assert Kgate(0, 0.3, normal_ordered=False).normal_ordered is False
 
-    def test_diagonal_on_number_state(self):
+    @pytest.mark.parametrize("normal_ordered", [True, False])
+    def test_diagonal_on_number_state(self, normal_ordered):
         "Kerr acts as a pure phase on number eigenstates."
         kappa = 0.4
         for n in range(4):
-            psi = Number(0, n) >> Kgate(0, kappa)
+            psi = Number(0, n) >> Kgate(0, kappa, normal_ordered=normal_ordered)
             assert isinstance(psi, Ket)
             arr = psi.fock_array(5)
             expected = np.zeros(5, dtype=complex)
-            expected[n] = np.exp(1j * kappa * n**2)
+            expected[n] = np.exp(1j * kappa * self._g(n, normal_ordered))
+            assert math.allclose(arr, expected)
+
+    def test_vacuum_and_one_photon_invariant_when_normal_ordered(self):
+        "With normal_ordered=True, |0> and |1> pick up no phase (g(0)=g(1)=0)."
+        for n in (0, 1):
+            psi = Number(0, n) >> Kgate(0, 0.7)
+            arr = psi.fock_array(3)
+            expected = np.zeros(3, dtype=complex)
+            expected[n] = 1.0
             assert math.allclose(arr, expected)
 
     def test_preserves_norm(self):
@@ -53,38 +69,45 @@ class TestKgate:
         assert isinstance(out, Ket)
         assert math.allclose(out.probability, psi.probability)
 
-    def test_superposition_phase(self):
-        "Kerr imparts exp(i kappa n^2) on each Fock component."
+    @pytest.mark.parametrize("normal_ordered", [True, False])
+    def test_superposition_phase(self, normal_ordered):
+        "Kerr imparts exp(i kappa g(n)) on each Fock component."
         kappa = 0.3
         psi = Number(0, 0) + Number(0, 2)
         before = psi.fock_array(3)
-        after = (psi >> Kgate(0, kappa)).fock_array(3)
-        phases = np.exp(1j * kappa * np.arange(3) ** 2)
+        after = (psi >> Kgate(0, kappa, normal_ordered=normal_ordered)).fock_array(3)
+        phases = np.exp(1j * kappa * self._g(np.arange(3), normal_ordered))
         assert math.allclose(after, before * phases)
 
-    def test_dm_action(self):
-        "On a DM, Kerr multiplies rho[bra,ket] by exp(i kappa (ket^2 - bra^2))."
+    @pytest.mark.parametrize("normal_ordered", [True, False])
+    def test_dm_action(self, normal_ordered):
+        "On a DM, Kerr multiplies rho[bra,ket] by exp(i kappa (g(ket) - g(bra)))."
         kappa = 0.2
         rho = (Number(0, 0) + Number(0, 1)).dm()
         before = rho.fock_array(3)
-        after = (rho >> Kgate(0, kappa)).fock_array(3)
-        assert isinstance(rho >> Kgate(0, kappa), DM)
+        gate = Kgate(0, kappa, normal_ordered=normal_ordered)
+        after = (rho >> gate).fock_array(3)
+        assert isinstance(rho >> gate, DM)
         n = np.arange(3)
-        factor = np.exp(1j * kappa * (n[None, :] ** 2 - n[:, None] ** 2))
+        gn = self._g(n, normal_ordered)
+        factor = np.exp(1j * kappa * (gn[None, :] - gn[:, None]))
         assert math.allclose(after, before * factor)
 
-    def test_consistent_with_ket_vs_dm(self):
+    @pytest.mark.parametrize("normal_ordered", [True, False])
+    def test_consistent_with_ket_vs_dm(self, normal_ordered):
         "Applying Kerr to a ket then taking the DM matches applying it to the DM."
         kappa = 0.35
         psi = Coherent(0, 0.5)
-        via_ket = (psi >> Kgate(0, kappa)).dm().fock_array(8)
-        via_dm = (psi.dm() >> Kgate(0, kappa)).fock_array(8)
+        gate = Kgate(0, kappa, normal_ordered=normal_ordered)
+        via_ket = (psi >> gate).dm().fock_array(8)
+        via_dm = (psi.dm() >> gate).fock_array(8)
         assert math.allclose(via_ket, via_dm)
 
-    def test_zero_kappa_is_identity(self):
+    @pytest.mark.parametrize("normal_ordered", [True, False])
+    def test_zero_kappa_is_identity(self, normal_ordered):
         psi = Coherent(0, 0.6).to_fock(shape=10)
         before = psi.fock_array()
-        after = (psi >> Kgate(0, 0.0)).fock_array()
+        after = (psi >> Kgate(0, 0.0, normal_ordered=normal_ordered)).fock_array()
         assert math.allclose(after, before)
 
     @pytest.mark.parametrize("batch_shape", [(), (2,), (2, 3)])
@@ -96,15 +119,16 @@ class TestKgate:
         assert isinstance(psi_out, Ket)
         assert math.allclose(psi_out.probability, psi_in.probability)
 
-    def test_kappa_batch(self):
+    @pytest.mark.parametrize("normal_ordered", [True, False])
+    def test_kappa_batch(self, normal_ordered):
         "Batched kappa produces leading batch axis on the output."
         kappas = math.astensor([0.0, 0.3, 0.7])
         psi = Number(0, 2)
-        out = psi >> Kgate(0, kappas)
+        out = psi >> Kgate(0, kappas, normal_ordered=normal_ordered)
         arr = out.fock_array(3)
         expected = np.zeros((3, 3), dtype=complex)
         for i, k in enumerate([0.0, 0.3, 0.7]):
-            expected[i, 2] = np.exp(1j * k * 4)
+            expected[i, 2] = np.exp(1j * k * self._g(2, normal_ordered))
         assert math.allclose(arr, expected)
 
     def test_trainable_parameters(self):
@@ -118,9 +142,23 @@ class TestKgate:
         gate2.parameters.kappa.value = 0.5
         assert gate2.parameters.kappa.value == 0.5
 
-    def test_compose_kerr_gates(self):
+    @pytest.mark.parametrize("normal_ordered", [True, False])
+    def test_compose_kerr_gates(self, normal_ordered):
         "Two Kerr gates on the same mode compose additively in kappa."
         psi = Number(0, 0) + Number(0, 1) + Number(0, 2)
-        out1 = psi >> Kgate(0, 0.2) >> Kgate(0, 0.3)
-        out2 = psi >> Kgate(0, 0.5)
+        k_a, k_b = 0.2, 0.3
+        out1 = (
+            psi
+            >> Kgate(0, k_a, normal_ordered=normal_ordered)
+            >> Kgate(0, k_b, normal_ordered=normal_ordered)
+        )
+        out2 = psi >> Kgate(0, k_a + k_b, normal_ordered=normal_ordered)
         assert math.allclose(out1.fock_array(4), out2.fock_array(4))
+
+    def test_n2_vs_nnm1_differ_by_rgate(self):
+        "Kgate with n^2 = Kgate with n(n-1) followed by an Rgate(kappa) on |n>, n>=1."
+        kappa = 0.3
+        psi = Number(0, 0) + Number(0, 1) + Number(0, 2) + Number(0, 3)
+        via_n2 = (psi >> Kgate(0, kappa, normal_ordered=False)).fock_array(4)
+        via_nnm1 = (psi >> Kgate(0, kappa) >> Rgate(0, kappa)).fock_array(4)
+        assert math.allclose(via_n2, via_nnm1)


### PR DESCRIPTION
## Summary
- New single-mode unitary `Kgate(mode, kappa)` acting as `U|n> = exp(i*kappa*n^2)|n>` on the number basis.
- Non-Gaussian, no Bargmann representation. Action implemented in Fock via `__custom_rrshift__`, same pattern as `PhaseNoise`: multiply the ket axis by `exp(i*kappa*n^2)` and the bra axis (when present) by `exp(-i*kappa*n^2)`.
- Supports batched `kappa` (batch dims prepend to state batch dims), trainable `kappa` via `Variable`.

## Test plan
- [x] `tests/test_lab/test_transformations/test_kgate.py` — 13 tests passing: init, number-state phase, norm preservation, superposition phase, DM action, ket vs DM consistency, kappa=0 identity, state batching, kappa batching, trainable parameter, composition additivity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)